### PR TITLE
Fixes ##795 resizer hover issue

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -308,7 +308,7 @@ class IDEView extends React.Component {
               defaultSize="50%"
               onChange={() => { this.overlay.style.display = 'block'; }}
               onDragFinished={() => { this.overlay.style.display = 'none'; }}
-              resizerStyle={{ marginRight: '0', marginLeft: '-10px' }}
+              resizerStyle={{ marginRight: '-4px', marginLeft: '-2px'}}
             >
               <SplitPane
                 split="horizontal"

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -308,7 +308,7 @@ class IDEView extends React.Component {
               defaultSize="50%"
               onChange={() => { this.overlay.style.display = 'block'; }}
               onDragFinished={() => { this.overlay.style.display = 'none'; }}
-              resizerStyle={{ marginRight: '-4px', marginLeft: '-2px'}}
+              resizerStyle={{ marginRight: '-4px', marginLeft: '-2px' }}
             >
               <SplitPane
                 split="horizontal"

--- a/client/styles/components/_resizer.scss
+++ b/client/styles/components/_resizer.scss
@@ -33,10 +33,11 @@
 }
 
 .Resizer.vertical {
-    width: 10px;
-    margin: 0 -5px;
-    border-left: 5px solid rgba(255, 255, 255, 0);
-    border-right: 5px solid rgba(255, 255, 255, 0);
+    width: 0px;
+    margin: 0 -15px;
+    padding: 0 3px;
+    // border-left: 5px solid rgba(255, 255, 255, 0);
+    // border-right: 5px solid rgba(255, 255, 255, 0);
     cursor: col-resize;
 }
 

--- a/client/styles/components/_resizer.scss
+++ b/client/styles/components/_resizer.scss
@@ -19,10 +19,11 @@
 // }
 
 .Resizer.horizontal {
-    height: 10px;
-    margin: -5px 0;
-    border-top: 5px solid rgba(255, 255, 255, 0);
-    border-bottom: 5px solid rgba(255, 255, 255, 0);
+    height: 0px;
+    padding: 4px 0;
+    margin: -1px 0 -7px;
+    // border-top: 5px solid rgba(255, 255, 255, 0);
+    // border-bottom: 5px solid rgba(255, 255, 255, 0);
     cursor: row-resize;
     width: 100%;
 }


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

I checked on both Mozilla and Chrome seems good to me
I have changed resizer width 6px for vertical and 8 px for horizontal
with a little padding to the off side
kindly review and verify my changes

I have a typo on commit message instead of "scroll bar" it should be "resizer"