### PR TITLE
Code folding (issue #382)

### DIFF
--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -7,9 +7,15 @@ import 'codemirror/addon/lint/lint';
 import 'codemirror/addon/lint/javascript-lint';
 import 'codemirror/addon/lint/css-lint';
 import 'codemirror/addon/lint/html-lint';
+import 'codemirror/addon/fold/brace-fold';
+import 'codemirror/addon/fold/comment-fold';
+import 'codemirror/addon/fold/foldcode';
+import 'codemirror/addon/fold/foldgutter';
+import 'codemirror/addon/fold/indent-fold';
 import 'codemirror/addon/comment/comment';
 import 'codemirror/keymap/sublime';
 import 'codemirror/addon/search/jump-to-line';
+import 'codemirror/addon/fold/foldgutter.css';
 import { JSHINT } from 'jshint';
 import { CSSLint } from 'csslint';
 import { HTMLHint } from 'htmlhint';
@@ -49,7 +55,8 @@ class Editor extends React.Component {
       inputStyle: 'contenteditable',
       lineWrapping: false,
       fixedGutter: false,
-      gutters: ['CodeMirror-lint-markers'],
+      foldGutter: true,
+      gutters: [/* 'CodeMirror-lint-markers', 'CodeMirror-linenumbers', */'CodeMirror-foldgutter'],
       keyMap: 'sublime',
       lint: {
         onUpdateLinting: debounce((annotations) => {
@@ -70,6 +77,7 @@ class Editor extends React.Component {
         }
       }
     });
+
 
     this._cm.setOption('extraKeys', {
       'Cmd-Enter': () => null,

--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -15,7 +15,6 @@ import 'codemirror/addon/fold/indent-fold';
 import 'codemirror/addon/comment/comment';
 import 'codemirror/keymap/sublime';
 import 'codemirror/addon/search/jump-to-line';
-import 'codemirror/addon/fold/foldgutter.css';
 import { JSHINT } from 'jshint';
 import { CSSLint } from 'csslint';
 import { HTMLHint } from 'htmlhint';
@@ -56,7 +55,8 @@ class Editor extends React.Component {
       lineWrapping: false,
       fixedGutter: false,
       foldGutter: true,
-      gutters: [/* 'CodeMirror-lint-markers', 'CodeMirror-linenumbers', */'CodeMirror-foldgutter'],
+      foldOptions: { widget: '\u2026' },
+      gutters: ['CodeMirror-foldgutter'],
       keyMap: 'sublime',
       lint: {
         onUpdateLinting: debounce((annotations) => {

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -27,6 +27,18 @@
 	padding-left: #{5 / $base-font-size}rem;
 }
 
+.CodeMirror-activeline-background {
+  background-color: rgba(0,0,0,0.025) !important;
+}
+.CodeMirror-linebackground {
+  
+}
+
+.line-runtime-error {
+  background-color: #ffaaaa !important;
+  border-radius: 5px;
+}
+
 .CodeMirror-gutter-wrapper {
   right: 100%;
   top: 0;
@@ -78,6 +90,16 @@
   }
   // left: 0 !important;
   width: #{48 / $base-font-size}rem;
+}
+
+.CodeMirror-guttermarker-subtle {
+  
+}
+.CodeMirror-foldgutter-folded {
+  
+}
+.CodeMirror-foldgutter-open {
+  
 }
 
 .editor-holder {

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -27,18 +27,6 @@
 	padding-left: #{5 / $base-font-size}rem;
 }
 
-.CodeMirror-activeline-background {
-  background-color: rgba(0,0,0,0.025) !important;
-}
-.CodeMirror-linebackground {
-  
-}
-
-.line-runtime-error {
-  background-color: #ffaaaa !important;
-  border-radius: 5px;
-}
-
 .CodeMirror-gutter-wrapper {
   right: 100%;
   top: 0;
@@ -90,16 +78,6 @@
   }
   // left: 0 !important;
   width: #{48 / $base-font-size}rem;
-}
-
-.CodeMirror-guttermarker-subtle {
-  
-}
-.CodeMirror-foldgutter-folded {
-  
-}
-.CodeMirror-foldgutter-open {
-  
 }
 
 .editor-holder {

--- a/client/styles/vendors/_codemirror.scss
+++ b/client/styles/vendors/_codemirror.scss
@@ -340,13 +340,15 @@ span.CodeMirror-selectedtext { background: none; }
 /* CODE FOLDING (FOLDGUTTER.JS) */
 
 .CodeMirror-foldmarker {
+  text-shadow: -1px 0 #ed225d, 0 1px #ed225d, 1px 0 #ed225d, 0 -1px #ed225d;
   color: #FFF;
-  background-color: rgba(237, 34, 93, 0.42);
-  border-radius: 3px;
+  /* background-color: rgba(237, 34, 93, 0.42); */
+  /* border-radius: 3px; */
   font-weight: bold;
   font-family: arial;
   line-height: .3;
   cursor: pointer;
+  opacity: 0.75;
 }
 .CodeMirror-foldgutter {
   width: 2.7em;

--- a/client/styles/vendors/_codemirror.scss
+++ b/client/styles/vendors/_codemirror.scss
@@ -336,3 +336,31 @@ div.CodeMirror-dragcursors {
 
 /* Help users use markselection to safely style text background */
 span.CodeMirror-selectedtext { background: none; }
+
+/* CODE FOLDING (FOLDGUTTER.JS) */
+
+.CodeMirror-foldmarker {
+  color: #FFF;
+  background-color: rgba(237, 34, 93, 0.42);
+  border-radius: 3px;
+  font-weight: bold;
+  font-family: arial;
+  line-height: .3;
+  cursor: pointer;
+}
+.CodeMirror-foldgutter {
+  width: 2.7em;
+}
+.CodeMirror-foldgutter-open,
+.CodeMirror-foldgutter-folded {
+  cursor: pointer;
+  padding-bottom: 0.4em;
+  text-align: right;
+  line-height: 1.0;
+}
+.CodeMirror-foldgutter-open:after {
+  content: "\25BE";
+}
+.CodeMirror-foldgutter-folded:after {
+  content: "\25B8";
+}

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -56,6 +56,10 @@ module.exports = {
         test: /\.scss$/,
         loaders: ['style', 'css', 'sass']
       },
+      { 
+        test: /\.css$/, 
+        loader: "style-loader!css-loader" 
+      },
       {
         test: /\.(svg|mp3)$/,
         loader: 'file'

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -56,10 +56,6 @@ module.exports = {
         test: /\.scss$/,
         loaders: ['style', 'css', 'sass']
       },
-      { 
-        test: /\.css$/, 
-        loader: "style-loader!css-loader" 
-      },
       {
         test: /\.(svg|mp3)$/,
         loader: 'file'


### PR DESCRIPTION
This will enable the code folding feature for CodeMirror. 

I also styled the default icons that CodeMirror uses for code folding to match p5 a bit more - they can be changed if needed, though.

![screen shot 2017-07-27 at 2 18 56 pm](https://user-images.githubusercontent.com/4970417/28685679-8cbbd79e-72d6-11e7-9c39-290c97cfd996.png)
