### PR TITLE
Prevent crash when console.error is used - Fixes #833

### DIFF
--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -192,10 +192,15 @@ class Editor extends React.Component {
     if (this.props.runtimeErrorWarningVisible && this._cm.getDoc().modeOption === 'javascript') {
       this.props.consoleEvents.forEach((consoleEvent) => {
         if (consoleEvent.method === 'error') {
-          if (consoleEvent.data[0].indexOf(')') > -1) {
+          if (consoleEvent.data &&
+            consoleEvent.data[0] &&
+            consoleEvent.data[0].indexOf &&
+            consoleEvent.data[0].indexOf(')') > -1) {
             const n = consoleEvent.data[0].replace(')', '').split(' ');
             const lineNumber = parseInt(n[n.length - 1], 10) - 1;
-            this._cm.addLineClass(lineNumber, 'background', 'line-runtime-error');
+            if (!Number.isNaN(lineNumber)) {
+              this._cm.addLineClass(lineNumber, 'background', 'line-runtime-error');
+            }
           }
         }
       });


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`