### PR TITLE
Removed github button from /accounts page

### DIFF
--- a/client/modules/User/pages/AccountView.jsx
+++ b/client/modules/User/pages/AccountView.jsx
@@ -9,7 +9,6 @@ import { Helmet } from 'react-helmet';
 import { updateSettings, initiateVerification } from '../actions';
 import AccountForm from '../components/AccountForm';
 import { validateSettings } from '../../../utils/reduxFormUtils';
-import GithubButton from '../components/GithubButton';
 
 const exitUrl = require('../../../images/exit.svg');
 const logoUrl = require('../../../images/p5js-logo.svg');
@@ -48,7 +47,6 @@ class AccountView extends React.Component {
           <h2 className="form-container__title">My Account</h2>
           <AccountForm {...this.props} />
           <h2 className="form-container__divider">Or</h2>
-          <GithubButton buttonText="Login with Github" />
         </div>
       </div>
     );


### PR DESCRIPTION
I have verified that this pull request:
Fixes #915 
* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Deleted Github button from accounts page. As it is not required because the user is already logged in.