### PR TITLE
Wraps console external component in error boundary

### DIFF
--- a/client/modules/IDE/components/Console.jsx
+++ b/client/modules/IDE/components/Console.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import InlineSVG from 'react-inlinesvg';
 import classNames from 'classnames';
 import { Console as ConsoleFeed } from 'console-feed';
+import ErrorBoundary from './ErrorBoundary';
 import {
   CONSOLE_FEED_WITHOUT_ICONS, CONSOLE_FEED_LIGHT_STYLES,
   CONSOLE_FEED_DARK_STYLES, CONSOLE_FEED_CONTRAST_STYLES
@@ -110,10 +111,12 @@ class Console extends React.Component {
                     {times}
                   </div>
                 }
-                <ConsoleFeed
-                  styles={this.getConsoleFeedStyle(theme, times)}
-                  logs={[consoleEvent]}
-                />
+                <ErrorBoundary>
+                  <ConsoleFeed
+                    styles={this.getConsoleFeedStyle(theme, times)}
+                    logs={[consoleEvent]}
+                  />
+                </ErrorBoundary>
               </div>
             );
           })}

--- a/client/modules/IDE/components/ErrorBoundary.jsx
+++ b/client/modules/IDE/components/ErrorBoundary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react';
 
 class ErrorBoundary extends React.Component {
@@ -14,5 +15,13 @@ class ErrorBoundary extends React.Component {
     return this.state.errorOccurred ? 'Something went wrong!' : this.props.children;
   }
 }
+
+ErrorBoundary.propTypes = {
+  children: PropTypes.node
+};
+
+ErrorBoundary.defaultProps = {
+  children: ''
+};
 
 export default ErrorBoundary;

--- a/client/modules/IDE/components/ErrorBoundary.jsx
+++ b/client/modules/IDE/components/ErrorBoundary.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { errorOccurred: false };
+  }
+
+  componentDidCatch(error, info) {
+    this.setState({ errorOccurred: true });
+  }
+
+  render() {
+    return this.state.errorOccurred ? 'Something went wrong!' : this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
addresses #1088 

Demonstration of the kind of ErrorBoundary that can be set up to stop the console-feed component crashing the entire IDE

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

