### PR TITLE
Exposes API endpoint URL to client via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project is currently in development! It will be announced when there is a (
 5. Create a file called `.env` in the root of this directory that looks like
 
   ```
+  API_URL=/api
   MONGO_URL=mongodb://localhost:27017/p5js-web-editor
   PORT=8000
   SESSION_SECRET=whatever_you_want_this_to_be_it_only_matters_for_production
@@ -36,6 +37,7 @@ This project is currently in development! It will be announced when there is a (
 5. Create a file called `.env` in the root of this directory that looks like
 
   ```
+  API_URL=/api
   MONGO_URL=mongodb://localhost:27017/p5js-web-editor
   PORT=8000
   SESSION_SECRET=make_this_a_long-random_string_like_maybe_126_characters_long

--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -5,7 +5,7 @@ import { reset } from 'redux-form';
 import * as ActionTypes from '../../../constants';
 import { setUnsavedChanges } from './ide';
 
-const ROOT_URL = location.href.indexOf('localhost') > 0 ? 'http://localhost:8000/api' : '/api';
+const ROOT_URL = process.env.API_URL;
 
 function appendToFilename(filename, string) {
   const dotIndex = filename.lastIndexOf('.');

--- a/client/modules/IDE/actions/preferences.js
+++ b/client/modules/IDE/actions/preferences.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import * as ActionTypes from '../../../constants';
 
-const ROOT_URL = location.href.indexOf('localhost') > 0 ? 'http://localhost:8000/api' : '/api';
+const ROOT_URL = process.env.API_URL;
 
 function updatePreferences(formParams, dispatch) {
   axios.put(`${ROOT_URL}/preferences`, formParams, { withCredentials: true })

--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -8,7 +8,7 @@ import { setUnsavedChanges,
   resetJustOpenedProject,
   showErrorModal } from './ide';
 
-const ROOT_URL = location.href.indexOf('localhost') > 0 ? 'http://localhost:8000/api' : '/api';
+const ROOT_URL = process.env.API_URL;
 
 export function setProject(project) {
   return {

--- a/client/modules/IDE/actions/projects.js
+++ b/client/modules/IDE/actions/projects.js
@@ -3,7 +3,7 @@ import * as ActionTypes from '../../../constants';
 import { showErrorModal, setPreviousPath } from './ide';
 import { resetProject } from './project';
 
-const ROOT_URL = location.href.indexOf('localhost') > 0 ? 'http://localhost:8000/api' : '/api';
+const ROOT_URL = process.env.API_URL;
 
 export function getProjects(username) {
   return (dispatch) => {

--- a/client/modules/IDE/actions/uploader.js
+++ b/client/modules/IDE/actions/uploader.js
@@ -3,7 +3,7 @@ import { createFile } from './files';
 
 const textFileRegex = /(text\/|application\/json)/;
 const s3BucketHttps = `https://s3-us-west-2.amazonaws.com/${process.env.S3_BUCKET}/`;
-const ROOT_URL = location.href.indexOf('localhost') > 0 ? 'http://localhost:8000/api' : '/api';
+const ROOT_URL = process.env.API_URL;
 const MAX_LOCAL_FILE_SIZE = 80000; // bytes, aka 80 KB
 
 function localIntercept(file, options = {}) {

--- a/client/modules/User/actions.js
+++ b/client/modules/User/actions.js
@@ -4,7 +4,7 @@ import * as ActionTypes from '../../constants';
 import { showErrorModal, justOpenedProject } from '../IDE/actions/ide';
 
 
-const ROOT_URL = location.href.indexOf('localhost') > 0 ? 'http://localhost:8000/api' : '/api';
+const ROOT_URL = process.env.API_URL;
 
 export function authError(error) {
   return {

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -34,6 +34,7 @@ module.exports = {
     }),
     new webpack.DefinePlugin({
       'process.env': {
+        API_URL: '"' + process.env.API_URL + '"',
         CLIENT: JSON.stringify(true),
         'NODE_ENV': JSON.stringify('development'),
         'S3_BUCKET': '"' + process.env.S3_BUCKET + '"'

--- a/webpack.config.prod.js
+++ b/webpack.config.prod.js
@@ -76,6 +76,7 @@ module.exports = {
   plugins: [
     new webpack.DefinePlugin({
       'process.env': {
+        'API_URL': '"' + process.env.API_URL + '"',
         'NODE_ENV': JSON.stringify('production'),
         'S3_BUCKET': '"' + process.env.S3_BUCKET + '"'
       }


### PR DESCRIPTION
Sets the API URL globally via a variable in `.env` that is used by the client to make API requests.

This means we can change the `API_URL` in a single place and still have something different in development and production if needed.

It should also mean that we can set `API_URL` to be `https` so that clients always communicate securely. However, when I tried to test this I got a CORS error so I think there'll be another PR to sort that out. Until then, setting the `API_URL=/api` gives us the same behaviour as we have now.