### PR TITLE
Add matches search into code mirror fixes #936

### DIFF
--- a/client/utils/codemirror-search.js
+++ b/client/utils/codemirror-search.js
@@ -73,6 +73,8 @@ export default function(CodeMirror) {
       CodeMirror.on(searchField, "keyup", function (e) {
         if (e.keyCode !== 13 && searchField.value.length > 1) { // not enter and more than 1 character to search
           startSearch(cm, getSearchState(cm), searchField.value);
+        } else {
+          cm.display.wrapper.querySelector('.CodeMirror-search-results').innerText = '';
         }
       });
 
@@ -260,6 +262,7 @@ export default function(CodeMirror) {
         </button>
       </div>
       <div class="CodeMirror-search-nav">
+        <button class="CodeMirror-search-results"></button>
         <button
           title="Previous"
           aria-label="Previous"
@@ -292,6 +295,10 @@ export default function(CodeMirror) {
       if (state.annotate) { state.annotate.clear(); state.annotate = null; }
       state.annotate = cm.showMatchesOnScrollbar(state.query,  state.caseInsensitive);
     }
+    var num_match = cm.state.search.annotate.matches.length;
+    var text_match = 
+      'Results: ' + num_match;
+    cm.display.wrapper.querySelector('.CodeMirror-search-results').innerText = text_match;
   }
 
   function doSearch(cm, rev, persistent, immediate, ignoreQuery) {

--- a/client/utils/codemirror-search.js
+++ b/client/utils/codemirror-search.js
@@ -356,7 +356,10 @@ export default function(CodeMirror) {
     var cursor = getSearchCursor(cm, state.query, rev ? state.posFrom : state.posTo);
     if (!cursor.find(rev)) {
       cursor = getSearchCursor(cm, state.query, rev ? CodeMirror.Pos(cm.lastLine()) : CodeMirror.Pos(cm.firstLine(), 0));
-      if (!cursor.find(rev)) return;
+      if (!cursor.find(rev)) {
+        cm.display.wrapper.querySelector('.CodeMirror-search-results').innerText = '';
+        return;
+      }
     }
     cm.setSelection(cursor.from(), cursor.to());
     cm.scrollIntoView({from: cursor.from(), to: cursor.to()}, 60);

--- a/client/utils/codemirror-search.js
+++ b/client/utils/codemirror-search.js
@@ -73,7 +73,7 @@ export default function(CodeMirror) {
       CodeMirror.on(searchField, "keyup", function (e) {
         if (e.keyCode !== 13 && searchField.value.length > 1) { // not enter and more than 1 character to search
           startSearch(cm, getSearchState(cm), searchField.value);
-        } else {
+        } else if (searchField.value.length <= 1) {
           cm.display.wrapper.querySelector('.CodeMirror-search-results').innerText = '';
         }
       });
@@ -295,10 +295,9 @@ export default function(CodeMirror) {
       if (state.annotate) { state.annotate.clear(); state.annotate = null; }
       state.annotate = cm.showMatchesOnScrollbar(state.query,  state.caseInsensitive);
     }
-    var num_match = cm.state.search.annotate.matches.length;
-    var text_match = 
-      'Results: ' + num_match;
-    cm.display.wrapper.querySelector('.CodeMirror-search-results').innerText = text_match;
+    if (originalQuery) {
+      return findNext(cm, false);
+    }
   }
 
   function doSearch(cm, rev, persistent, immediate, ignoreQuery) {
@@ -362,6 +361,11 @@ export default function(CodeMirror) {
     cm.setSelection(cursor.from(), cursor.to());
     cm.scrollIntoView({from: cursor.from(), to: cursor.to()}, 60);
     state.posFrom = cursor.from(); state.posTo = cursor.to();
+    var num_match = cm.state.search.annotate.matches.length;
+    var next = cm.state.search.annotate.matches
+      .findIndex(s => s.from.ch === cursor.from().ch && s.from.line === cursor.from().line) + 1;
+    var text_match = next + '/' + num_match;
+    cm.display.wrapper.querySelector('.CodeMirror-search-results').innerText = text_match;
     if (callback) callback(cursor.from(), cursor.to())
   });}
 


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Show the count of search elements found #936`