### PR TITLE
Remove file menu on blur

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -154,6 +154,7 @@ export class FileNode extends React.Component {
                   tabIndex="0"
                   onClick={this.toggleFileOptions}
                   onBlur={() => setTimeout(this.hideFileOptions, 200)}
+                  style={{ display: (this.state.isOptionsOpen) ? 'inline-block' : '' }}
                 >
                   <InlineSVG src={downArrowUrl} />
                 </button>

--- a/client/styles/components/_sidebar.scss
+++ b/client/styles/components/_sidebar.scss
@@ -125,7 +125,6 @@
   @include icon();
   @include themify() {
     padding: #{4 / $base-font-size}rem 0;
-    background-color: map-get($theme-map, 'file-selected-color');
     padding-right: #{6 / $base-font-size}rem;
   }
   display: none;
@@ -136,6 +135,9 @@
     .sidebar--cant-edit & {
       display: none;
     }
+  }
+  .sidebar__file-item:hover > .file-item__content & {
+    display: inline-block;
   }
   & svg {
     width: #{10 / $base-font-size}rem;


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #874`

Fixes #874 

This PR resolves the issue of multiple file menu as on blurring, they will be hidden.
But this work in all cases except when we right click on the current file as it automatically changes the focus to the ```˅``` resulting in losing of focus from the file name and disappearing of menu. If you right click on the ```˅``` then it would work properly.

![Screenshot from 2019-03-09 12-55-56](https://user-images.githubusercontent.com/37630020/54067815-dfc97800-426a-11e9-8f31-cf55c1b7c36b.png)

@catarak why is a down arrow required specifically for the current file, whereas it is not availaible for other files.

Doesn't work if person uses TAB to navigate as it loses Focus. I will find another approach.