### PR TITLE
for #989, files cannot be renamed to empty string

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -68,20 +68,12 @@ export class FileNode extends React.Component {
     const oldFileExtension = this.originalFileName.match(/\.[0-9a-z]+$/i);
     const newFileExtension = this.props.name.match(/\.[0-9a-z]+$/i);
     const newFileName = this.props.name;
-    if (oldFileExtension && !newFileExtension) {
-      this.props.updateFileName(this.props.id, this.originalFileName);
-    }
-    if (
-      oldFileExtension &&
-      newFileExtension &&
-      oldFileExtension[0].toLowerCase() !== newFileExtension[0].toLowerCase()
-    ) {
-      this.props.updateFileName(this.props.id, this.originalFileName);
-    }
-    if (newFileName === '') {
-      this.props.updateFileName(this.props.id, this.originalFileName);
-    }
-    if (newFileName === newFileExtension[0]) {
+    const hasNoExtension = oldFileExtension && !newFileExtension;
+    const notSameExtension = oldFileExtension && newFileExtension &&
+    oldFileExtension[0].toLowerCase() !== newFileExtension[0].toLowerCase();
+    const hasEmptyFilename = newFileName === '';
+    const hasOnlyExtension = newFileExtension && newFileName === newFileExtension[0];
+    if (hasEmptyFilename || hasNoExtension || notSameExtension || hasOnlyExtension) {
       this.props.updateFileName(this.props.id, this.originalFileName);
     }
   }

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -67,6 +67,7 @@ export class FileNode extends React.Component {
   validateFileName() {
     const oldFileExtension = this.originalFileName.match(/\.[0-9a-z]+$/i);
     const newFileExtension = this.props.name.match(/\.[0-9a-z]+$/i);
+    const newFileName = this.props.name;
     if (oldFileExtension && !newFileExtension) {
       this.props.updateFileName(this.props.id, this.originalFileName);
     }
@@ -75,6 +76,12 @@ export class FileNode extends React.Component {
       newFileExtension &&
       oldFileExtension[0].toLowerCase() !== newFileExtension[0].toLowerCase()
     ) {
+      this.props.updateFileName(this.props.id, this.originalFileName);
+    }
+    if (newFileName === '') {
+      this.props.updateFileName(this.props.id, this.originalFileName);
+    }
+    if (newFileName === newFileExtension[0]) {
       this.props.updateFileName(this.props.id, this.originalFileName);
     }
   }

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -67,13 +67,15 @@ export class FileNode extends React.Component {
   validateFileName() {
     const oldFileExtension = this.originalFileName.match(/\.[0-9a-z]+$/i);
     const newFileExtension = this.props.name.match(/\.[0-9a-z]+$/i);
+    const hasPeriod = this.props.name.match(/\.+/);
     const newFileName = this.props.name;
     const hasNoExtension = oldFileExtension && !newFileExtension;
-    const notSameExtension = oldFileExtension && newFileExtension &&
-    oldFileExtension[0].toLowerCase() !== newFileExtension[0].toLowerCase();
+    const hasExtensionIfFolder = this.props.fileType === 'folder' && hasPeriod;
+    const notSameExtension = oldFileExtension && newFileExtension
+      && oldFileExtension[0].toLowerCase() !== newFileExtension[0].toLowerCase();
     const hasEmptyFilename = newFileName === '';
     const hasOnlyExtension = newFileExtension && newFileName === newFileExtension[0];
-    if (hasEmptyFilename || hasNoExtension || notSameExtension || hasOnlyExtension) {
+    if (hasEmptyFilename || hasNoExtension || notSameExtension || hasOnlyExtension || hasExtensionIfFolder) {
       this.props.updateFileName(this.props.id, this.originalFileName);
     }
   }

--- a/client/modules/IDE/components/NewFolderModal.jsx
+++ b/client/modules/IDE/components/NewFolderModal.jsx
@@ -38,6 +38,8 @@ function validate(formProps) {
     errors.name = 'Please enter a name';
   } else if (formProps.name.trim().length === 0) {
     errors.name = 'Folder name cannot contain only spaces';
+  } else if (formProps.name.match(/\.+/i)) {
+    errors.name = 'Folder name cannot contain an extension';
   }
 
   return errors;


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`