### PR TITLE
Server should respond to account page request

### DIFF
--- a/server/routes/server.routes.js
+++ b/server/routes/server.routes.js
@@ -54,4 +54,10 @@ router.route('/:username/sketches').get((req, res) => {
   ));
 });
 
+router.route('/:username/account').get((req, res) => {
+  userExists(req.params.username, exists => (
+    exists ? res.send(renderIndex()) : get404Sketch(html => res.send(html))
+  ));
+});
+
 export default router;


### PR DESCRIPTION
The server routing should respond to `/:username/account` with the index page so that we can redirect from HTTP -> HTTPS correctly.

Without this route, the index page is not served.