### PR TITLE
Fix needs saving mark for renamed: Fixes #576

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -71,10 +71,13 @@ export function clearPersistedState() {
   };
 }
 
+/**
+ * Compare whether two project objects are the same. Used to check that the
+ * response returned from the server still matches the local copy.
+ */
 function projectIsEqual(base, other) {
   const filter = ['isEditingName', 'isOptionsOpen'];
 
-  // debugger;
   if (Array.isArray(base)) {
     // It must be a collection of children (files or folders).
     if (!Array.isArray(other) || other.length !== base.length) {
@@ -99,14 +102,14 @@ function projectIsEqual(base, other) {
     // Check the individual object for equality.
     let allEqual = true;
     Object.keys(base).forEach((k, i) => {
-      // Only compare keys that are not in the filter.
-      if (filter.indexOf(k) < 0) {
+      // Only compare keys that are not in the filter (unless they are set true)
+      if (filter.indexOf(k) < 0 || base[k] === true) {
         allEqual = allEqual && isEqual(base[k], other[k]);
       }
     });
     return allEqual;
   }
-  // Otherwise, I don't know what kind of object it is. Return false.
+  // Otherwise, we don't know what kind of object it is. Return false.
   return false;
 }
 


### PR DESCRIPTION
Before your pull request is reviewed and merged, please ensure that:

* [ ] there are no linting errors -- `npm run lint` (there are linting errors, but not in the files I have touched.)
* [X] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [X] your pull request is descriptively named and links to an issue number, i.e. `Fixes #576`

This is an attempt at fixing the problem described in #576, which is that after a file in a project has been renamed, the 'needs-saving' marker is not cleared after saving. I'm mainly adding this pull request to show that it fixes the problem, but I don't think it's the best code. If I was more familiar with the lodash library, I would try and use one of the functions provided by that rather than writing my own custom comparison function. 

Another option is to look at the parts of the code that set the 'isEditingName' and 'isOptionsOpen' properties after files have been renamed. These are the properties that cause the comparision between the local copy of the project and that returned by the server to be different. 