### PR TITLE
replaced () with {} to fix implicit return error in IDEView.jsx - fixed #433

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -300,8 +300,8 @@ class IDEView extends React.Component {
             <SplitPane
               split="vertical"
               defaultSize={'50%'}
-              onChange={() => (this.overlay.style.display = 'block')}
-              onDragFinished={() => (this.overlay.style.display = 'none')}
+              onChange={() => { this.overlay.style.display = 'block'; }}
+              onDragFinished={() => { this.overlay.style.display = 'none'; }}
             >
               <SplitPane
                 split="horizontal"


### PR DESCRIPTION
As a fix to issue #433, I tried the following and it seemed to work. Perhaps it has something to do with the implicit return error?

```
 <SplitPane
              split="vertical"
              defaultSize={'50%'}
              onChange={() => { this.overlay.style.display = 'block'; }}
              onDragFinished={() => { this.overlay.style.display = 'none'; }}
            >
```
