### PR TITLE
Fix async validation in signup form (fixes #742)

### DIFF
--- a/client/styles/components/_forms.scss
+++ b/client/styles/components/_forms.scss
@@ -45,3 +45,7 @@
 .form input[type="submit"] {
   @extend %forms-button;
 }
+
+.form input[type="submit"]:disabled {
+  cursor: not-allowed;
+}

--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -38,7 +38,12 @@ export function createUser(req, res, next) {
     });
 
     User.findOne(
-      { email: req.body.email },
+      {
+        $or: [
+          { email: req.body.email },
+          { username: req.body.username }
+        ]
+      },
       (err, existingUser) => {
         if (err) {
           res.status(404).send({ error: err });
@@ -46,7 +51,8 @@ export function createUser(req, res, next) {
         }
 
         if (existingUser) {
-          res.status(422).send({ error: 'Email is in use' });
+          const fieldInUse = existingUser.email === req.body.email ? 'Email' : 'Username';
+          res.status(422).send({ error: `${fieldInUse} is in use` });
           return;
         }
         user.save((saveErr) => {


### PR DESCRIPTION
I fixed the exception caused by signing up with a username that is already in use, and added support for multiple asynchronous errors in the sign up form (previously, moving focus from the email field would erase errors in the username field.)


* [x] there are no linting errors -- `npm run lint`
* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`

