### PR TITLE
Fix Issue #588. Only highlight runtime errors at the appropriate line…

### DIFF
--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -197,7 +197,7 @@ class Editor extends React.Component {
             consoleEvent.data[0].indexOf(')') > -1) {
             const n = consoleEvent.data[0].replace(')', '').split(' ');
             const lineNumber = parseInt(n[n.length - 1], 10) - 1;
-            if (!Number.isNaN(lineNumber)) {
+            if (!Number.isNaN(lineNumber) && `${consoleEvent.source}.js` === this.props.file.name) {
               this._cm.addLineClass(lineNumber, 'background', 'line-runtime-error');
             }
           }


### PR DESCRIPTION
… for file in which the error occurred.

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`