### PR TITLE
Responsiveness for settings overlay

### DIFF
--- a/client/styles/components/_overlay.scss
+++ b/client/styles/components/_overlay.scss
@@ -22,8 +22,14 @@
   display: flex;
   flex-wrap: wrap;
   flex-flow: column;
-  max-height: 80%;
-  max-width: 65%;
+  max-width: 100%;
+  max-height: 100%;
+  overflow-y: auto;
+  @include media-breakpoint-up($sm) {
+    overflow-y: unset;
+    max-width: 65%;
+    max-height: 80%;
+  }
 }
 
 .overlay__header {


### PR DESCRIPTION
I have verified that this pull request: Fixes #1036 

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`