### PR TITLE
Fix: Add backend validation for sketch and file names

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -67,6 +67,7 @@ export class FileNode extends React.Component {
   validateFileName() {
     const oldFileExtension = this.originalFileName.match(/\.[0-9a-z]+$/i);
     const newFileExtension = this.props.name.match(/\.[0-9a-z]+$/i);
+    const fileName = this.props.name.replace(/\.[^/.]+$/, '');
     if (oldFileExtension && !newFileExtension) {
       this.props.updateFileName(this.props.id, this.originalFileName);
     }
@@ -75,6 +76,10 @@ export class FileNode extends React.Component {
       newFileExtension &&
       oldFileExtension[0].toLowerCase() !== newFileExtension[0].toLowerCase()
     ) {
+      this.props.updateFileName(this.props.id, this.originalFileName);
+    }
+    //  Handles empty file names
+    if (!fileName.length) {
       this.props.updateFileName(this.props.id, this.originalFileName);
     }
   }

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -67,7 +67,7 @@ export class FileNode extends React.Component {
   validateFileName() {
     const oldFileExtension = this.originalFileName.match(/\.[0-9a-z]+$/i);
     const newFileExtension = this.props.name.match(/\.[0-9a-z]+$/i);
-    const fileName = this.props.name.replace(/\.[^/.]+$/, '');
+    const fileNameWithoutExtension = this.props.name.replace(/\.[^/.]+$/, '');
     if (oldFileExtension && !newFileExtension) {
       this.props.updateFileName(this.props.id, this.originalFileName);
     }
@@ -79,7 +79,7 @@ export class FileNode extends React.Component {
       this.props.updateFileName(this.props.id, this.originalFileName);
     }
     //  Handles empty file names
-    if (!fileName.length) {
+    if (!fileNameWithoutExtension.length) {
       this.props.updateFileName(this.props.id, this.originalFileName);
     }
   }

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -162,6 +162,7 @@ export class FileNode extends React.Component {
                 <button className="sidebar__file-item-name" onClick={this.handleFileClick}>{this.props.name}</button>
                 <input
                   type="text"
+                  maxLength="256"
                   className="sidebar__file-item-input"
                   value={this.props.name}
                   onChange={this.handleFileNameChange}

--- a/server/controllers/project.controller.js
+++ b/server/controllers/project.controller.js
@@ -53,7 +53,8 @@ export function updateProject(req, res) {
         $set: req.body
       },
       {
-        new: true
+        new: true,
+        runValidators: true
       }
     )
       .populate('user', 'username')

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -4,14 +4,30 @@ import slugify from 'slugify';
 
 const { Schema } = mongoose;
 
+
+const fileNameValidator = (file) => {
+  const fileName = file.replace(/\.[^/.]+$/, ''); // Removes the extension from the fileName
+  if (fileName.length === 0) {
+    return false;
+  }
+
+  return true;
+};
+
 const fileSchema = new Schema(
   {
-    name: { type: String, default: 'sketch.js' },
+    name: {
+      type: String,
+      default: 'sketch.js',
+      minlength: 1,
+      maxlength: 256,
+      validate: [fileNameValidator, 'File Name Validation Failed!']
+    },
     content: { type: String, default: '' },
     url: { type: String },
     children: { type: [String], default: [] },
     fileType: { type: String, default: 'file' },
-    isSelectedFile: { type: Boolean }
+    isSelectedFile: { type: Boolean },
   },
   { timestamps: true, _id: true, usePushEach: true }
 );
@@ -26,7 +42,9 @@ fileSchema.set('toJSON', {
 
 const projectSchema = new Schema(
   {
-    name: { type: String, default: "Hello p5.js, it's the server" },
+    name: {
+      type: String, default: "Hello p5.js, it's the server", minlength: 1, maxlength: 256
+    },
     user: { type: Schema.Types.ObjectId, ref: 'User' },
     serveSecure: { type: Boolean, default: false },
     files: { type: [fileSchema] },
@@ -46,7 +64,11 @@ projectSchema.set('toJSON', {
 
 projectSchema.pre('save', function generateSlug(next) {
   const project = this;
+  const MAX_PROJECT_LENGTH = 256;
+
   project.slug = slugify(project.name, '_');
+  project.name = project.name.substring(0, MAX_PROJECT_LENGTH);
+
   return next();
 });
 

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -75,11 +75,11 @@ function projectPreUpdate(next) {
   project.name = project.name.substring(0, MAX_PROJECT_NAME_LENGTH); // Truncates project name
 
   // Truncate file names
-  project.files.forEach((ele)=>{
+  project.files.forEach((ele) => {
     const fullFileName = ele.name;
     const fileName = fullFileName.replace(/\.[^/.]+$/, '');
     const extension = fullFileName.substring(fileName.length);
-    ele.name = fileName.substring(0, MAX_FILE_NAME_LENGTH)+extension;
+    ele.name = fileName.substring(0, MAX_FILE_NAME_LENGTH) + extension;
   });
 
   return next();
@@ -87,12 +87,12 @@ function projectPreUpdate(next) {
 
 projectSchema.pre('findOneAndUpdate', projectPreUpdate);
 
-fileSchema.pre('save', function (next) {
+fileSchema.pre('save', function truncateFileName(next) {
   const file = this;
   const fullFileName = file.name;
   const fileName = fullFileName.replace(/\.[^/.]+$/, '');
   const extension = fullFileName.substring(fileName.length);
-  file.name = fileName.substring(0, MAX_FILE_NAME_LENGTH)+extension;
+  file.name = fileName.substring(0, MAX_FILE_NAME_LENGTH) + extension;
 
   return next();
 });

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -8,8 +8,8 @@ const MAX_PROJECT_NAME_LENGTH = 256;
 const MAX_FILE_NAME_LENGTH = 256;
 
 const fileNameValidator = (file) => {
-  const fileName = file.replace(/\.[^/.]+$/, ''); // Removes the extension from the fileName
-  if (fileName.length === 0) {
+  const fileNameWithoutExtension = file.replace(/\.[^/.]+$/, ''); // Removes the extension from the fileName
+  if (fileNameWithoutExtension.length === 0) {
     return false;
   }
 

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -64,8 +64,8 @@ projectSchema.set('toJSON', {
 
 projectSchema.pre('save', function generateSlug(next) {
   const project = this;
-  project.slug = slugify(project.name, '_');
   project.name = project.name.substring(0, MAX_PROJECT_NAME_LENGTH); // Truncates project name
+  project.slug = slugify(project.name, '_');
 
   return next();
 });


### PR DESCRIPTION
- Truncate sketch names to max length
- Add validations for sketch names
- Add validation for file names

Fixes #568 and #989 

@catarak what do you think?

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`