### PR TITLE
Fix nav to apply CSS hover effect only when the nav item is clickable

### DIFF
--- a/client/styles/components/_nav.scss
+++ b/client/styles/components/_nav.scss
@@ -49,7 +49,7 @@
   margin-right: #{5 / $base-font-size}rem;
 }
 
-.nav__item:hover {
+.nav__item button:hover {
   .nav__item-header {
     @include themify() {
       color: getThemifyVariable('nav-hover-color');


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number: `Fixes #908`