### PR TITLE
resolves syntax error freezing behavior in #428 

### DIFF
--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -162,6 +162,22 @@ class PreviewFrame extends React.Component {
     });
   }
 
+  jsPreprocess(sketchDoc) {
+    let newContent = sketchDoc;
+    // check the code for js errors before sending it to strip comments
+    // or loops.
+    JSHINT(newContent);
+
+    if (!JSHINT.errors) {
+      newContent = decomment(newContent, {
+        ignore: /noprotect/g,
+        space: true
+      });
+      newContent = loopProtect(newContent);
+    }
+    return newContent;
+  }
+
   injectLocalFiles() {
     const htmlFile = this.props.htmlFile.content;
     let scriptOffs = [];
@@ -291,18 +307,7 @@ class PreviewFrame extends React.Component {
       }
     });
 
-    // check the code for js errors before sending it to strip comments
-    // or loops.
-    JSHINT(newContent);
-
-    if (!JSHINT.errors) {
-      newContent = decomment(newContent, {
-        ignore: /noprotect/g,
-        space: true
-      });
-      newContent = loopProtect(newContent);
-    }
-    return newContent;
+    return this.jsPreprocess(newContent);
   }
 
   resolveCSSLinksInString(content, files) {

--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -4,6 +4,7 @@ import ReactDOM from 'react-dom';
 import srcDoc from 'srcdoc-polyfill';
 
 import loopProtect from 'loop-protect';
+import { JSHINT } from 'jshint';
 import { getBlobUrl } from '../actions/files';
 import { resolvePathToFile } from '../../../../server/utils/filePath';
 
@@ -289,11 +290,18 @@ class PreviewFrame extends React.Component {
         }
       }
     });
-    newContent = decomment(newContent, {
-      ignore: /noprotect/g,
-      space: true
-    });
-    newContent = loopProtect(newContent);
+
+    // check the code for js errors before sending it to strip comments
+    // or loops.
+    JSHINT(newContent);
+
+    if (!JSHINT.errors) {
+      newContent = decomment(newContent, {
+        ignore: /noprotect/g,
+        space: true
+      });
+      newContent = loopProtect(newContent);
+    }
     return newContent;
   }
 


### PR DESCRIPTION
It looks like decomment is throwing uncaught errors when it tries to strip comments from JavaScript code with syntax errors in it. This PR checks to see if there are syntax errors before decommenting and resolves #428 where users who encounter a state issue when making syntax errors in auto refresh mode.

I am also preemptively doing the same thing in this PR for loopProtect which I imagine could also error out on malformed JS.

This is a workable solution for now, but really, I think the longer term answer is to not "autorun" code with syntax errors in it at all, and to do that check based on the state of the editor (which already does all the analysis). I'm going to open another issue for that.