### PR TITLE
Update homebrew install instructions for MongoDB

### DIFF
--- a/developer_docs/installation.md
+++ b/developer_docs/installation.md
@@ -21,7 +21,7 @@ _Note_: The installation steps assume you are using a Unix-like shell. If you ar
    $ npm install
    ```
 5. Install MongoDB and make sure it is running
-   * For Mac OSX with [homebrew](http://brew.sh/): `brew install mongodb` then `brew services start mongodb`
+   * For Mac OSX with [homebrew](http://brew.sh/): [MongoDB Installation](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/#using-mongodb-from-homebrew-and-macports)
    * For Windows and Linux: [MongoDB Installation](https://docs.mongodb.com/manual/installation/)
 6. `$ cp .env.example .env`
 7. (Optional) Update `.env` with necessary keys to enable certain app behavoirs, i.e. add Github ID and Github Secret if you want to be able to log in with Github.


### PR DESCRIPTION
The install process for MongoDB via homebrew has changed and these docs no longer work. Seems best for now to link to the official docs instead which provide more detailed instructions on the new, multi-step install process.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`