### PR TITLE
fixes #906

### DIFF
--- a/client/utils/reduxFormUtils.js
+++ b/client/utils/reduxFormUtils.js
@@ -73,8 +73,8 @@ export function validateSignup(formProps) {
     errors.confirmPassword = 'Please enter a password confirmation';
   }
 
-  if (formProps.password !== formProps.confirmPassword) {
-    errors.password = 'Passwords must match';
+  if (formProps.password !== formProps.confirmPassword && formProps.confirmPassword) {
+    errors.confirmPassword = 'Passwords must match';
   }
 
   return errors;


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

fixes #906

I fixed the problem here by:

- simply checking if the confirm password field has at least one or more characters
- displaying the error message below the confirm password field instead of the password field. I think this is an additional improvement for intuitivity, as it is the second field that says "Confirm password", so it is the one that should say that passwords do not match. (GMail signup also works the same way)

Hope it is good. Please let me know of additional suggestions for improvement @catarak 