### PR TITLE
Patched console.log to only log in dev mode (#853)

### DIFF
--- a/client/index.jsx
+++ b/client/index.jsx
@@ -6,6 +6,8 @@ import { Router, browserHistory } from 'react-router';
 import configureStore from './store';
 import routes from './routes';
 
+// Load the patched console.log
+require('./utils/logger.js');
 require('./styles/main.scss');
 
 // Load the p5 png logo, so that webpack will use it

--- a/client/utils/logger.js
+++ b/client/utils/logger.js
@@ -1,0 +1,5 @@
+// eslint-disable-next-line
+if (process.env.NODE_ENV === 'production'){
+// eslint-disable-next-line
+    console.log = function(){}
+}


### PR DESCRIPTION
I have verified that this pull request:

* [x ] has no linting errors (`npm run lint`)
* [x ] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ x] is descriptively named and links to an issue number, i.e. `Fixes #123`

I don't think this is the mode elegant solution , but we can add another logger that logs with time and everything.
Also there is a need to remove console.logs from error callbacks and actually handle errors.
I will look into it next

