### PR TITLE
Set Ctrl+Enter shortcuts to null, don't generate newlines

### DIFF
--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -73,7 +73,9 @@ class Editor extends React.Component {
 
     this._cm.setOption('extraKeys', {
       'Cmd-Enter': () => null,
-      'Shift-Cmd-Enter': () => null
+      'Shift-Cmd-Enter': () => null,
+      'Ctrl-Enter': () => null,
+      'Shift-Ctrl-Enter': () => null
     });
 
     this.initializeDocuments(this.props.files);


### PR DESCRIPTION
_Fixed bug: Newlines being generated when using Run (Ctrl+Enter) and Pause (Shift+Ctrl+Enter) shortcuts on Windows machines._ 

Previous code set 'Cmd' key presses to null, which avoids the problem for Mac but not for Windows. Adding additional lines which set 'Ctrl' key presses to null fixes this for Windows. 