### PR TITLE
Patched console.logs to work only in dev mode (#853)

### DIFF
--- a/webpack/config.prod.js
+++ b/webpack/config.prod.js
@@ -120,7 +120,8 @@ module.exports = [{
     new webpack.optimize.UglifyJsPlugin({
       sourceMap: true,
       compress: {
-        warnings: false
+        warnings: false,
+        drop_console :true
       }
     }),
     new webpack.LoaderOptionsPlugin({


### PR DESCRIPTION
I have verified that this pull request:

* [x ] has no linting errors (`npm run lint`)
* [x ] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Also why are we still using webpack 3 , should I do the migration?