### PR TITLE
Fixes #491 adds support for a configurable cache-control max-age sett…

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -57,7 +57,9 @@ app.options('*', corsMiddleware);
 
 // Body parser, cookie parser, sessions, serve public assets
 
-app.use(Express.static(path.resolve(__dirname, '../static')));
+app.use(Express.static(path.resolve(__dirname, '../static'), {
+  maxAge: process.env.STATIC_MAX_AGE || (process.env.NODE_ENV === 'production' ? '1d' : '0')
+}));
 app.use(bodyParser.urlencoded({ limit: '50mb', extended: true }));
 app.use(bodyParser.json({ limit: '50mb' }));
 app.use(cookieParser());


### PR DESCRIPTION
…ing for serving static assets, with a default of 1d on production and 0 elsewhere

Before your pull request is reviewed and merged, make sure you

* [x] there are no linting errors -- `npm run lint`
* [x] code is in uniquely-named feature branch, and has been rebased on top of latest master. If you're asked to make more changes make sure you rebase onto master then too!
* [x] pull request is descriptively named and links to an issue number, i.e. `Fixes #123`

Thank you!
