### PR TITLE
Signup fix: Fixes unintuitive password must match error #906

### DIFF
--- a/client/utils/reduxFormUtils.js
+++ b/client/utils/reduxFormUtils.js
@@ -73,7 +73,11 @@ export function validateSignup(formProps) {
     errors.confirmPassword = 'Please enter a password confirmation';
   }
 
-  if (formProps.confirmPassword && formProps.confirmPassword.length > 0 && formProps.password !== formProps.confirmPassword) {
+  if (
+    formProps.confirmPassword &&
+    formProps.confirmPassword.length > 0 &&
+    formProps.password !== formProps.confirmPassword
+  ) {
     errors.password = 'Passwords must match';
   }
 

--- a/client/utils/reduxFormUtils.js
+++ b/client/utils/reduxFormUtils.js
@@ -73,7 +73,7 @@ export function validateSignup(formProps) {
     errors.confirmPassword = 'Please enter a password confirmation';
   }
 
-  if (formProps.password !== formProps.confirmPassword) {
+  if (formProps.confirmPassword && formProps.confirmPassword.length > 0 && formProps.password !== formProps.confirmPassword) {
     errors.password = 'Passwords must match';
   }
 


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Fixes Issue: #906 
Solution: 
. Check for existence of confirmPassword
. Check for the length of the confirmPassword
. I left the error to occur in the password field itself because this allows for showing the error dynamically

Files Changed:
. client/utils/reduxFormUtils.js

@catarak Any views on this?