### PR TITLE
Fixes issue with drop-down arrow not being clickable (#981)

### DIFF
--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -487,8 +487,8 @@ class Nav extends React.PureComponent {
                 onFocus={this.clearHideTimeout}
               >
                 My Account
+                <InlineSVG className="nav__item-header-triangle" src={triangleUrl} />
               </button>
-              <InlineSVG className="nav__item-header-triangle" src={triangleUrl} />
               <ul className="nav__dropdown">
                 <button
                   onClick={this.toggleDropdown.bind(this, 'account')}


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`