### PR TITLE
fixed upper-right editor button being blocked by vertical scroll bar

### DIFF
--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -80,7 +80,8 @@
   }
   position: absolute;
   top: #{5 / $base-font-size}rem;
-  right: #{5 / $base-font-size}rem;
+  // right: #{5 / $base-font-size}rem;
+  right: #{5 / $base-font-size * 4}rem; // move a little left to avoid vertical scroll bar
   z-index: 1;
 }
 

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
     "react-inlinesvg": "^0.4.2",
-    "react-prefixer": "^1.1.4",
     "react-redux": "^4.4.5",
     "react-router": "^2.4.1",
     "react-split-pane": "^0.1.44",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
     "react-inlinesvg": "^0.4.2",
+    "react-prefixer": "^1.1.4",
     "react-redux": "^4.4.5",
     "react-router": "^2.4.1",
     "react-split-pane": "^0.1.44",


### PR DESCRIPTION
moved the upper-right button in editor a little to the left, so that
vertical scroll bar will not block this button

#127 