### PR TITLE
Fixed 'Add Folder' option

### DIFF
--- a/client/modules/IDE/components/NewFolderForm.jsx
+++ b/client/modules/IDE/components/NewFolderForm.jsx
@@ -14,7 +14,7 @@ class NewFolderForm extends React.Component {
 
   render() {
     const {
-      fields: { name }, handleSubmit, submitting, pristine
+      fields: { name }, handleSubmit
     } = this.props;
     return (
       <form
@@ -34,7 +34,7 @@ class NewFolderForm extends React.Component {
           ref={(element) => { this.fileName = element; }}
           {...domOnlyProps(name)}
         />
-        <input type="submit" value="Add Folder" disabled={submitting || pristine} aria-label="add folder" />
+        <input type="submit" value="Add Folder" aria-label="add folder" />
         {name.touched && name.error && <span className="form-error">{name.error}</span>}
       </form>
     );


### PR DESCRIPTION
I have verified that this pull request:
#1139 
* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

@catarak Please review this :)