### PR TITLE
Remove unnecessary Login with Github button

### DIFF
--- a/client/modules/User/pages/AccountView.jsx
+++ b/client/modules/User/pages/AccountView.jsx
@@ -47,8 +47,6 @@ class AccountView extends React.Component {
         <div className="form-container__content">
           <h2 className="form-container__title">My Account</h2>
           <AccountForm {...this.props} />
-          <h2 className="form-container__divider">Or</h2>
-          <GithubButton buttonText="Login with Github" />
         </div>
       </div>
     );


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [N/A] is descriptively named and links to an issue number

On the [account settings page](https://editor.p5js.org/account), there is this Github button to sign in, but the user is already signed in when on this page, and so this button appears to serve no purpose. 