### PR TITLE
Fixes #680 by adjusting canvas and iframe layout

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -370,41 +370,43 @@ class IDEView extends React.Component {
                 <header className="preview-frame__header">
                   <h2 className="preview-frame__title">Preview</h2>
                 </header>
-                <div className="preview-frame-overlay" ref={(element) => { this.overlay = element; }}>
+                <div className="preview-frame__content">
+                  <div className="preview-frame-overlay" ref={(element) => { this.overlay = element; }}>
+                  </div>
+                  <div>
+                    {(
+                      (
+                        (this.props.preferences.textOutput ||
+                            this.props.preferences.gridOutput ||
+                            this.props.preferences.soundOutput
+                        ) &&
+                            this.props.ide.isPlaying
+                      ) ||
+                        this.props.ide.isAccessibleOutputPlaying
+                    )
+                    }
+                  </div>
+                  <PreviewFrame
+                    htmlFile={this.props.htmlFile}
+                    files={this.props.files}
+                    content={this.props.selectedFile.content}
+                    isPlaying={this.props.ide.isPlaying}
+                    isAccessibleOutputPlaying={this.props.ide.isAccessibleOutputPlaying}
+                    textOutput={this.props.preferences.textOutput}
+                    gridOutput={this.props.preferences.gridOutput}
+                    soundOutput={this.props.preferences.soundOutput}
+                    setTextOutput={this.props.setTextOutput}
+                    setGridOutput={this.props.setGridOutput}
+                    setSoundOutput={this.props.setSoundOutput}
+                    dispatchConsoleEvent={this.props.dispatchConsoleEvent}
+                    autorefresh={this.props.preferences.autorefresh}
+                    previewIsRefreshing={this.props.ide.previewIsRefreshing}
+                    endSketchRefresh={this.props.endSketchRefresh}
+                    stopSketch={this.props.stopSketch}
+                    setBlobUrl={this.props.setBlobUrl}
+                    expandConsole={this.props.expandConsole}
+                  />
                 </div>
-                <div>
-                  {(
-                    (
-                      (this.props.preferences.textOutput ||
-                          this.props.preferences.gridOutput ||
-                          this.props.preferences.soundOutput
-                      ) &&
-                          this.props.ide.isPlaying
-                    ) ||
-                      this.props.ide.isAccessibleOutputPlaying
-                  )
-                  }
-                </div>
-                <PreviewFrame
-                  htmlFile={this.props.htmlFile}
-                  files={this.props.files}
-                  content={this.props.selectedFile.content}
-                  isPlaying={this.props.ide.isPlaying}
-                  isAccessibleOutputPlaying={this.props.ide.isAccessibleOutputPlaying}
-                  textOutput={this.props.preferences.textOutput}
-                  gridOutput={this.props.preferences.gridOutput}
-                  soundOutput={this.props.preferences.soundOutput}
-                  setTextOutput={this.props.setTextOutput}
-                  setGridOutput={this.props.setGridOutput}
-                  setSoundOutput={this.props.setSoundOutput}
-                  dispatchConsoleEvent={this.props.dispatchConsoleEvent}
-                  autorefresh={this.props.preferences.autorefresh}
-                  previewIsRefreshing={this.props.ide.previewIsRefreshing}
-                  endSketchRefresh={this.props.endSketchRefresh}
-                  stopSketch={this.props.stopSketch}
-                  setBlobUrl={this.props.setBlobUrl}
-                  expandConsole={this.props.expandConsole}
-                />
               </div>
             </SplitPane>
           </SplitPane>

--- a/client/modules/IDE/reducers/files.js
+++ b/client/modules/IDE/reducers/files.js
@@ -31,6 +31,9 @@ const defaultCSS =
   margin: 0;
   padding: 0;
 }
+canvas {
+  display: block;
+}
 `;
 
 const initialState = () => {

--- a/client/styles/components/_preview-frame.scss
+++ b/client/styles/components/_preview-frame.scss
@@ -5,6 +5,11 @@
   border-width: 0;
 }
 
+.preview-frame-holder {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
 
 .preview-frame-overlay {
   height: 100%;
@@ -36,4 +41,9 @@
   padding-left: #{5 / $base-font-size}rem;
   font-size: #{12 / $base-font-size}rem;
   font-weight: normal;
+}
+
+.preview-frame__content {
+  position: relative;
+  flex: 1 1 0;
 }

--- a/server/examples.js
+++ b/server/examples.js
@@ -28,6 +28,9 @@ const defaultCSS =
   margin: 0;
   padding: 0;
 }
+canvas {
+  display: block;
+}
 `;
 
 const clientId = process.env.GITHUB_ID;


### PR DESCRIPTION
- Set the preview canvas to `display:block` to remove vertical spacing
caused by the default value, which was making a full-height canvas cause
vertical scrolling, and the vertical scrollbar caused horizontal
scrolling
- Wrap the preview content in a container with `position:relative` and
no other visible content, so that the full-height iframe excludes the
height of the preview frame header, preventing it from going beyond the
height of the page

Fixes #680

![image](https://user-images.githubusercontent.com/647807/45257680-01e74980-b35f-11e8-90e7-bdf3a525f41f.png)

>Before your pull request is reviewed and merged, please ensure that:
>
>* [x] there are no linting errors -- `npm run lint`
>No additional errors
>* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
>* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`
>
>Thank you!
