### PR TITLE
fixes #675

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -97,6 +97,7 @@ export function saveProject(autosave = false) {
               dispatch(showToast(1500));
               dispatch(setToastText('Project saved.'));
             }
+            dispatch(setUnsavedChanges(false));
           }
         })
         .catch((response) => {


### PR DESCRIPTION
Before your pull request is reviewed and merged, please ensure that:

* [ ] there are no linting errors -- `npm run lint`. All lint errors are for `object-curly-newline`, and  every time I get an NPM ERR saying that `eslint client server --ext .jsx --ext .js` fails on my system. However, I have only changed a single line in the code so I hope the linting doesn't matter much this time. Although it'd be great if you could tell me how to fix it, I tried but couldn't get it to work.
* [x] your code is in a uniquely-named feature branch and has been rebased on top of the latest master. If you're asked to make more changes, make sure you rebase onto master then too!
* [x] your pull request is descriptively named and links to an issue number, i.e. `Fixes #123`

Thank you!

I went through the code and saw that when autosave is disabled, the call to `dispatch(setUnsavedChanges(false));` was missing. As soon as I added this line and re-ran the [procedure given](https://github.com/processing/p5.js-web-editor/issues/675#issuecomment-420805393), I can no longer reproduce the bug.