### PR TITLE
fixed upper-right button being blocked by vertical scrollbar

### DIFF
--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -80,8 +80,7 @@
   }
   position: absolute;
   top: #{5 / $base-font-size}rem;
-  // right: #{5 / $base-font-size}rem;
-  right: #{5 / $base-font-size * 4}rem; // move left to avoid vertical scroll bar
+  right: #{20 / $base-font-size}rem; // move left to avoid vertical scroll bar
   z-index: 1;
 }
 

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -80,7 +80,8 @@
   }
   position: absolute;
   top: #{5 / $base-font-size}rem;
-  right: #{5 / $base-font-size}rem;
+  // right: #{5 / $base-font-size}rem;
+  right: #{5 / $base-font-size * 4}rem; // move left to avoid vertical scroll bar
   z-index: 1;
 }
 


### PR DESCRIPTION
Moved the upper-right editor option button a little to the left, so that once vertical scrollbar appears, this button will not be blocked by the scrollbar.  #127 

Before:

![image](https://cloud.githubusercontent.com/assets/8460819/19182188/f3ea3c72-8c3f-11e6-8434-64a0482777a9.png)

This fix:

![image](https://cloud.githubusercontent.com/assets/8460819/19180871/24a95004-8c37-11e6-9c5f-16dc1c252a2c.png)
