### PR TITLE
add on focus

### DIFF
--- a/client/modules/IDE/components/SketchList.js
+++ b/client/modules/IDE/components/SketchList.js
@@ -11,15 +11,15 @@ const exitUrl = require('../../../images/exit.svg');
 class SketchList extends React.Component {
   componentDidMount() {
     this.props.getProjects(this.props.username);
-    document.getElementById('sketchlistbutton').focus();
+    document.getElementById('sketchlist').focus();
   }
 
   render() {
     return (
-      <div className="sketch-list">
+      <section className="sketch-list" aria-label="project list" tabIndex="0" role="main" id="sketchlist">
         <header className="sketch-list__header">
           <h2>Sketches</h2>
-          <button className="sketch-list__exit-button" onClick={this.props.closeSketchList} id="sketchlistbutton">
+          <button className="sketch-list__exit-button" onClick={this.props.closeSketchList}>
             <InlineSVG src={exitUrl} alt="Close Sketch List Overlay" />
           </button>
         </header>
@@ -43,7 +43,7 @@ class SketchList extends React.Component {
             </tbody>
           </table>
         </div>
-      </div>
+      </section>
     );
   }
 }

--- a/client/modules/IDE/components/SketchList.js
+++ b/client/modules/IDE/components/SketchList.js
@@ -11,6 +11,7 @@ const exitUrl = require('../../../images/exit.svg');
 class SketchList extends React.Component {
   componentDidMount() {
     this.props.getProjects(this.props.username);
+    document.getElementById('sketchlistbutton').focus();
   }
 
   render() {
@@ -18,7 +19,7 @@ class SketchList extends React.Component {
       <div className="sketch-list">
         <header className="sketch-list__header">
           <h2>Sketches</h2>
-          <button className="sketch-list__exit-button" onClick={this.props.closeSketchList}>
+          <button className="sketch-list__exit-button" onClick={this.props.closeSketchList} id="sketchlistbutton">
             <InlineSVG src={exitUrl} alt="Close Sketch List Overlay" />
           </button>
         </header>

--- a/client/modules/IDE/components/TextOutput.js
+++ b/client/modules/IDE/components/TextOutput.js
@@ -17,14 +17,14 @@ class TextOutput extends React.Component {
         </section>
         <p
           tabIndex="0"
-          role="region"
+          role="main"
           id="textOutput-content-summary"
           aria-label="text output summary"
         >
         </p>
         <table
           tabIndex="0"
-          role="region"
+          role="main"
           id="textOutput-content-details"
           aria-label="text output summary details"
         >


### PR DESCRIPTION
This PR -
* makes the output role `main` instead of `region`. More screen readers respond to `main`
* Add a `focus` so that the keyboard focus moves to the list window when the 'Open' menu is clicked