### PR TITLE
fixes #924

### DIFF
--- a/client/modules/IDE/components/Preferences.jsx
+++ b/client/modules/IDE/components/Preferences.jsx
@@ -32,6 +32,7 @@ class Preferences extends React.Component {
       value = 8;
     }
     this.props.setFontSize(value);
+    event.target.value = value;
   }
 
   handleUpdateIndentation(event) {
@@ -46,6 +47,7 @@ class Preferences extends React.Component {
       value = 0;
     }
     this.props.setIndentation(value);
+    event.target.value = value;
   }
 
   handleUpdateAutosave(event) {
@@ -127,8 +129,8 @@ class Preferences extends React.Component {
                 className="preference__value"
                 aria-live="polite"
                 aria-atomic="true"
-                value={this.props.fontSize}
-                onChange={this.handleUpdateFont}
+                defaultValue={this.props.fontSize}
+                onBlur={this.handleUpdateFont}
                 ref={(element) => { this.fontSizeInput = element; }}
                 onClick={() => {
                   this.fontSizeInput.select();
@@ -159,8 +161,8 @@ class Preferences extends React.Component {
                 className="preference__value"
                 aria-live="polite"
                 aria-atomic="true"
-                value={this.props.indentationAmount}
-                onChange={this.handleUpdateIndentation}
+                defaultValue={this.props.indentationAmount}
+                onBlur={this.handleUpdateIndentation}
                 ref={(element) => { this.indentationInput = element; }}
                 onClick={() => {
                   this.indentationInput.select();


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

**Problem identification:** the input element was using an `onChange` event instead of an `onBlur` event. So typing `20` yielded `36` because the first input of `2` yielded `8` (as 8 is the lowest element) and the subsequent `0` made it `80` therefore we will get `36` (since 36 is upper limit).

**Problem fix:** using `onBlur` and `defaultValue`. Now, the value only updates when the user finalizes their input value and leaves (`blur`s) the input field.