### PR TITLE
Improved editor option menu for readability

### DIFF
--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -88,12 +88,19 @@
   display: none;
   @extend %modal;
   position: absolute;
-  top: #{20 / $base-font-size}rem;
+  top: #{30 / $base-font-size}rem;
   right: #{5 / $base-font-size}rem;
   padding: #{10 / $base-font-size}rem;
 
+  // when editor options menu is opened,
+  // its parent will have .editor--options class,
+  // thus set .editor__options with display: block;
   .editor--options & {
     display: block;
+  }
+
+  li {
+    padding: #{10 / $base-font-size}rem;
   }
 }
 


### PR DESCRIPTION
- Moved menu a little down, so it doesn't cover the collapse button
- Added padding to menu items, so they are easier to be clicked on
- Also added comments for an existing style

Before:

![screen shot 2016-10-07 at 3 13 59 am](https://cloud.githubusercontent.com/assets/8460819/19181705/e045dc06-8c3c-11e6-90de-e06e927621e4.png)

After:

![screen shot 2016-10-07 at 3 13 36 am](https://cloud.githubusercontent.com/assets/8460819/19181709/e36f2180-8c3c-11e6-92fd-b4227a92a8a6.png)
