### PR TITLE
Do not send out the full User object when the user updates their account

### DIFF
--- a/server/controllers/user.controller.js
+++ b/server/controllers/user.controller.js
@@ -292,7 +292,13 @@ export function saveUser(res, user) {
       return;
     }
 
-    res.json(user);
+    res.json({
+      email: user.email,
+      username: user.username,
+      preferences: user.preferences,
+      verified: user.verified,
+      id: user._id
+    });
   });
 }
 


### PR DESCRIPTION
Prevents leaking their encrypted password and verification tokens to the user.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. 

Fixes #822