### PR TITLE
Public API: Toggle personal access token UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,4 @@ PORT=8000
 S3_BUCKET=<your-s3-bucket>
 S3_BUCKET_URL_BASE=<alt-for-s3-url>
 SESSION_SECRET=whatever_you_want_this_to_be_it_only_matters_for_production
+UI_ACCESS_TOKEN_ENABLED=false

--- a/client/modules/User/pages/AccountView.jsx
+++ b/client/modules/User/pages/AccountView.jsx
@@ -36,6 +36,8 @@ class AccountView extends React.Component {
   }
 
   render() {
+    const accessTokensUIEnabled = window.process.env.UI_ACCESS_TOKEN_ENABLED;
+
     return (
       <div className="user">
         <Helmet>
@@ -53,7 +55,7 @@ class AccountView extends React.Component {
               <TabList>
                 <div className="tabs__titles">
                   <Tab><h4 className="tabs__title">Account</h4></Tab>
-                  <Tab><h4 className="tabs__title">Access Tokens</h4></Tab>
+                  {accessTokensUIEnabled && <Tab><h4 className="tabs__title">Access Tokens</h4></Tab>}
                 </div>
               </TabList>
               <TabPanel>

--- a/server/views/index.js
+++ b/server/views/index.js
@@ -30,6 +30,8 @@ export function renderIndex() {
         window.process.env.CLIENT = true;
         window.process.env.LOGIN_ENABLED = ${process.env.LOGIN_ENABLED === 'false' ? false : true};
         window.process.env.EXAMPLES_ENABLED = ${process.env.EXAMPLES_ENABLED === 'false' ? false : true};
+        window.process.env.EXAMPLES_ENABLED = ${process.env.EXAMPLES_ENABLED === 'false' ? false : true};
+        window.process.env.UI_ACCESS_TOKEN_ENABLED = ${process.env.UI_ACCESS_TOKEN_ENABLED === 'false' ? false : true};
       </script>
     </head>
     <body>


### PR DESCRIPTION
This enables the Personal Access Token tab on the Account page to be enabled/disabled in the UI depending on the `UI_ACCESS_TOKEN_ENABLED` feature flag variable in `.env`.

This enables us to deploy the code to production, but have it hidden until we're happy with it.


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`