### PR TITLE
Removed outline from sidebar items

### DIFF
--- a/client/styles/components/_sidebar.scss
+++ b/client/styles/components/_sidebar.scss
@@ -107,6 +107,7 @@
 
 .sidebar__file-item-name {
   padding: #{4 / $base-font-size}rem 0;
+  outline: none;
   .sidebar__file-item--editing & {
     display: none;
   }
@@ -119,6 +120,10 @@
     content: '';
     width: 100%;
   }
+}
+
+.sidebar__file-item-name:focus {
+  outline: none;
 }
 
 .sidebar__file-item-show-options {


### PR DESCRIPTION
Sidebar items had that ugly outline while focused. Now it should be fixed.

Before your pull request is reviewed and merged, please ensure that:

* [ x ] there are no linting errors -- `npm run lint`
* [ x ] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [ x ] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`

Thank you!
