### PR TITLE
Removes unused createProject IDE action

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -215,32 +215,6 @@ export function autosaveProject() {
   };
 }
 
-export function createProject() {
-  return (dispatch, getState) => {
-    const state = getState();
-    if (state.project.isSaving) {
-      Promise.resolve();
-      return;
-    }
-    dispatch(startSavingProject());
-    axios.post(`${ROOT_URL}/projects`, {}, { withCredentials: true })
-      .then((response) => {
-        dispatch(endSavingProject());
-        dispatch(setUnsavedChanges(false));
-        browserHistory.push(`/${response.data.user.username}/sketches/${response.data.id}`);
-        const { hasChanges, synchedProject } = getSynchedProject(getState(), response.data);
-        if (hasChanges) {
-          dispatch(setUnsavedChanges(true));
-        }
-        dispatch(setNewProject(synchedProject));
-      })
-      .catch((response) => {
-        dispatch(endSavingProject());
-        dispatch(projectSaveFail(response.data));
-      });
-  };
-}
-
 export function exportProjectAsZip(projectId) {
   const win = window.open(`${ROOT_URL}/projects/${projectId}/zip`, '_blank');
   win.focus();


### PR DESCRIPTION
Creating a new project seems to use the `saveProject` action so this isn't needed anymore.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [N/A] is descriptively named and links to an issue number, i.e. `Fixes #123`