### PR TITLE
Fixes #682 by isolating preview pane layers

### DIFF
--- a/client/styles/layout/_ide.scss
+++ b/client/styles/layout/_ide.scss
@@ -14,6 +14,9 @@
   flex: 1 0 0px;
   display: flex;
   position: relative;
+
+  // create a stacking context to isolate z-index layering
+  z-index: 0;
 }
 
 .editor-console-container {


### PR DESCRIPTION
Restrict the z-index of the console (and any other preview panes) to the
context of the preview container, thereby preventing any internal
content from overlaying a modal. `z-index:0` is used as a more
browser-compliant form of `isolation:isolate` or `contain:paint` to
create an isolated stacking context.

>Before your pull request is reviewed and merged, please ensure that:
>
>* [x] there are no linting errors -- `npm run lint`

There were pre-existing errors, but this doesn't add any.
>* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
>* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`
>
>Thank you!