### PR TITLE
Add toast to notify when creating new file. Fixes #1140

### DIFF
--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -94,11 +94,11 @@ class Nav extends React.PureComponent {
   handleNew() {
     if (!this.props.unsavedChanges) {
       this.props.showToast(1500);
-      this.props.setToastText('New sketch created.');
+      this.props.setToastText('Opened new sketch.');
       this.props.newProject();
     } else if (this.props.warnIfUnsavedChanges()) {
       this.props.showToast(1500);
-      this.props.setToastText('New sketch created.');
+      this.props.setToastText('Opened new sketch.');
       this.props.newProject();
     }
     this.setDropdown('none');

--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router';
 import InlineSVG from 'react-inlinesvg';
 import classNames from 'classnames';
 import * as IDEActions from '../modules/IDE/actions/ide';
+import * as toastActions from '../modules/IDE/actions/toast';
 import * as projectActions from '../modules/IDE/actions/project';
 import { setAllAccessibleOutput } from '../modules/IDE/actions/preferences';
 import { logoutUser } from '../modules/User/actions';
@@ -92,6 +93,8 @@ class Nav extends React.PureComponent {
 
   handleNew() {
     if (!this.props.unsavedChanges) {
+      this.props.showToast(1500);
+      this.props.setToastText('New file created.');
       this.props.newProject();
     } else if (this.props.warnIfUnsavedChanges()) {
       this.props.newProject();
@@ -624,6 +627,8 @@ class Nav extends React.PureComponent {
 
 Nav.propTypes = {
   newProject: PropTypes.func.isRequired,
+  showToast: PropTypes.func.isRequired,
+  setToastText: PropTypes.func.isRequired,
   saveProject: PropTypes.func.isRequired,
   autosaveProject: PropTypes.func.isRequired,
   exportProjectAsZip: PropTypes.func.isRequired,
@@ -678,6 +683,7 @@ function mapStateToProps(state) {
 const mapDispatchToProps = {
   ...IDEActions,
   ...projectActions,
+  ...toastActions,
   logoutUser,
   setAllAccessibleOutput
 };

--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -94,11 +94,11 @@ class Nav extends React.PureComponent {
   handleNew() {
     if (!this.props.unsavedChanges) {
       this.props.showToast(1500);
-      this.props.setToastText('New file created.');
+      this.props.setToastText('New sketch created.');
       this.props.newProject();
     } else if (this.props.warnIfUnsavedChanges()) {
       this.props.showToast(1500);
-      this.props.setToastText('New file created.');
+      this.props.setToastText('New sketch created.');
       this.props.newProject();
     }
     this.setDropdown('none');

--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -97,6 +97,8 @@ class Nav extends React.PureComponent {
       this.props.setToastText('New file created.');
       this.props.newProject();
     } else if (this.props.warnIfUnsavedChanges()) {
+      this.props.showToast(1500);
+      this.props.setToastText('New file created.');
       this.props.newProject();
     }
     this.setDropdown('none');


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

As title states this PR adds a 'toast' notification to alert the user when a new file has been created. Fixes #1140 