### PR TITLE
1133 - hides scrollbar when not needed

### DIFF
--- a/client/styles/components/_asset-list.scss
+++ b/client/styles/components/_asset-list.scss
@@ -1,6 +1,6 @@
 .asset-table-container {
   // flex: 1 1 0%;
-  overflow-y: scroll;
+  overflow-y: auto;
   max-width: 100%;
   width: #{1000 / $base-font-size}rem;
   min-height: #{400 / $base-font-size}rem;

--- a/client/styles/components/_sketch-list.scss
+++ b/client/styles/components/_sketch-list.scss
@@ -1,5 +1,5 @@
 .sketches-table-container {
-  overflow-y: scroll;
+  overflow-y: auto;
   max-width: 100%;
   width: #{1000 / $base-font-size}rem;
   min-height: #{400 / $base-font-size}rem;


### PR DESCRIPTION
Fixes #1133 

I'm not particularly good at CSS, but I've tested this on FF and Chrome (on linux) and it seems to do the trick.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`