### PR TITLE
CSRF/XSS protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "cookie-parser": "^1.4.1",
     "cors": "^2.8.1",
     "csslint": "^0.10.0",
+    "csurf": "^1.9.0",
     "decomment": "^0.8.7",
     "dotenv": "^2.0.0",
     "dropzone": "^4.3.0",

--- a/server/server.js
+++ b/server/server.js
@@ -23,6 +23,7 @@ import files from './routes/file.routes';
 import aws from './routes/aws.routes';
 import serverRoutes from './routes/server.routes';
 import embedRoutes from './routes/embed.routes';
+import { requestsOfTypeJSON } from './utils/requestsOfType';
 
 import { renderIndex } from './views/index';
 import { get404Sketch } from './views/404Page';
@@ -75,11 +76,11 @@ app.use(session({
 }));
 app.use(passport.initialize());
 app.use(passport.session());
-app.use('/api', users);
-app.use('/api', sessions);
-app.use('/api', projects);
-app.use('/api', files);
-app.use('/api', aws);
+app.use('/api', requestsOfTypeJSON(), users);
+app.use('/api', requestsOfTypeJSON(), sessions);
+app.use('/api', requestsOfTypeJSON(), projects);
+app.use('/api', requestsOfTypeJSON(), files);
+app.use('/api', requestsOfTypeJSON(), aws);
 // this is supposed to be TEMPORARY -- until i figure out
 // isomorphic rendering
 app.use('/', serverRoutes);

--- a/server/utils/requestsOfType.js
+++ b/server/utils/requestsOfType.js
@@ -1,0 +1,15 @@
+/*
+  express middleware that sends a 406 Unacceptable
+  response if an incoming request's Content-Type
+  header does not match `type`
+*/
+const requestsOfType = type => (req, res, next) => {
+  if (req.get('content-type') != null && !req.is(type)) {
+    return next({ statusCode: 406 }); // 406 UNACCEPTABLE
+  }
+
+  return next();
+};
+
+export default requestsOfType;
+export const requestsOfTypeJSON = () => requestsOfType('application/json');


### PR DESCRIPTION
It's difficult to work out what protections a Single Page Application communicating via an API requires. A lot of the documentation out there expects the server to generate an HTML form that can be submitted without JS. 

However, these documents are good:
 - [Your API-Centric Web App Is Probably Not Safe Against XSS and CSRF](http://www.redotheweb.com/2015/11/09/api-security.html)
 - [Understanding CSRF](https://github.com/pillarjs/understanding-csrf)

I'm not an expert though.


The Editor API only accepts incoming requests with a `Content-Type` of `application/json`. Other requests are rejected. Requests which have no `Content-Type` (like `GET` requests) are always allowed. This protects against HTML-only forms submitted by the browser which will have a `application/x-www-form-urlencoded` MIME type.


We implemented a whitelist of allowed domains to `*.p5js.org` in #324 so this should protect against some XSS attacks.


A CSRF token is sent as the cookie 'XSRF-TOKEN' on all HTML page requests. This token is  picked up automatically by axios and sent to the API with all requests as an 'X-XSRF-TOKEN' header. The middleware runs on all routes and verifies that the token matches what's stored in the session.


I've clicked around the site and tested everything I can think of and things seem to work as intended. Changing some of the client API actions to send `Content-Type: text/plain` fails as expected. Altering the CSRF token in the console and then trying to sign in also fails with a CSRF error.