### PR TITLE
Fix needs saving mark 2 - for #576

### DIFF
--- a/client/constants.js
+++ b/client/constants.js
@@ -65,8 +65,9 @@ export const CLEAR_LINT_MESSAGE = 'CLEAR_LINT_MESSAGE';
 
 export const UPDATE_FILE_NAME = 'UPDATE_FILE_NAME';
 export const DELETE_FILE = 'DELETE_FILE';
-export const SHOW_EDIT_FILE_NAME = 'SHOW_EDIT_FILE_NAME';
-export const HIDE_EDIT_FILE_NAME = 'HIDE_EDIT_FILE_NAME';
+// Constants for show/hide file name editing
+// export const SHOW_EDIT_FILE_NAME = 'SHOW_EDIT_FILE_NAME';
+// export const HIDE_EDIT_FILE_NAME = 'HIDE_EDIT_FILE_NAME';
 
 export const SET_AUTOSAVE = 'SET_AUTOSAVE';
 export const SET_LINT_WARNING = 'SET_LINT_WARNING';

--- a/client/constants.js
+++ b/client/constants.js
@@ -59,8 +59,9 @@ export const COLLAPSE_CONSOLE = 'COLLAPSE_CONSOLE';
 export const UPDATE_LINT_MESSAGE = 'UPDATE_LINT_MESSAGE';
 export const CLEAR_LINT_MESSAGE = 'CLEAR_LINT_MESSAGE';
 
-export const SHOW_FILE_OPTIONS = 'SHOW_FILE_OPTIONS';
-export const HIDE_FILE_OPTIONS = 'HIDE_FILE_OPTIONS';
+// Constants for show/hide file options
+// export const SHOW_FILE_OPTIONS = 'SHOW_FILE_OPTIONS';
+// export const HIDE_FILE_OPTIONS = 'HIDE_FILE_OPTIONS';
 
 export const UPDATE_FILE_NAME = 'UPDATE_FILE_NAME';
 export const DELETE_FILE = 'DELETE_FILE';

--- a/client/constants.js
+++ b/client/constants.js
@@ -59,15 +59,8 @@ export const COLLAPSE_CONSOLE = 'COLLAPSE_CONSOLE';
 export const UPDATE_LINT_MESSAGE = 'UPDATE_LINT_MESSAGE';
 export const CLEAR_LINT_MESSAGE = 'CLEAR_LINT_MESSAGE';
 
-// Constants for show/hide file options
-// export const SHOW_FILE_OPTIONS = 'SHOW_FILE_OPTIONS';
-// export const HIDE_FILE_OPTIONS = 'HIDE_FILE_OPTIONS';
-
 export const UPDATE_FILE_NAME = 'UPDATE_FILE_NAME';
 export const DELETE_FILE = 'DELETE_FILE';
-// Constants for show/hide file name editing
-// export const SHOW_EDIT_FILE_NAME = 'SHOW_EDIT_FILE_NAME';
-// export const HIDE_EDIT_FILE_NAME = 'HIDE_EDIT_FILE_NAME';
 
 export const SET_AUTOSAVE = 'SET_AUTOSAVE';
 export const SET_LINT_WARNING = 'SET_LINT_WARNING';

--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -162,19 +162,21 @@ export function createFolder(formProps) {
 //     id: fileId
 //   };
 // }
-export function showEditFileName(id) {
-  return {
-    type: ActionTypes.SHOW_EDIT_FILE_NAME,
-    id
-  };
-}
+// Exports the redux action for showing the edit file name
+// export function showEditFileName(id) {
+//   return {
+//     type: ActionTypes.SHOW_EDIT_FILE_NAME,
+//     id
+//   };
+// }
 
-export function hideEditFileName(id) {
-  return {
-    type: ActionTypes.HIDE_EDIT_FILE_NAME,
-    id
-  };
-}
+// Exports the redux action for hiding the edit file name
+// export function hideEditFileName(id) {
+//   return {
+//     type: ActionTypes.HIDE_EDIT_FILE_NAME,
+//     id
+//   };
+// }
 
 export function updateFileName(id, name) {
   return {

--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -147,20 +147,21 @@ export function createFolder(formProps) {
   };
 }
 
-export function showFileOptions(fileId) {
-  return {
-    type: ActionTypes.SHOW_FILE_OPTIONS,
-    id: fileId
-  };
-}
+// Exports the redux action for showing file options
+// export function showFileOptions(fileId) {
+//   return {
+//     type: ActionTypes.SHOW_FILE_OPTIONS,
+//     id: fileId
+//   };
+// }
 
-export function hideFileOptions(fileId) {
-  return {
-    type: ActionTypes.HIDE_FILE_OPTIONS,
-    id: fileId
-  };
-}
-
+// Exports the redux action for hiding file options
+// export function hideFileOptions(fileId) {
+//   return {
+//     type: ActionTypes.HIDE_FILE_OPTIONS,
+//     id: fileId
+//   };
+// }
 export function showEditFileName(id) {
   return {
     type: ActionTypes.SHOW_EDIT_FILE_NAME,

--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -147,37 +147,6 @@ export function createFolder(formProps) {
   };
 }
 
-// Exports the redux action for showing file options
-// export function showFileOptions(fileId) {
-//   return {
-//     type: ActionTypes.SHOW_FILE_OPTIONS,
-//     id: fileId
-//   };
-// }
-
-// Exports the redux action for hiding file options
-// export function hideFileOptions(fileId) {
-//   return {
-//     type: ActionTypes.HIDE_FILE_OPTIONS,
-//     id: fileId
-//   };
-// }
-// Exports the redux action for showing the edit file name
-// export function showEditFileName(id) {
-//   return {
-//     type: ActionTypes.SHOW_EDIT_FILE_NAME,
-//     id
-//   };
-// }
-
-// Exports the redux action for hiding the edit file name
-// export function hideEditFileName(id) {
-//   return {
-//     type: ActionTypes.HIDE_EDIT_FILE_NAME,
-//     id
-//   };
-// }
-
 export function updateFileName(id, name) {
   return {
     type: ActionTypes.UPDATE_FILE_NAME,

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -24,6 +24,7 @@ export class FileNode extends React.Component {
 
     this.state = {
       isOptionsOpen: false,
+      isEditingName: false,
     };
   }
 
@@ -40,7 +41,7 @@ export class FileNode extends React.Component {
 
   handleKeyPress(event) {
     if (event.key === 'Enter') {
-      this.props.hideEditFileName(this.props.id);
+      this.hideEditFileName(this.props.id);
     }
   }
 
@@ -84,6 +85,14 @@ export class FileNode extends React.Component {
     return false;
   }
 
+  showEditFileName(id) {
+    this.setState({ isEditingName: true });
+  }
+
+  hideEditFileName(id) {
+    this.setState({ isEditingName: false });
+  }
+
   renderChild(childId) {
     return (
       <li key={childId}>
@@ -98,7 +107,7 @@ export class FileNode extends React.Component {
       'sidebar__file-item': this.props.name !== 'root',
       'sidebar__file-item--selected': this.props.isSelectedFile,
       'sidebar__file-item--open': this.state.isOptionsOpen,
-      'sidebar__file-item--editing': this.props.isEditingName,
+      'sidebar__file-item--editing': this.state.isEditingName,
       'sidebar__file-item--closed': this.props.isFolderClosed
     });
     return (
@@ -142,7 +151,7 @@ export class FileNode extends React.Component {
                   ref={(element) => { this.fileNameInput = element; }}
                   onBlur={() => {
                     this.validateFileName();
-                    this.props.hideEditFileName(this.props.id);
+                    this.hideEditFileName(this.props.id);
                   }}
                   onKeyPress={this.handleKeyPress}
                 />
@@ -192,7 +201,7 @@ export class FileNode extends React.Component {
                       <button
                         onClick={() => {
                           this.originalFileName = this.props.name;
-                          this.props.showEditFileName(this.props.id);
+                          this.showEditFileName(this.props.id);
                           setTimeout(() => this.fileNameInput.focus(), 0);
                         }}
                         className="sidebar__file-item-option"
@@ -242,14 +251,14 @@ FileNode.propTypes = {
   fileType: PropTypes.string.isRequired,
   isSelectedFile: PropTypes.bool,
   // isOptionsOpen: PropTypes.bool,
-  isEditingName: PropTypes.bool,
+  // isEditingName: PropTypes.bool,
   isFolderClosed: PropTypes.bool,
   setSelectedFile: PropTypes.func.isRequired,
   // showFileOptions: PropTypes.func.isRequired,
   // hideFileOptions: PropTypes.func.isRequired,
   deleteFile: PropTypes.func.isRequired,
-  showEditFileName: PropTypes.func.isRequired,
-  hideEditFileName: PropTypes.func.isRequired,
+  // showEditFileName: PropTypes.func.isRequired,
+  // hideEditFileName: PropTypes.func.isRequired,
   updateFileName: PropTypes.func.isRequired,
   resetSelectedFile: PropTypes.func.isRequired,
   newFile: PropTypes.func.isRequired,
@@ -262,7 +271,7 @@ FileNode.defaultProps = {
   parentId: '0',
   isSelectedFile: false,
   // isOptionsOpen: false,
-  isEditingName: false,
+  // isEditingName: false,
   isFolderClosed: false
 };
 

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -63,25 +63,16 @@ export class FileNode extends React.Component {
   toggleFileOptions(e) {
     e.preventDefault();
     if (this.state.isOptionsOpen) {
-      // this.props.hideFileOptions(this.props.id);
-      this.setState({
-        isOptionsOpen: false
-      });
+      this.setState({ isOptionsOpen: false });
     } else {
       this[`fileOptions-${this.props.id}`].focus();
-      // this.props.showFileOptions(this.props.id);
-      this.setState({
-        isOptionsOpen: true
-      });
+      this.setState({ isOptionsOpen: true });
     }
   }
 
   hideFileOptions(e) {
     // e.preventDefault();
-    this.setState({
-      isOptionsOpen: false
-    });
-    // this.props.hideFileOptions(this.props.id);
+    this.setState({ isOptionsOpen: false });
     return false;
   }
 
@@ -250,15 +241,9 @@ FileNode.propTypes = {
   name: PropTypes.string.isRequired,
   fileType: PropTypes.string.isRequired,
   isSelectedFile: PropTypes.bool,
-  // isOptionsOpen: PropTypes.bool,
-  // isEditingName: PropTypes.bool,
   isFolderClosed: PropTypes.bool,
   setSelectedFile: PropTypes.func.isRequired,
-  // showFileOptions: PropTypes.func.isRequired,
-  // hideFileOptions: PropTypes.func.isRequired,
   deleteFile: PropTypes.func.isRequired,
-  // showEditFileName: PropTypes.func.isRequired,
-  // hideEditFileName: PropTypes.func.isRequired,
   updateFileName: PropTypes.func.isRequired,
   resetSelectedFile: PropTypes.func.isRequired,
   newFile: PropTypes.func.isRequired,
@@ -270,8 +255,6 @@ FileNode.propTypes = {
 FileNode.defaultProps = {
   parentId: '0',
   isSelectedFile: false,
-  // isOptionsOpen: false,
-  // isEditingName: false,
   isFolderClosed: false
 };
 

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -21,6 +21,10 @@ export class FileNode extends React.Component {
     this.validateFileName = this.validateFileName.bind(this);
     this.handleFileClick = this.handleFileClick.bind(this);
     this.toggleFileOptions = this.toggleFileOptions.bind(this);
+
+    this.state = {
+      isOptionsOpen: false,
+    };
   }
 
   handleFileClick(e) {
@@ -57,12 +61,27 @@ export class FileNode extends React.Component {
 
   toggleFileOptions(e) {
     e.preventDefault();
-    if (this.props.isOptionsOpen) {
-      this.props.hideFileOptions(this.props.id);
+    if (this.state.isOptionsOpen) {
+      // this.props.hideFileOptions(this.props.id);
+      this.setState({
+        isOptionsOpen: false
+      });
     } else {
       this[`fileOptions-${this.props.id}`].focus();
-      this.props.showFileOptions(this.props.id);
+      // this.props.showFileOptions(this.props.id);
+      this.setState({
+        isOptionsOpen: true
+      });
     }
+  }
+
+  hideFileOptions(e) {
+    // e.preventDefault();
+    this.setState({
+      isOptionsOpen: false
+    });
+    // this.props.hideFileOptions(this.props.id);
+    return false;
   }
 
   renderChild(childId) {
@@ -78,7 +97,7 @@ export class FileNode extends React.Component {
       'sidebar__root-item': this.props.name === 'root',
       'sidebar__file-item': this.props.name !== 'root',
       'sidebar__file-item--selected': this.props.isSelectedFile,
-      'sidebar__file-item--open': this.props.isOptionsOpen,
+      'sidebar__file-item--open': this.state.isOptionsOpen,
       'sidebar__file-item--editing': this.props.isEditingName,
       'sidebar__file-item--closed': this.props.isFolderClosed
     });
@@ -133,7 +152,7 @@ export class FileNode extends React.Component {
                   ref={(element) => { this[`fileOptions-${this.props.id}`] = element; }}
                   tabIndex="0"
                   onClick={this.toggleFileOptions}
-                  onBlur={() => setTimeout(() => this.props.hideFileOptions(this.props.id), 200)}
+                  onBlur={() => setTimeout(() => this.hideFileOptions(this.props.id), 200)}
                 >
                   <InlineSVG src={downArrowUrl} />
                 </button>
@@ -222,12 +241,12 @@ FileNode.propTypes = {
   name: PropTypes.string.isRequired,
   fileType: PropTypes.string.isRequired,
   isSelectedFile: PropTypes.bool,
-  isOptionsOpen: PropTypes.bool,
+  // isOptionsOpen: PropTypes.bool,
   isEditingName: PropTypes.bool,
   isFolderClosed: PropTypes.bool,
   setSelectedFile: PropTypes.func.isRequired,
-  showFileOptions: PropTypes.func.isRequired,
-  hideFileOptions: PropTypes.func.isRequired,
+  // showFileOptions: PropTypes.func.isRequired,
+  // hideFileOptions: PropTypes.func.isRequired,
   deleteFile: PropTypes.func.isRequired,
   showEditFileName: PropTypes.func.isRequired,
   hideEditFileName: PropTypes.func.isRequired,
@@ -242,7 +261,7 @@ FileNode.propTypes = {
 FileNode.defaultProps = {
   parentId: '0',
   isSelectedFile: false,
-  isOptionsOpen: false,
+  // isOptionsOpen: false,
   isEditingName: false,
   isFolderClosed: false
 };

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -21,6 +21,9 @@ export class FileNode extends React.Component {
     this.validateFileName = this.validateFileName.bind(this);
     this.handleFileClick = this.handleFileClick.bind(this);
     this.toggleFileOptions = this.toggleFileOptions.bind(this);
+    this.hideFileOptions = this.hideFileOptions.bind(this);
+    this.showEditFileName = this.showEditFileName.bind(this);
+    this.hideEditFileName = this.hideEditFileName.bind(this);
 
     this.state = {
       isOptionsOpen: false,
@@ -41,7 +44,7 @@ export class FileNode extends React.Component {
 
   handleKeyPress(event) {
     if (event.key === 'Enter') {
-      this.hideEditFileName(this.props.id);
+      this.hideEditFileName();
     }
   }
 
@@ -70,17 +73,15 @@ export class FileNode extends React.Component {
     }
   }
 
-  hideFileOptions(e) {
-    // e.preventDefault();
+  hideFileOptions() {
     this.setState({ isOptionsOpen: false });
-    return false;
   }
 
-  showEditFileName(id) {
+  showEditFileName() {
     this.setState({ isEditingName: true });
   }
 
-  hideEditFileName(id) {
+  hideEditFileName() {
     this.setState({ isEditingName: false });
   }
 
@@ -142,7 +143,7 @@ export class FileNode extends React.Component {
                   ref={(element) => { this.fileNameInput = element; }}
                   onBlur={() => {
                     this.validateFileName();
-                    this.hideEditFileName(this.props.id);
+                    this.hideEditFileName();
                   }}
                   onKeyPress={this.handleKeyPress}
                 />
@@ -152,7 +153,7 @@ export class FileNode extends React.Component {
                   ref={(element) => { this[`fileOptions-${this.props.id}`] = element; }}
                   tabIndex="0"
                   onClick={this.toggleFileOptions}
-                  onBlur={() => setTimeout(() => this.hideFileOptions(this.props.id), 200)}
+                  onBlur={() => setTimeout(this.hideFileOptions, 200)}
                 >
                   <InlineSVG src={downArrowUrl} />
                 </button>
@@ -192,7 +193,7 @@ export class FileNode extends React.Component {
                       <button
                         onClick={() => {
                           this.originalFileName = this.props.name;
-                          this.showEditFileName(this.props.id);
+                          this.showEditFileName();
                           setTimeout(() => this.fileNameInput.focus(), 0);
                         }}
                         className="sidebar__file-item-option"

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -296,11 +296,7 @@ class IDEView extends React.Component {
               setSelectedFile={this.props.setSelectedFile}
               newFile={this.props.newFile}
               isExpanded={this.props.ide.sidebarIsExpanded}
-              // showFileOptions={this.props.showFileOptions}
-              // hideFileOptions={this.props.hideFileOptions}
               deleteFile={this.props.deleteFile}
-              // showEditFileName={this.props.showEditFileName}
-              // hideEditFileName={this.props.hideEditFileName}
               updateFileName={this.props.updateFileName}
               projectOptionsVisible={this.props.ide.projectOptionsVisible}
               openProjectOptions={this.props.openProjectOptions}
@@ -622,11 +618,7 @@ IDEView.propTypes = {
   cloneProject: PropTypes.func.isRequired,
   expandConsole: PropTypes.func.isRequired,
   collapseConsole: PropTypes.func.isRequired,
-  // showFileOptions: PropTypes.func.isRequired,
-  // hideFileOptions: PropTypes.func.isRequired,
   deleteFile: PropTypes.func.isRequired,
-  // showEditFileName: PropTypes.func.isRequired,
-  // hideEditFileName: PropTypes.func.isRequired,
   updateFileName: PropTypes.func.isRequired,
   showEditProjectName: PropTypes.func.isRequired,
   hideEditProjectName: PropTypes.func.isRequired,

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -296,8 +296,8 @@ class IDEView extends React.Component {
               setSelectedFile={this.props.setSelectedFile}
               newFile={this.props.newFile}
               isExpanded={this.props.ide.sidebarIsExpanded}
-              showFileOptions={this.props.showFileOptions}
-              hideFileOptions={this.props.hideFileOptions}
+              // showFileOptions={this.props.showFileOptions}
+              // hideFileOptions={this.props.hideFileOptions}
               deleteFile={this.props.deleteFile}
               showEditFileName={this.props.showEditFileName}
               hideEditFileName={this.props.hideEditFileName}
@@ -622,8 +622,8 @@ IDEView.propTypes = {
   cloneProject: PropTypes.func.isRequired,
   expandConsole: PropTypes.func.isRequired,
   collapseConsole: PropTypes.func.isRequired,
-  showFileOptions: PropTypes.func.isRequired,
-  hideFileOptions: PropTypes.func.isRequired,
+  // showFileOptions: PropTypes.func.isRequired,
+  // hideFileOptions: PropTypes.func.isRequired,
   deleteFile: PropTypes.func.isRequired,
   showEditFileName: PropTypes.func.isRequired,
   hideEditFileName: PropTypes.func.isRequired,

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -299,8 +299,8 @@ class IDEView extends React.Component {
               // showFileOptions={this.props.showFileOptions}
               // hideFileOptions={this.props.hideFileOptions}
               deleteFile={this.props.deleteFile}
-              showEditFileName={this.props.showEditFileName}
-              hideEditFileName={this.props.hideEditFileName}
+              // showEditFileName={this.props.showEditFileName}
+              // hideEditFileName={this.props.hideEditFileName}
               updateFileName={this.props.updateFileName}
               projectOptionsVisible={this.props.ide.projectOptionsVisible}
               openProjectOptions={this.props.openProjectOptions}
@@ -625,8 +625,8 @@ IDEView.propTypes = {
   // showFileOptions: PropTypes.func.isRequired,
   // hideFileOptions: PropTypes.func.isRequired,
   deleteFile: PropTypes.func.isRequired,
-  showEditFileName: PropTypes.func.isRequired,
-  hideEditFileName: PropTypes.func.isRequired,
+  // showEditFileName: PropTypes.func.isRequired,
+  // hideEditFileName: PropTypes.func.isRequired,
   updateFileName: PropTypes.func.isRequired,
   showEditProjectName: PropTypes.func.isRequired,
   hideEditProjectName: PropTypes.func.isRequired,

--- a/client/modules/IDE/reducers/files.js
+++ b/client/modules/IDE/reducers/files.js
@@ -196,22 +196,25 @@ const files = (state, action) => {
       // });
       // return newState.filter(file => file.id !== action.id);
     }
-    case ActionTypes.SHOW_EDIT_FILE_NAME:
-      return state.map((file) => {
-        if (file.id !== action.id) {
-          return file;
-        }
+    // This is the redux action for editing the file name
+    // case ActionTypes.SHOW_EDIT_FILE_NAME:
+    //   return state.map((file) => {
+    //     if (file.id !== action.id) {
+    //       return file;
+    //     }
 
-        return Object.assign({}, file, { isEditingName: true });
-      });
-    case ActionTypes.HIDE_EDIT_FILE_NAME:
-      return state.map((file) => {
-        if (file.id !== action.id) {
-          return file;
-        }
+    //     return Object.assign({}, file, { isEditingName: true });
+    //   });
+    // This is the redux action for hiding the editing of the filename
+    // case ActionTypes.HIDE_EDIT_FILE_NAME:
+    //   return state.map((file) => {
+    //     if (file.id !== action.id) {
+    //       return file;
+    //     }
 
-        return Object.assign({}, file, { isEditingName: false });
-      });
+    //     return Object.assign({}, file, { isEditingName: false });
+    //   });
+
     case ActionTypes.SET_SELECTED_FILE:
       return state.map((file) => {
         if (file.id === action.selectedFile) {

--- a/client/modules/IDE/reducers/files.js
+++ b/client/modules/IDE/reducers/files.js
@@ -155,22 +155,26 @@ const files = (state, action) => {
           fileType: action.fileType || 'file'
         }];
     }
-    case ActionTypes.SHOW_FILE_OPTIONS:
-      return state.map((file) => {
-        if (file.id !== action.id) {
-          return file;
-        }
 
-        return Object.assign({}, file, { isOptionsOpen: true });
-      });
-    case ActionTypes.HIDE_FILE_OPTIONS:
-      return state.map((file) => {
-        if (file.id !== action.id) {
-          return file;
-        }
+    // This is the redux action for showing file options.
+    // case ActionTypes.SHOW_FILE_OPTIONS:
+    //   return state.map((file) => {
+    //     if (file.id !== action.id) {
+    //       return file;
+    //     }
+    //
+    //     return Object.assign({}, file, { isOptionsOpen: true });
+    //   });
+    // This is the redux action for hiding file options
+    // case ActionTypes.HIDE_FILE_OPTIONS:
+    //   return state.map((file) => {
+    //     if (file.id !== action.id) {
+    //       return file;
+    //     }
+    //
+    //     return Object.assign({}, file, { isOptionsOpen: false });
+    //   });
 
-        return Object.assign({}, file, { isOptionsOpen: false });
-      });
     case ActionTypes.UPDATE_FILE_NAME:
       return state.map((file) => {
         if (file.id !== action.id) {

--- a/client/modules/IDE/reducers/files.js
+++ b/client/modules/IDE/reducers/files.js
@@ -155,26 +155,6 @@ const files = (state, action) => {
           fileType: action.fileType || 'file'
         }];
     }
-
-    // This is the redux action for showing file options.
-    // case ActionTypes.SHOW_FILE_OPTIONS:
-    //   return state.map((file) => {
-    //     if (file.id !== action.id) {
-    //       return file;
-    //     }
-    //
-    //     return Object.assign({}, file, { isOptionsOpen: true });
-    //   });
-    // This is the redux action for hiding file options
-    // case ActionTypes.HIDE_FILE_OPTIONS:
-    //   return state.map((file) => {
-    //     if (file.id !== action.id) {
-    //       return file;
-    //     }
-    //
-    //     return Object.assign({}, file, { isOptionsOpen: false });
-    //   });
-
     case ActionTypes.UPDATE_FILE_NAME:
       return state.map((file) => {
         if (file.id !== action.id) {
@@ -196,25 +176,6 @@ const files = (state, action) => {
       // });
       // return newState.filter(file => file.id !== action.id);
     }
-    // This is the redux action for editing the file name
-    // case ActionTypes.SHOW_EDIT_FILE_NAME:
-    //   return state.map((file) => {
-    //     if (file.id !== action.id) {
-    //       return file;
-    //     }
-
-    //     return Object.assign({}, file, { isEditingName: true });
-    //   });
-    // This is the redux action for hiding the editing of the filename
-    // case ActionTypes.HIDE_EDIT_FILE_NAME:
-    //   return state.map((file) => {
-    //     if (file.id !== action.id) {
-    //       return file;
-    //     }
-
-    //     return Object.assign({}, file, { isEditingName: false });
-    //   });
-
     case ActionTypes.SET_SELECTED_FILE:
       return state.map((file) => {
         if (file.id === action.selectedFile) {


### PR DESCRIPTION
Before your pull request is reviewed and merged, please ensure that:

* [X] there are no linting errors -- `npm run lint`
* [X] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [X] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`

This is a work in progress pull request to address #576 based on advice from @catarak and @shinytang6 on my previous pull request (#652).

I am trying to move the properties `isOptionsOpen` and `isEditingName` to be stored as state in the `FileNode` component, rather than going into the Redux state. This PR just does this for `isOptionsOpen`. I want to check that I'm on the right track and am not doing anything too heinous...
