### PR TITLE
components/Editor.jsx: Allow indentation on entering new line

### DIFF
--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -136,6 +136,7 @@ class Editor extends React.Component {
     this._cm.getWrapperElement().style['font-size'] = `${this.props.fontSize}px`;
     this._cm.setOption('indentWithTabs', this.props.isTabIndent);
     this._cm.setOption('tabSize', this.props.indentationAmount);
+    this._cm.setOption('indentUnit', this.props.indentationAmount);
 
     this.props.provideController({
       tidyCode: this.tidyCode,
@@ -171,6 +172,7 @@ class Editor extends React.Component {
     }
     if (this.props.indentationAmount !== prevProps.indentationAmount) {
       this._cm.setOption('tabSize', this.props.indentationAmount);
+      this._cm.setOption('indentUnit', this.props.indentationAmount);
     }
     if (this.props.isTabIndent !== prevProps.isTabIndent) {
       this._cm.setOption('indentWithTabs', this.props.isTabIndent);


### PR DESCRIPTION
`indentUnit` updated on settings->indentation amount change.
This allows proper indentation on pressing 'enter' too.

Fixes https://github.com/processing/p5.js-web-editor/issues/700