### PR TITLE
fixes #795

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -251,7 +251,9 @@ class IDEView extends React.Component {
               defaultSize="50%"
               onChange={() => { this.overlay.style.display = 'block'; }}
               onDragFinished={() => { this.overlay.style.display = 'none'; }}
-              resizerStyle={{ borderLeftWidth: '2px', borderRightWidth: '2px', width: '2px', margin: '0px 0px' }}
+              resizerStyle={{
+                borderLeftWidth: '2px', borderRightWidth: '2px', width: '2px', margin: '0px 0px'
+              }}
             >
               <SplitPane
                 split="horizontal"

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -251,7 +251,7 @@ class IDEView extends React.Component {
               defaultSize="50%"
               onChange={() => { this.overlay.style.display = 'block'; }}
               onDragFinished={() => { this.overlay.style.display = 'none'; }}
-              resizerStyle={{ marginRight: '0', marginLeft: '-10px' }}
+              resizerStyle={{ borderLeftWidth: '2px', borderRightWidth: '2px', width: '2px', margin: '0px 0px' }}
             >
               <SplitPane
                 split="horizontal"


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

I fixed the issue by:

1. reducing the border widths on the resizer
2. reducing its width to `2px`
3. and maintained consistency for #441 by removing the extra `-5px` margin.

I have verified that this issue is fixed (and issue #441) does not reappear on both Chrome and Firefox. Now, both the scrollbar and resizer are usable over a proper range. Please let me know if any changes are needed. Thanks!