### PR TITLE
switch brown in dark theme

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -206,4 +206,3 @@ export function hideEditProjectName() {
     type: ActionTypes.HIDE_EDIT_PROJECT_NAME
   };
 }
-

--- a/client/styles/components/_p5-dark-codemirror-theme.scss
+++ b/client/styles/components/_p5-dark-codemirror-theme.scss
@@ -11,7 +11,7 @@
 //dark gray: #b5b5b5
 
 $p5-dark-lightbrown: #A67F59;
-$p5-dark-brown: #6C4D13;
+$p5-light-green: #42F48F;
 $p5-dark-black: #333;
 $p5-dark-pink: #D9328F;
 $p5-dark-gray: #A0A0A0;
@@ -53,7 +53,7 @@ $p5-dark-activeline: rgb(207, 207, 207);
 }
 
 .cm-s-p5-dark .cm-keyword {
-  color: $p5-dark-brown;
+  color: $p5-light-green;
 }
 
 .cm-s-p5-dark .cm-variable {


### PR DESCRIPTION
The dark brown in the dark-theme was unreadable. Switched it to a light green as a temporary solution.

**Old Colors:**
<img width="837" alt="screen shot 2017-02-09 at 12 05 32 pm" src="https://cloud.githubusercontent.com/assets/5505598/22795028/311d2c22-eec3-11e6-902b-afee5685b2ef.png">

**New Colors:**
<img width="822" alt="screen shot 2017-02-09 at 12 05 03 pm" src="https://cloud.githubusercontent.com/assets/5505598/22795035/36535fea-eec3-11e6-9811-ad2a20933a1f.png">
