### PR TITLE
Fixed folder can be renamed to empty string "" #989

### DIFF
--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -5,7 +5,6 @@ import { reset } from 'redux-form';
 import * as ActionTypes from '../../../constants';
 import { setUnsavedChanges } from './ide';
 import { setProjectSavedTime } from './project';
-import { showToast, setToastText } from './toast';
 
 const __process = (typeof global !== 'undefined' ? global : window).process;
 const ROOT_URL = __process.env.API_URL;
@@ -153,18 +152,10 @@ export function createFolder(formProps) {
 }
 
 export function updateFileName(id, name) {
-  return (dispatch, getState) => {
-    const state = getState();
-    if (!state.name.length) {
-      dispatch(showToast(5500));
-      dispatch(setToastText('Invalid folder name'));
-    } else {
-      dispatch({
-        type: ActionTypes.UPDATE_FILE_NAME,
-        id,
-        name
-      });
-    }
+  return {
+    type: ActionTypes.UPDATE_FILE_NAME,
+    id,
+    name
   };
 }
 

--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -5,6 +5,7 @@ import { reset } from 'redux-form';
 import * as ActionTypes from '../../../constants';
 import { setUnsavedChanges } from './ide';
 import { setProjectSavedTime } from './project';
+import { showToast, setToastText } from './toast';
 
 const __process = (typeof global !== 'undefined' ? global : window).process;
 const ROOT_URL = __process.env.API_URL;
@@ -152,10 +153,15 @@ export function createFolder(formProps) {
 }
 
 export function updateFileName(id, name) {
-  return {
+  if(name.length) {
+    return {
     type: ActionTypes.UPDATE_FILE_NAME,
     id,
     name
+    }
+  } else {
+    dispatch(showToast(5500))
+    dispatch(setToastText('Invalid folder name'))
   };
 }
 

--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -153,15 +153,18 @@ export function createFolder(formProps) {
 }
 
 export function updateFileName(id, name) {
-  if(name.length) {
-    return {
-    type: ActionTypes.UPDATE_FILE_NAME,
-    id,
-    name
+  return (dispatch, getState) => {
+    const state = getState();
+    if (!state.name.length) {
+      dispatch(showToast(5500));
+      dispatch(setToastText('Invalid folder name'));
+    } else {
+      dispatch({
+        type: ActionTypes.UPDATE_FILE_NAME,
+        id,
+        name
+      });
     }
-  } else {
-    dispatch(showToast(5500))
-    dispatch(setToastText('Invalid folder name'))
   };
 }
 

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -55,7 +55,9 @@ export class FileNode extends React.Component {
   }
 
   handleFileNameChange(event) {
-    this.props.updateFileName(this.props.id, event.target.value);
+    if (event.target.value.length) {
+      this.props.updateFileName(this.props.id, event.target.value);
+    }
   }
 
   handleKeyPress(event) {


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run   lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #989`