### PR TITLE
fixes #963: fixes bug in which files/folders would get added to

### DIFF
--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -41,14 +41,7 @@ export function updateFileContent(id, content) {
 export function createFile(formProps) {
   return (dispatch, getState) => {
     const state = getState();
-    const selectedFile = state.files.find(file => file.isSelectedFile);
-    const rootFile = state.files.find(file => file.name === 'root');
-    let parentId;
-    if (selectedFile.fileType === 'folder') {
-      parentId = selectedFile.id;
-    } else {
-      parentId = rootFile.id;
-    }
+    const { parentId } = state.ide;
     if (state.project.id) {
       const postParams = {
         name: createUniqueName(formProps.name, parentId, state.files),
@@ -99,14 +92,7 @@ export function createFile(formProps) {
 export function createFolder(formProps) {
   return (dispatch, getState) => {
     const state = getState();
-    const selectedFile = state.files.find(file => file.isSelectedFile);
-    const rootFile = state.files.find(file => file.name === 'root');
-    let parentId;
-    if (selectedFile.fileType === 'folder') {
-      parentId = selectedFile.id;
-    } else {
-      parentId = rootFile.id;
-    }
+    const { parentId } = state.ide;
     if (state.project.id) {
       const postParams = {
         name: createUniqueName(formProps.name, parentId, state.files),

--- a/client/modules/IDE/actions/ide.js
+++ b/client/modules/IDE/actions/ide.js
@@ -62,9 +62,10 @@ export function resetSelectedFile(previousId) {
   };
 }
 
-export function newFile() {
+export function newFile(parentId) {
   return {
-    type: ActionTypes.SHOW_MODAL
+    type: ActionTypes.SHOW_MODAL,
+    parentId
   };
 }
 
@@ -122,9 +123,10 @@ export function closeProjectOptions() {
   };
 }
 
-export function newFolder() {
+export function newFolder(parentId) {
   return {
-    type: ActionTypes.SHOW_NEW_FOLDER_MODAL
+    type: ActionTypes.SHOW_NEW_FOLDER_MODAL,
+    parentId
   };
 }
 

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -188,7 +188,7 @@ export class FileNode extends React.Component {
                             <button
                               aria-label="add file"
                               onClick={() => {
-                                this.props.newFile();
+                                this.props.newFile(this.props.id);
                                 setTimeout(() => this.hideFileOptions(), 0);
                               }}
                               onBlur={this.onBlurComponent}
@@ -208,7 +208,7 @@ export class FileNode extends React.Component {
                             <button
                               aria-label="add folder"
                               onClick={() => {
-                                this.props.newFolder();
+                                this.props.newFolder(this.props.id);
                                 setTimeout(() => this.hideFileOptions(), 0);
                               }}
                               onBlur={this.onBlurComponent}

--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -66,6 +66,7 @@ class Sidebar extends React.Component {
       'sidebar--project-options': this.props.projectOptionsVisible,
       'sidebar--cant-edit': !canEditProject
     });
+    const rootFile = this.props.files.filter(file => file.name === 'root')[0];
 
     return (
       <nav className={sidebarClass} title="file-navigation" >
@@ -90,7 +91,7 @@ class Sidebar extends React.Component {
                 <button
                   aria-label="add folder"
                   onClick={() => {
-                    this.props.newFolder();
+                    this.props.newFolder(rootFile.id);
                     setTimeout(this.props.closeProjectOptions, 0);
                   }}
                   onBlur={this.onBlurComponent}
@@ -103,7 +104,7 @@ class Sidebar extends React.Component {
                 <button
                   aria-label="add file"
                   onClick={() => {
-                    this.props.newFile();
+                    this.props.newFile(rootFile.id);
                     setTimeout(this.props.closeProjectOptions, 0);
                   }}
                   onBlur={this.onBlurComponent}
@@ -116,7 +117,7 @@ class Sidebar extends React.Component {
           </div>
         </div>
         <ConnectedFileNode
-          id={this.props.files.filter(file => file.name === 'root')[0].id}
+          id={rootFile.id}
           canEdit={canEditProject}
         />
       </nav>

--- a/client/modules/IDE/reducers/ide.js
+++ b/client/modules/IDE/reducers/ide.js
@@ -24,6 +24,7 @@ const initialState = {
   previousPath: '/',
   errorType: undefined,
   runtimeErrorWarningVisible: true,
+  parentId: undefined
 };
 
 const ide = (state = initialState, action) => {
@@ -39,7 +40,7 @@ const ide = (state = initialState, action) => {
     case ActionTypes.CONSOLE_EVENT:
       return Object.assign({}, state, { consoleEvent: action.event });
     case ActionTypes.SHOW_MODAL:
-      return Object.assign({}, state, { modalIsVisible: true });
+      return Object.assign({}, state, { modalIsVisible: true, parentId: action.parentId });
     case ActionTypes.HIDE_MODAL:
       return Object.assign({}, state, { modalIsVisible: false });
     case ActionTypes.COLLAPSE_SIDEBAR:
@@ -61,7 +62,7 @@ const ide = (state = initialState, action) => {
     case ActionTypes.CLOSE_PROJECT_OPTIONS:
       return Object.assign({}, state, { projectOptionsVisible: false });
     case ActionTypes.SHOW_NEW_FOLDER_MODAL:
-      return Object.assign({}, state, { newFolderModalVisible: true });
+      return Object.assign({}, state, { newFolderModalVisible: true, parentId: action.parentId });
     case ActionTypes.CLOSE_NEW_FOLDER_MODAL:
       return Object.assign({}, state, { newFolderModalVisible: false });
     case ActionTypes.SHOW_SHARE_MODAL:


### PR DESCRIPTION
selected file (or root), rather than the file that you opened the popover from.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`