### PR TITLE
Fix typo in preview version/bug reporting announcement.

### DIFF
--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -152,8 +152,8 @@ class Nav extends React.PureComponent {
           })()}
         </ul>
         <div className="nav__announce">
-          This is a preview version of the editor, that has not yet been officially released. It is in development, you can report bugs
-          <a href="https://github.com/processing/p5.js-web-editor/issues" target="_blank" rel="noopener noreferrer">here</a>.
+          This is a preview version of the editor, that has not yet been officially released.
+          It is in development, you can report bugs <a href="https://github.com/processing/p5.js-web-editor/issues" target="_blank" rel="noopener noreferrer">here</a>.
           Please use with caution.
         </div>
       </nav>


### PR DESCRIPTION
There is a typo in the preview version/bug fix announcement within Nav.jsx.  A space is needed between "bugs" and "here." Screenshot from the public production version:

![nav_typo](https://cloud.githubusercontent.com/assets/18091418/25567539/a69262f4-2da4-11e7-8436-324479008c6b.png)

I added a space.




