### PR TITLE
fixes #850, bundling external libraries was causing a callback to never be called

### DIFF
--- a/server/controllers/project.controller.js
+++ b/server/controllers/project.controller.js
@@ -255,6 +255,10 @@ function bundleExternalLibs(project, zip, callback) {
 
     if (!isUrl(src)) {
       numScriptsResolved += 1;
+      if (numScriptsResolved === numScriptTags) {
+        indexHtml.content = serializeDocument(document);
+        callback();
+      }
       return;
     }
 
@@ -280,6 +284,10 @@ function bundleExternalLibs(project, zip, callback) {
     numScriptTags = scriptTags.length;
     for (let i = 0; i < numScriptTags; i += 1) {
       resolveScriptTagSrc(scriptTags[i], indexHtmlDoc);
+    }
+    if (numScriptTags === 0) {
+      indexHtml.content = serializeDocument(document);
+      callback();
     }
   });
 }


### PR DESCRIPTION
I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`