### PR TITLE
Fix multiple file options showing up (#987)

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -105,6 +105,9 @@ export class FileNode extends React.Component {
       'sidebar__file-item--editing': this.state.isEditingName,
       'sidebar__file-item--closed': this.props.isFolderClosed
     });
+
+    let isFocused = false;
+
     return (
       <div className={itemClass}>
         {(() => { // eslint-disable-line
@@ -156,6 +159,15 @@ export class FileNode extends React.Component {
                   ref={(element) => { this[`fileOptions-${this.props.id}`] = element; }}
                   tabIndex="0"
                   onClick={this.toggleFileOptions}
+                  onBlur={() => {
+                    isFocused = false;
+                    setTimeout(() => {
+                      if (!isFocused) {
+                        this.hideFileOptions();
+                      }
+                    }, 200);
+                  }}
+                  onFocus={() => { isFocused = true; }}
                 >
                   <InlineSVG src={downArrowUrl} />
                 </button>
@@ -171,6 +183,15 @@ export class FileNode extends React.Component {
                                 this.props.newFile();
                                 setTimeout(() => this.hideFileOptions(), 0);
                               }}
+                              onBlur={() => {
+                                isFocused = false;
+                                setTimeout(() => {
+                                  if (!isFocused) {
+                                    this.hideFileOptions();
+                                  }
+                                }, 200);
+                              }}
+                              onFocus={() => { isFocused = true; }}
                               className="sidebar__file-item-option"
                             >
                               Add File
@@ -189,6 +210,15 @@ export class FileNode extends React.Component {
                                 this.props.newFolder();
                                 setTimeout(() => this.hideFileOptions(), 0);
                               }}
+                              onBlur={() => {
+                                isFocused = false;
+                                setTimeout(() => {
+                                  if (!isFocused) {
+                                    this.hideFileOptions();
+                                  }
+                                }, 200);
+                              }}
+                              onFocus={() => { isFocused = true; }}
                               className="sidebar__file-item-option"
                             >
                               Add Folder
@@ -205,6 +235,15 @@ export class FileNode extends React.Component {
                           setTimeout(() => this.fileNameInput.focus(), 0);
                           setTimeout(() => this.hideFileOptions(), 0);
                         }}
+                        onBlur={() => {
+                          isFocused = false;
+                          setTimeout(() => {
+                            if (!isFocused) {
+                              this.hideFileOptions();
+                            }
+                          }, 200);
+                        }}
+                        onFocus={() => { isFocused = true; }}
                         className="sidebar__file-item-option"
                       >
                         Rename
@@ -220,8 +259,14 @@ export class FileNode extends React.Component {
                           }
                         }}
                         onBlur={() => {
-                          setTimeout(this.hideFileOptions, 200);
+                          isFocused = false;
+                          setTimeout(() => {
+                            if (!isFocused) {
+                              this.hideFileOptions();
+                            }
+                          }, 200);
                         }}
+                        onFocus={() => { isFocused = true; }}
                         className="sidebar__file-item-option"
                       >
                         Delete

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -24,10 +24,12 @@ export class FileNode extends React.Component {
     this.hideFileOptions = this.hideFileOptions.bind(this);
     this.showEditFileName = this.showEditFileName.bind(this);
     this.hideEditFileName = this.hideEditFileName.bind(this);
+    this.blurComponent = this.blurComponent.bind(this);
 
     this.state = {
       isOptionsOpen: false,
       isEditingName: false,
+      isFocused: false,
     };
   }
 
@@ -80,6 +82,15 @@ export class FileNode extends React.Component {
     this.setState({ isOptionsOpen: false });
   }
 
+  blurComponent() {
+    this.setState({ isFocused: false });
+    setTimeout(() => {
+      if (!this.state.isFocused) {
+        this.hideFileOptions();
+      }
+    }, 200);
+  }
+
   showEditFileName() {
     this.setState({ isEditingName: true });
   }
@@ -105,8 +116,6 @@ export class FileNode extends React.Component {
       'sidebar__file-item--editing': this.state.isEditingName,
       'sidebar__file-item--closed': this.props.isFolderClosed
     });
-
-    let isFocused = false;
 
     return (
       <div className={itemClass}>
@@ -159,15 +168,8 @@ export class FileNode extends React.Component {
                   ref={(element) => { this[`fileOptions-${this.props.id}`] = element; }}
                   tabIndex="0"
                   onClick={this.toggleFileOptions}
-                  onBlur={() => {
-                    isFocused = false;
-                    setTimeout(() => {
-                      if (!isFocused) {
-                        this.hideFileOptions();
-                      }
-                    }, 200);
-                  }}
-                  onFocus={() => { isFocused = true; }}
+                  onBlur={this.blurComponent}
+                  onFocus={() => { this.setState({ isFocused: true }); }}
                 >
                   <InlineSVG src={downArrowUrl} />
                 </button>
@@ -183,15 +185,8 @@ export class FileNode extends React.Component {
                                 this.props.newFile();
                                 setTimeout(() => this.hideFileOptions(), 0);
                               }}
-                              onBlur={() => {
-                                isFocused = false;
-                                setTimeout(() => {
-                                  if (!isFocused) {
-                                    this.hideFileOptions();
-                                  }
-                                }, 200);
-                              }}
-                              onFocus={() => { isFocused = true; }}
+                              onBlur={this.blurComponent}
+                              onFocus={() => { this.setState({ isFocused: true }); }}
                               className="sidebar__file-item-option"
                             >
                               Add File
@@ -210,15 +205,8 @@ export class FileNode extends React.Component {
                                 this.props.newFolder();
                                 setTimeout(() => this.hideFileOptions(), 0);
                               }}
-                              onBlur={() => {
-                                isFocused = false;
-                                setTimeout(() => {
-                                  if (!isFocused) {
-                                    this.hideFileOptions();
-                                  }
-                                }, 200);
-                              }}
-                              onFocus={() => { isFocused = true; }}
+                              onBlur={this.blurComponent}
+                              onFocus={() => { this.setState({ isFocused: true }); }}
                               className="sidebar__file-item-option"
                             >
                               Add Folder
@@ -235,15 +223,8 @@ export class FileNode extends React.Component {
                           setTimeout(() => this.fileNameInput.focus(), 0);
                           setTimeout(() => this.hideFileOptions(), 0);
                         }}
-                        onBlur={() => {
-                          isFocused = false;
-                          setTimeout(() => {
-                            if (!isFocused) {
-                              this.hideFileOptions();
-                            }
-                          }, 200);
-                        }}
-                        onFocus={() => { isFocused = true; }}
+                        onBlur={this.blurComponent}
+                        onFocus={() => { this.setState({ isFocused: true }); }}
                         className="sidebar__file-item-option"
                       >
                         Rename
@@ -258,15 +239,8 @@ export class FileNode extends React.Component {
                             setTimeout(() => this.props.deleteFile(this.props.id, this.props.parentId), 100);
                           }
                         }}
-                        onBlur={() => {
-                          isFocused = false;
-                          setTimeout(() => {
-                            if (!isFocused) {
-                              this.hideFileOptions();
-                            }
-                          }, 200);
-                        }}
-                        onFocus={() => { isFocused = true; }}
+                        onBlur={this.blurComponent}
+                        onFocus={() => { this.setState({ isFocused: true }); }}
                         className="sidebar__file-item-option"
                       >
                         Delete

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -24,13 +24,27 @@ export class FileNode extends React.Component {
     this.hideFileOptions = this.hideFileOptions.bind(this);
     this.showEditFileName = this.showEditFileName.bind(this);
     this.hideEditFileName = this.hideEditFileName.bind(this);
-    this.blurComponent = this.blurComponent.bind(this);
+    this.onBlurComponent = this.onBlurComponent.bind(this);
+    this.onFocusComponent = this.onFocusComponent.bind(this);
 
     this.state = {
       isOptionsOpen: false,
       isEditingName: false,
       isFocused: false,
     };
+  }
+
+  onFocusComponent() {
+    this.setState({ isFocused: true });
+  }
+
+  onBlurComponent() {
+    this.setState({ isFocused: false });
+    setTimeout(() => {
+      if (!this.state.isFocused) {
+        this.hideFileOptions();
+      }
+    }, 200);
   }
 
   handleFileClick(e) {
@@ -80,15 +94,6 @@ export class FileNode extends React.Component {
 
   hideFileOptions() {
     this.setState({ isOptionsOpen: false });
-  }
-
-  blurComponent() {
-    this.setState({ isFocused: false });
-    setTimeout(() => {
-      if (!this.state.isFocused) {
-        this.hideFileOptions();
-      }
-    }, 200);
   }
 
   showEditFileName() {
@@ -168,8 +173,8 @@ export class FileNode extends React.Component {
                   ref={(element) => { this[`fileOptions-${this.props.id}`] = element; }}
                   tabIndex="0"
                   onClick={this.toggleFileOptions}
-                  onBlur={this.blurComponent}
-                  onFocus={() => { this.setState({ isFocused: true }); }}
+                  onBlur={this.onBlurComponent}
+                  onFocus={this.onFocusComponent}
                 >
                   <InlineSVG src={downArrowUrl} />
                 </button>
@@ -185,8 +190,8 @@ export class FileNode extends React.Component {
                                 this.props.newFile();
                                 setTimeout(() => this.hideFileOptions(), 0);
                               }}
-                              onBlur={this.blurComponent}
-                              onFocus={() => { this.setState({ isFocused: true }); }}
+                              onBlur={this.onBlurComponent}
+                              onFocus={this.onFocusComponent}
                               className="sidebar__file-item-option"
                             >
                               Add File
@@ -205,8 +210,8 @@ export class FileNode extends React.Component {
                                 this.props.newFolder();
                                 setTimeout(() => this.hideFileOptions(), 0);
                               }}
-                              onBlur={this.blurComponent}
-                              onFocus={() => { this.setState({ isFocused: true }); }}
+                              onBlur={this.onBlurComponent}
+                              onFocus={this.onFocusComponent}
                               className="sidebar__file-item-option"
                             >
                               Add Folder
@@ -223,8 +228,8 @@ export class FileNode extends React.Component {
                           setTimeout(() => this.fileNameInput.focus(), 0);
                           setTimeout(() => this.hideFileOptions(), 0);
                         }}
-                        onBlur={this.blurComponent}
-                        onFocus={() => { this.setState({ isFocused: true }); }}
+                        onBlur={this.onBlurComponent}
+                        onFocus={this.onFocusComponent}
                         className="sidebar__file-item-option"
                       >
                         Rename
@@ -239,8 +244,8 @@ export class FileNode extends React.Component {
                             setTimeout(() => this.props.deleteFile(this.props.id, this.props.parentId), 100);
                           }
                         }}
-                        onBlur={this.blurComponent}
-                        onFocus={() => { this.setState({ isFocused: true }); }}
+                        onBlur={this.onBlurComponent}
+                        onFocus={this.onFocusComponent}
                         className="sidebar__file-item-option"
                       >
                         Delete

--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -12,6 +12,20 @@ class Sidebar extends React.Component {
     super(props);
     this.resetSelectedFile = this.resetSelectedFile.bind(this);
     this.toggleProjectOptions = this.toggleProjectOptions.bind(this);
+    this.blurComponent = this.blurComponent.bind(this);
+
+    this.state = {
+      isFocused: false,
+    };
+  }
+
+  blurComponent() {
+    this.setState({ isFocused: false });
+    setTimeout(() => {
+      if (!this.state.isFocused) {
+        this.props.closeProjectOptions();
+      }
+    }, 200);
   }
 
   resetSelectedFile() {
@@ -41,7 +55,6 @@ class Sidebar extends React.Component {
   }
 
   render() {
-    let isFocused = false;
     const canEditProject = this.userCanEditProject();
     const sidebarClass = classNames({
       'sidebar': true,
@@ -66,15 +79,8 @@ class Sidebar extends React.Component {
               tabIndex="0"
               ref={(element) => { this.sidebarOptions = element; }}
               onClick={this.toggleProjectOptions}
-              onBlur={() => {
-                isFocused = false;
-                setTimeout(() => {
-                  if (!isFocused) {
-                    this.props.closeProjectOptions();
-                  }
-                }, 200);
-              }}
-              onFocus={() => { isFocused = true; }}
+              onBlur={this.blurComponent}
+              onFocus={() => { this.setState({ isFocused: true }); }}
             >
               <InlineSVG src={downArrowUrl} />
             </button>
@@ -86,15 +92,8 @@ class Sidebar extends React.Component {
                     this.props.newFolder();
                     setTimeout(this.props.closeProjectOptions, 0);
                   }}
-                  onBlur={() => {
-                    isFocused = false;
-                    setTimeout(() => {
-                      if (!isFocused) {
-                        this.props.closeProjectOptions();
-                      }
-                    }, 200);
-                  }}
-                  onFocus={() => { isFocused = true; }}
+                  onBlur={this.blurComponent}
+                  onFocus={() => { this.setState({ isFocused: true }); }}
                 >
                   Add folder
                 </button>
@@ -106,15 +105,8 @@ class Sidebar extends React.Component {
                     this.props.newFile();
                     setTimeout(this.props.closeProjectOptions, 0);
                   }}
-                  onBlur={() => {
-                    isFocused = false;
-                    setTimeout(() => {
-                      if (!isFocused) {
-                        this.props.closeProjectOptions();
-                      }
-                    }, 200);
-                  }}
-                  onFocus={() => { isFocused = true; }}
+                  onBlur={this.blurComponent}
+                  onFocus={() => { this.setState({ isFocused: true }); }}
                 >
                   Add file
                 </button>

--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -12,20 +12,25 @@ class Sidebar extends React.Component {
     super(props);
     this.resetSelectedFile = this.resetSelectedFile.bind(this);
     this.toggleProjectOptions = this.toggleProjectOptions.bind(this);
-    this.blurComponent = this.blurComponent.bind(this);
+    this.onBlurComponent = this.onBlurComponent.bind(this);
+    this.onFocusComponent = this.onFocusComponent.bind(this);
 
     this.state = {
       isFocused: false,
     };
   }
 
-  blurComponent() {
+  onBlurComponent() {
     this.setState({ isFocused: false });
     setTimeout(() => {
       if (!this.state.isFocused) {
         this.props.closeProjectOptions();
       }
     }, 200);
+  }
+
+  onFocusComponent() {
+    this.setState({ isFocused: true });
   }
 
   resetSelectedFile() {
@@ -79,8 +84,8 @@ class Sidebar extends React.Component {
               tabIndex="0"
               ref={(element) => { this.sidebarOptions = element; }}
               onClick={this.toggleProjectOptions}
-              onBlur={this.blurComponent}
-              onFocus={() => { this.setState({ isFocused: true }); }}
+              onBlur={this.onBlurComponent}
+              onFocus={this.onFocusComponent}
             >
               <InlineSVG src={downArrowUrl} />
             </button>
@@ -92,8 +97,8 @@ class Sidebar extends React.Component {
                     this.props.newFolder();
                     setTimeout(this.props.closeProjectOptions, 0);
                   }}
-                  onBlur={this.blurComponent}
-                  onFocus={() => { this.setState({ isFocused: true }); }}
+                  onBlur={this.onBlurComponent}
+                  onFocus={this.onFocusComponent}
                 >
                   Add folder
                 </button>
@@ -105,8 +110,8 @@ class Sidebar extends React.Component {
                     this.props.newFile();
                     setTimeout(this.props.closeProjectOptions, 0);
                   }}
-                  onBlur={this.blurComponent}
-                  onFocus={() => { this.setState({ isFocused: true }); }}
+                  onBlur={this.onBlurComponent}
+                  onFocus={this.onFocusComponent}
                 >
                   Add file
                 </button>

--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -41,6 +41,7 @@ class Sidebar extends React.Component {
   }
 
   render() {
+    let isFocused = false;
     const canEditProject = this.userCanEditProject();
     const sidebarClass = classNames({
       'sidebar': true,
@@ -65,6 +66,15 @@ class Sidebar extends React.Component {
               tabIndex="0"
               ref={(element) => { this.sidebarOptions = element; }}
               onClick={this.toggleProjectOptions}
+              onBlur={() => {
+                isFocused = false;
+                setTimeout(() => {
+                  if (!isFocused) {
+                    this.props.closeProjectOptions();
+                  }
+                }, 200);
+              }}
+              onFocus={() => { isFocused = true; }}
             >
               <InlineSVG src={downArrowUrl} />
             </button>
@@ -76,6 +86,15 @@ class Sidebar extends React.Component {
                     this.props.newFolder();
                     setTimeout(this.props.closeProjectOptions, 0);
                   }}
+                  onBlur={() => {
+                    isFocused = false;
+                    setTimeout(() => {
+                      if (!isFocused) {
+                        this.props.closeProjectOptions();
+                      }
+                    }, 200);
+                  }}
+                  onFocus={() => { isFocused = true; }}
                 >
                   Add folder
                 </button>
@@ -87,7 +106,15 @@ class Sidebar extends React.Component {
                     this.props.newFile();
                     setTimeout(this.props.closeProjectOptions, 0);
                   }}
-                  onBlur={() => { setTimeout(this.props.closeProjectOptions, 200); }}
+                  onBlur={() => {
+                    isFocused = false;
+                    setTimeout(() => {
+                      if (!isFocused) {
+                        this.props.closeProjectOptions();
+                      }
+                    }, 200);
+                  }}
+                  onFocus={() => { isFocused = true; }}
                 >
                   Add file
                 </button>


### PR DESCRIPTION
This change ensures that the file options composite widget is
hidden if and only if none of its components is in focus. This
is achieved by having a variable keep track of the state of
the composite widget (in focus / not in focus).

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`