### PR TITLE
populate current line number differently

### DIFF
--- a/client/modules/IDE/components/Editor.js
+++ b/client/modules/IDE/components/Editor.js
@@ -54,7 +54,8 @@ class Editor extends React.Component {
       this.props.updateFileContent(this.props.file.name, this._cm.getValue());
     }));
     this._cm.on('keyup', () => {
-      this.props.updateLineNumber(parseInt((this._cm.getCursor().line) + 1, 10));
+      const temp = `line ${parseInt((this._cm.getCursor().line) + 1, 10)}`;
+      document.getElementById('current-line').innerHTML = temp;
     });
     // this._cm.on('change', () => { // eslint-disable-line
     //   // this.props.updateFileContent('sketch.js', this._cm.getValue());

--- a/client/modules/IDE/components/EditorAccessibility.js
+++ b/client/modules/IDE/components/EditorAccessibility.js
@@ -27,7 +27,7 @@ class EditorAccessibility extends React.Component {
           {messages}
         </ul>
         <p> Current line
-          <span className="editor-linenumber" aria-live="polite" aria-atomic="true" id="current-line"> {this.props.lineNumber} </span>
+          <span className="editor-linenumber" aria-live="polite" aria-atomic="true" id="current-line"> </span>
         </p>
       </div>
     );


### PR DESCRIPTION
This PR changes the line number using innerHTML instead of the react way. This is because aria seems to not pick up the change when it is populated through `{this.props.lineNumber}` (only in IE + JAWS)

@catarak - This is only a temporary fix so that line number can be read out in IE as well. If the fix is ok, would it be possible to deploy this soon? Sorry for the rush, if we have it on the link we can use it for the testing today.

(cc @cleezyITP)