### PR TITLE
Use File id in Redux Actions - Fixes #842

### DIFF
--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -29,10 +29,10 @@ function createUniqueName(name, parentId, files) {
   return testName;
 }
 
-export function updateFileContent(name, content) {
+export function updateFileContent(id, content) {
   return {
     type: ActionTypes.UPDATE_FILE_CONTENT,
-    name,
+    id,
     content
   };
 }
@@ -206,7 +206,7 @@ export function hideFolderChildren(id) {
 export function setBlobUrl(file, blobURL) {
   return {
     type: ActionTypes.SET_BLOB_URL,
-    name: file.name,
+    id: file.id,
     blobURL
   };
 }

--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -116,7 +116,7 @@ class Editor extends React.Component {
 
     this._cm.on('change', debounce(() => {
       this.props.setUnsavedChanges(true);
-      this.props.updateFileContent(this.props.file.name, this._cm.getValue());
+      this.props.updateFileContent(this.props.file.id, this._cm.getValue());
       if (this.props.autorefresh && this.props.isPlaying) {
         this.props.clearConsole();
         this.props.startRefreshSketch();

--- a/client/modules/IDE/reducers/files.js
+++ b/client/modules/IDE/reducers/files.js
@@ -118,7 +118,7 @@ const files = (state, action) => {
   switch (action.type) {
     case ActionTypes.UPDATE_FILE_CONTENT:
       return state.map((file) => {
-        if (file.name !== action.name) {
+        if (file.id !== action.id) {
           return file;
         }
 
@@ -126,7 +126,7 @@ const files = (state, action) => {
       });
     case ActionTypes.SET_BLOB_URL:
       return state.map((file) => {
-        if (file.name !== action.name) {
+        if (file.id !== action.id) {
           return file;
         }
         return Object.assign({}, file, { blobURL: action.blobURL });


### PR DESCRIPTION
Prevents file name collisions that are possible with the folder
system.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`