### PR TITLE
adding in continue comment codemirror addon adresses #836

### DIFF
--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -14,12 +14,14 @@ import 'codemirror/addon/fold/foldcode';
 import 'codemirror/addon/fold/foldgutter';
 import 'codemirror/addon/fold/indent-fold';
 import 'codemirror/addon/comment/comment';
+import 'codemirror/addon/comment/continuecomment';
 import 'codemirror/keymap/sublime';
 import 'codemirror/addon/search/searchcursor';
 import 'codemirror/addon/search/matchesonscrollbar';
 import 'codemirror/addon/search/match-highlighter';
 import 'codemirror/addon/search/jump-to-line';
 import 'codemirror/addon/edit/matchbrackets';
+
 
 import { JSHINT } from 'jshint';
 import { CSSLint } from 'csslint';
@@ -81,6 +83,7 @@ class Editor extends React.Component {
       styleActiveLine: true,
       inputStyle: 'contenteditable',
       lineWrapping: false,
+      continueComments: true,
       fixedGutter: false,
       foldGutter: true,
       foldOptions: { widget: '\u2026' },


### PR DESCRIPTION
I'm not sure that this behavior is actually a good idea, it's a bit tricky to get out of the continuation of the comments, it might be better to add a real soft wrap option into the settings or edit menu.

I have verified that this pull request:
* [x] has no linting errors (`npm run lint`)
* [?] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too) <-- I think?
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
