### PR TITLE
Fixes bug where requestsOfType() would fail if no body

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -132,6 +132,17 @@ app.get('/', (req, res) => {
   res.sendFile(renderIndex());
 });
 
+// Handle API errors
+app.use('/api', (error, req, res, next) => {
+  if (error && error.code && !res.headersSent) {
+    res.status(error.code).json({ error: error.message });
+    return;
+  }
+
+  next(error);
+});
+
+
 // Handle missing routes.
 app.get('*', (req, res) => {
   res.status(404);

--- a/server/utils/requestsOfType.js
+++ b/server/utils/requestsOfType.js
@@ -4,11 +4,14 @@
   header does not match `type`
 */
 const requestsOfType = type => (req, res, next) => {
-  if (req.get('content-type') != null && !req.is(type)) {
+  const hasContentType = req.get('content-type') !== null;
+  const isCorrectType = req.is(type) === null || req.is(type) === type;
+
+  if (hasContentType && !isCorrectType) {
     if (process.env.NODE_ENV === 'development') {
-      console.log('in requests of type error');
+      console.error(`Requests with a body must be of Content-Type "${type}". Sending HTTP 406`);
     }
-    return next({ statusCode: 406 }); // 406 UNACCEPTABLE
+    return next({ code: 406, message: `Requests with a body must be of Content-Type "${type}"` }); // 406 UNACCEPTABLE
   }
 
   return next();


### PR DESCRIPTION
The `requestsOfType()` middleware wasn't behaving correctly when an incoming request had no body. When there is no body, the request should succeed.

Express' [`request.is(type)`](https://expressjs.com/en/api.html#req.is) function can return three things:
- the content-type of the request if it matches the specified `type` e.g. `application/json`
- `null` if the request has no body
- `false` if it doesn't match

If the request does have a body, then we check that the `Content-Type` matches the `type` provided, and fail if it doesn't.

I also added some error middleware that will return a JSON object with the correct status code from the API and will log a more descriptive error in development.

--

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`