### PR TITLE
Remove file menu on blur

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -107,7 +107,11 @@ export class FileNode extends React.Component {
         {(() => { // eslint-disable-line
           if (this.props.name !== 'root') {
             return (
-              <div className="file-item__content" onContextMenu={this.toggleFileOptions}>
+              <div
+                className="file-item__content"
+                onContextMenu={this.toggleFileOptions}
+                onBlur={this.hideFileOptions}
+              >
                 <span className="file-item__spacer"></span>
                 {(() => { // eslint-disable-line
                   if (this.props.fileType === 'file') {


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #874`

Fixes #874 

This PR resolves the issue of multiple file menu as on blurring, they will be hidden.

At line 160 I saw @catarak a time interval of 0.2 sec was given before hiding.
```  onBlur={() => setTimeout(this.hideFileOptions, 200)}```
Currently I did not create that interval. I did not get the logic for that. Generally in editors context menu closes as soon as it blurs.