### PR TITLE
Fix lint warning sound

### DIFF
--- a/client/modules/IDE/components/Editor.js
+++ b/client/modules/IDE/components/Editor.js
@@ -49,19 +49,17 @@ class Editor extends React.Component {
       gutters: ['CodeMirror-lint-markers'],
       keyMap: 'sublime',
       lint: {
-        onUpdateLinting: () => {
-          debounce(2000, (annotations) => {
-            this.props.clearLintMessage();
-            annotations.forEach((x) => {
-              if (x.from.line > -1) {
-                this.props.updateLintMessage(x.severity, (x.from.line + 1), x.message);
-              }
-            });
-            if (this.props.lintMessages.length > 0 && this.props.lintWarning) {
-              this.beep.play();
+        onUpdateLinting: debounce(2000, (annotations) => {
+          this.props.clearLintMessage();
+          annotations.forEach((x) => {
+            if (x.from.line > -1) {
+              this.props.updateLintMessage(x.severity, (x.from.line + 1), x.message);
             }
           });
-        }
+          if (this.props.lintMessages.length > 0 && this.props.lintWarning) {
+            this.beep.play();
+          }
+        })
       }
     });
 


### PR DESCRIPTION
The code for lint warning sound  seems to not be working right after [this change](https://github.com/processing/p5.js-web-editor/pull/94/commits/43052cb675fa0bc500467f5c7c6643f3636493ae?diff=split#diff-86c03a3ffefe63a80376f3a2db405fa1L50).
@yining1023 - just wanted to ask what the context for this change was. Would it be okay to revert it?
Please let me know if I'm missing something!
