### PR TITLE
Fix ESLint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -20,7 +20,7 @@
     "no-console": 0,
     "no-alert": 0,
     "no-underscore-dangle": 0,
-    "max-len": [1, 120, 2, {ignoreComments: true}],
+    "max-len": [1, 120, 2, {"ignoreComments": true, "ignoreTemplateLiterals": true}],
     "quote-props": [1, "consistent-as-needed"],
     "no-unused-vars": [1, {"vars": "local", "args": "none"}],
     "consistent-return": ["error", { "treatUndefinedAsUnspecified": true }],

--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -81,7 +81,10 @@ class PreviewFrame extends React.Component {
 
   handleConsoleEvent(messageEvent) {
     if (Array.isArray(messageEvent.data)) {
-      const decodedMessages = messageEvent.data.map(message => Object.assign(Decode(message.log), { source: message.source }));
+      const decodedMessages = messageEvent.data.map(message =>
+        Object.assign(Decode(message.log), {
+          source: message.source
+        }));
 
       decodedMessages.every((message, index, arr) => {
         const { data: args } = message;


### PR DESCRIPTION
This fixes failing `npm run lint`:

- fixes `max-len` issue in code by reformat of the expression
- exempt ES6 template literals from `max-len` rule using ESLint
  configuration change

Thanks!

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`


Errors fixed:

```bash
> eslint client server --ext .jsx --ext .js


/Users/piotrblazejewicz/git/p5.js-web-editor/client/modules/IDE/components/PreviewFrame.jsx
  84:1  warning  Line 84 exceeds the maximum line length of 120  max-len

/Users/piotrblazejewicz/git/p5.js-web-editor/server/scripts/examples-gg-latest.js
  30:1  warning  Line 30 exceeds the maximum line length of 120  max-len
```