### PR TITLE
Fix signup form password matching

### DIFF
--- a/client/modules/IDE/components/Preferences.jsx
+++ b/client/modules/IDE/components/Preferences.jsx
@@ -32,6 +32,7 @@ class Preferences extends React.Component {
       value = 8;
     }
     this.props.setFontSize(value);
+    event.target.value = value;
   }
 
   handleUpdateIndentation(event) {
@@ -46,6 +47,7 @@ class Preferences extends React.Component {
       value = 0;
     }
     this.props.setIndentation(value);
+    event.target.value = value;
   }
 
   handleUpdateAutosave(event) {
@@ -127,8 +129,8 @@ class Preferences extends React.Component {
                 className="preference__value"
                 aria-live="polite"
                 aria-atomic="true"
-                value={this.props.fontSize}
-                onChange={this.handleUpdateFont}
+                defaultValue={this.props.fontSize}
+                onBlur={this.handleUpdateFont}
                 ref={(element) => { this.fontSizeInput = element; }}
                 onClick={() => {
                   this.fontSizeInput.select();
@@ -159,8 +161,8 @@ class Preferences extends React.Component {
                 className="preference__value"
                 aria-live="polite"
                 aria-atomic="true"
-                value={this.props.indentationAmount}
-                onChange={this.handleUpdateIndentation}
+                defaultValue={this.props.indentationAmount}
+                onBlur={this.handleUpdateIndentation}
                 ref={(element) => { this.indentationInput = element; }}
                 onClick={() => {
                   this.indentationInput.select();

--- a/client/modules/User/components/SignupForm.jsx
+++ b/client/modules/User/components/SignupForm.jsx
@@ -44,12 +44,12 @@ function SignupForm(props) {
         {password.touched && password.error && <span className="form-error">{password.error}</span>}
       </p>
       <p className="form__field">
-        <label htmlFor="confirm password" className="form__label">Confirm Password</label>
+        <label htmlFor="confirm_password" className="form__label">Confirm Password</label>
         <input
           className="form__input"
           type="password"
           aria-label="confirm password"
-          id="confirm password"
+          id="confirm_password"
           {...domOnlyProps(confirmPassword)}
         />
         {

--- a/client/utils/reduxFormUtils.js
+++ b/client/utils/reduxFormUtils.js
@@ -73,8 +73,8 @@ export function validateSignup(formProps) {
     errors.confirmPassword = 'Please enter a password confirmation';
   }
 
-  if (formProps.password !== formProps.confirmPassword) {
-    errors.password = 'Passwords must match';
+  if (formProps.password !== formProps.confirmPassword && formProps.confirmPassword) {
+    errors.confirmPassword = 'Passwords must match';
   }
 
   return errors;


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

I fixed the problem here by:

- simply checking if the confirm password field has at least one or more characters
- displaying the error message below the confirm password field instead of the password field. I think this is an additional improvement for intuitivity, as it is the second field that says "Confirm password", so it is the one that should say that passwords do not match. (GMail signup also works the same way)

Hope it is good. Please let me know of additional suggestions for improvement @catarak 