### PR TITLE
[WIP] fixes #934

### DIFF
--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -86,7 +86,11 @@ class PreviewFrame extends React.Component {
           source: message.source
         }));
 
-      decodedMessages.every((message, index, arr) => {
+      console.log(JSON.stringify(decodedMessages));
+
+      for (let index = 0, len = decodedMessages.length; index < len; index += 1) {
+        const message = decodedMessages[index];
+
         const { data: args } = message;
         let hasInfiniteLoop = false;
         Object.keys(args).forEach((key) => {
@@ -97,23 +101,22 @@ class PreviewFrame extends React.Component {
           }
         });
         if (hasInfiniteLoop) {
-          return false;
+          break;
         }
-        if (index === arr.length - 1) {
+        if (index === decodedMessages.length - 1) {
           Object.assign(message, { times: 1 });
-          return false;
+          break;
         }
         const cur = Object.assign(message, { times: 1 });
         const nextIndex = index + 1;
-        while (isEqual(cur.data, arr[nextIndex].data) && cur.method === arr[nextIndex].method) {
+        while (isEqual(cur.data, decodedMessages[nextIndex].data) && cur.method === decodedMessages[nextIndex].method) {
           cur.times += 1;
-          arr.splice(nextIndex, 1);
-          if (nextIndex === arr.length) {
-            return false;
+          decodedMessages.splice(nextIndex, 1);
+          if (nextIndex === decodedMessages.length) {
+            break;
           }
         }
-        return true;
-      });
+      }
 
       this.props.dispatchConsoleEvent(decodedMessages);
     }

--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -80,15 +80,15 @@ class PreviewFrame extends React.Component {
   }
 
   handleConsoleEvent(messageEvent) {
-    if (Array.isArray(messageEvent.data)) {
+    if (messageEvent && Array.isArray(messageEvent.data)) {
       const decodedMessages = messageEvent.data.map(message =>
         Object.assign(Decode(message.log), {
           source: message.source
         }));
 
-      console.log(JSON.stringify(decodedMessages));
+      // console.log(JSON.stringify(decodedMessages));
 
-      for (let index = 0, len = decodedMessages.length; index < len; index += 1) {
+      for (let index = 0; index < decodedMessages.length; index += 1) {
         const message = decodedMessages[index];
 
         const { data: args } = message;
@@ -115,6 +115,23 @@ class PreviewFrame extends React.Component {
           if (nextIndex === decodedMessages.length) {
             break;
           }
+        }
+      }
+
+      // now the messages have been decoded among themselves
+      // compare the first such message with the last message
+      // already visible on the console
+      const previousMessages = this.props.consoleEvents;
+      const previousMessagesCount = previousMessages.length;
+
+      if (previousMessagesCount) {
+        const lastMessage = previousMessages[previousMessagesCount - 1];
+        const incomingLatestMessage = decodedMessages[0];
+
+        if (isEqual(lastMessage.data, incomingLatestMessage.data) && lastMessage.method === incomingLatestMessage.method) {
+          decodedMessages.splice(0, 1);
+          // how to update previously set console event
+          // in this.props.consoleEvents?
         }
       }
 
@@ -375,6 +392,8 @@ PreviewFrame.propTypes = {
     url: PropTypes.string,
     id: PropTypes.string.isRequired
   })).isRequired,
+  // eslint-disable-next-line
+  consoleEvents: PropTypes.array,
   dispatchConsoleEvent: PropTypes.func.isRequired,
   endSketchRefresh: PropTypes.func.isRequired,
   previewIsRefreshing: PropTypes.bool.isRequired,

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -339,6 +339,7 @@ class IDEView extends React.Component {
                     setTextOutput={this.props.setTextOutput}
                     setGridOutput={this.props.setGridOutput}
                     setSoundOutput={this.props.setSoundOutput}
+                    consoleEvents={this.props.console}
                     dispatchConsoleEvent={this.props.dispatchConsoleEvent}
                     autorefresh={this.props.preferences.autorefresh}
                     previewIsRefreshing={this.props.ide.previewIsRefreshing}


### PR DESCRIPTION
I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`

----

fixes #934 

@catarak a question: Why is the `PreviewFrame` componenet handling updates to the `Console`? Shouldn't the `handleConsoleEvent` method be part of `Console` instead? I am asking because if it was a part of `Console` then I would be able to re-render the console, and not have to extraneously pass `props.consoleEvent` down to `PreviewFrame` as well.

Thoughts?