### PR TITLE
Basic Find using CodeMirror

### DIFF
--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -10,6 +10,8 @@ import 'codemirror/addon/lint/html-lint';
 import 'codemirror/addon/comment/comment';
 import 'codemirror/keymap/sublime';
 import 'codemirror/addon/search/jump-to-line';
+import 'codemirror/addon/display/panel';
+import 'codemirror-revisedsearch';
 import { JSHINT } from 'jshint';
 import { CSSLint } from 'csslint';
 import { HTMLHint } from 'htmlhint';

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -80,6 +80,119 @@
   width: #{48 / $base-font-size}rem;
 }
 
+/*
+  Search dialog
+*/
+.CodeMirror-advanced-dialog {
+  padding: #{14 / $base-font-size}rem #{20 / $base-font-size}rem #{14 / $base-font-size}rem #{18 / $base-font-size}rem;
+
+  border-radius: 2px;
+
+  @include themify() {
+    background-color: getThemifyVariable('modal-background-color');
+    box-shadow: 0 12px 12px 0 getThemifyVariable('shadow-color');
+    border: solid 0.5px getThemifyVariable('modal-border-color');
+  }
+}
+
+.CodeMirror-advanced-dialog .find label {
+  display: block;
+  margin-bottom: #{12 / $base-font-size}rem;
+
+  font-size: #{21 / $base-font-size}rem;
+  font-weight: bold;
+}
+
+.CodeMirror-search-field {
+  display: block;
+  width: 100%;
+  margin-bottom: #{12 / $base-font-size}rem;
+}
+
+.CodeMirror-search-hint {
+  display: none;
+}
+
+.CodeMirror-search-count {
+  display: block;
+  height: #{20 / $base-font-size}rem;
+  text-align: right;
+}
+
+.CodeMirror-advanced-dialog .buttons {
+  display: flex;
+  justify-content: flex-end;
+}
+
+/*
+  Previous / Next buttons
+*/
+.CodeMirror-advanced-dialog .buttons button:first-child,
+.CodeMirror-advanced-dialog .buttons button:nth-child(2) {
+  display: flex;
+  flex-direction: row;
+}
+
+.CodeMirror-advanced-dialog .buttons button:first-child::after,
+.CodeMirror-advanced-dialog .buttons button:nth-child(2)::after {
+  display: block;
+  content: ' ';
+
+  width: 14px;
+  height: 14px;
+
+  margin-left: #{8 / $base-font-size}rem;
+
+  @include themify() {
+    @extend %icon;
+  }
+
+  background-repeat: no-repeat;
+  background-position: center;
+}
+
+// Previous button
+.CodeMirror-advanced-dialog .buttons button:first-child::after {
+  background-image: url(../images/up-arrow.svg)
+}
+
+// Next button
+.CodeMirror-advanced-dialog .buttons button {
+  margin-left: #{12 / $base-font-size}rem;
+}
+
+.CodeMirror-advanced-dialog .buttons button:nth-child(2)::after {
+  background-image: url(../images/down-arrow.svg)
+}
+
+/*
+  Close button
+*/
+.CodeMirror-advanced-dialog .buttons button:last-child {
+  position: absolute;
+  top: #{14 / $base-font-size}rem;
+  right: #{18 / $base-font-size}rem;
+
+  display: flex;
+  flex-direction: row;
+}
+
+.CodeMirror-advanced-dialog .buttons button:last-child:after {
+  display: block;
+  content: ' ';
+
+  width: 16px;
+  height: 16px;
+
+  margin-left: #{8 / $base-font-size}rem;
+
+  @include themify() {
+    @extend %icon;
+  }
+
+  background: transparent url(../images/exit.svg) no-repeat;
+}
+
 .editor-holder {
   height: calc(100% - #{29 / $base-font-size}rem);
   width: 100%;

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "bson-objectid": "^1.1.4",
     "classnames": "^2.2.5",
     "codemirror": "^5.21.0",
+    "codemirror-revisedsearch": "^1.0.12",
     "connect-mongo": "^1.2.0",
     "cookie-parser": "^1.4.1",
     "cors": "^2.8.1",


### PR DESCRIPTION
Implements basic find functionality (#205) using the [`codemirror-revisedsearch`](https://github.com/Maloric/CodeMirror-RevisedSearch#readme) module. This renders the Previous/Next/Close buttons in the dialog, making it much easier to style.

The dialog is full-width as the addon pushes the current code panedown so no code is obscured.

<img width="772" alt="screenshot 2017-05-04 01 04 27" src="https://cloud.githubusercontent.com/assets/1762/25685231/62458274-3066-11e7-8e2d-5aaf78ddb2b8.png">
