### PR TITLE
Fix broken anchor link in contributing guide

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Here are links to all the sections in this document:
 <!-- If you change any of the headings in this document, remember to update the table of contents. -->
 
 - [Code of Conduct](#code-of-conduct)
-- [How Can I Contribute ?](#how-can-i-contribute?)
+- [How Can I Contribute?](#how-can-i-contribute)
   - [First Timers](#first-timers)
   - [Want something more challenging](#want-something-more-challenging)
   - [Feature Enhancement](#feature-enhancement)


### PR DESCRIPTION
This is minor-ish change just fixing broken inter-document navigation.

Thanks!