### PR TITLE
Added length cap to sketch name 

### DIFF
--- a/client/modules/IDE/components/Toolbar.jsx
+++ b/client/modules/IDE/components/Toolbar.jsx
@@ -124,6 +124,7 @@ class Toolbar extends React.Component {
           </a>
           <input
             type="text"
+            maxLength="256"
             className="toolbar__project-name-input"
             value={this.props.project.name}
             onChange={this.handleProjectNameChange}


### PR DESCRIPTION
I have verified that this pull request:

* [x ] has no linting errors (`npm run lint`)
* [ x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x ] is descriptively named and links to an issue number, i.e. `Fixes #123`

ref https://github.com/processing/p5.js-web-editor/issues/568#issuecomment-465731531