### PR TITLE
Set default Theme value to "light" (fixes #974)

### DIFF
--- a/client/modules/App/App.jsx
+++ b/client/modules/App/App.jsx
@@ -14,6 +14,7 @@ class App extends React.Component {
 
   componentDidMount() {
     this.setState({ isMounted: true }); // eslint-disable-line react/no-did-mount-set-state
+    document.body.className = 'light';
   }
 
   componentWillReceiveProps(nextProps) {


### PR DESCRIPTION
## Problem

In `<IDEView>` and `<FullView>` , theme value is set for `<body>` 's class name.
But, follows URL has no theme attribution on case directly access.

```
/login
/signup
/verify
/account
/reset-password
/reset-password/:reset_password_token
```

In #974 , style whose selector is `.light .github-button` , is not applied because `.light` is not provide for `/login` .


## Solution

As default theme value, set `light` class name to `<body>`.

---

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`