### PR TITLE
fixes #1057, fullscreen wasn't rendering because clearConsole was not defined

### DIFF
--- a/client/modules/IDE/pages/FullView.jsx
+++ b/client/modules/IDE/pages/FullView.jsx
@@ -53,6 +53,7 @@ class FullView extends React.Component {
             setBlobUrl={this.ident}
             stopSketch={this.ident}
             expandConsole={this.ident}
+            clearConsole={this.ident}
           />
         </div>
       </div>


### PR DESCRIPTION
… defined

I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`