### PR TITLE
Change setting so that decomment library preserves spaces

### DIFF
--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -280,7 +280,7 @@ class PreviewFrame extends React.Component {
         }
       }
     });
-    newContent = decomment(newContent, { 
+    newContent = decomment(newContent, {
       ignore: /noprotect/g,
       space: true
     });

--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -280,7 +280,10 @@ class PreviewFrame extends React.Component {
         }
       }
     });
-    newContent = decomment(newContent, { ignore: /noprotect/g });
+    newContent = decomment(newContent, { 
+      ignore: /noprotect/g,
+      space: true
+    });
     newContent = loopProtect(newContent);
     return newContent;
   }


### PR DESCRIPTION
Ran into a problem today where students were getting the wrong line number in the console when a runtime error happened. @catarak fixed part of the problem in this commit:

https://github.com/zrispo/p5.js-web-editor/commit/e111d3c020a4a56c33ee901a1afa1826a0edab7e

But the main issue was that I didn't enable the `space` flag when I used `decomment` (see https://github.com/vitaly-t/decomment), causing the line numbers in the editor to not match up with the line numbers of the sketch currently playing.