### PR TITLE
fixes #1065, checks if cmController.getContent is defined

### DIFF
--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -145,8 +145,10 @@ class PreviewFrame extends React.Component {
 
   mergeLocalFilesAndEditorActiveFile() {
     const files = this.props.files.slice();
-    const activeFileInEditor = this.props.cmController.getContent();
-    files.find(file => file.id === activeFileInEditor.id).content = activeFileInEditor.content;
+    if (this.props.cmController.getContent) {
+      const activeFileInEditor = this.props.cmController.getContent();
+      files.find(file => file.id === activeFileInEditor.id).content = activeFileInEditor.content;
+    }
     return files;
   }
 


### PR DESCRIPTION
I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`