### PR TITLE
Add content-type to assets uploaded to s3

### DIFF
--- a/client/modules/IDE/actions/uploader.js
+++ b/client/modules/IDE/actions/uploader.js
@@ -82,7 +82,7 @@ export function dropzoneSendingCallback(file, xhr, formData) {
       Object.keys(file.postData).forEach((key) => {
         formData.append(key, file.postData[key]);
       });
-      formData.append('Content-type', '');
+      formData.append('Content-type', file.type);
       formData.append('Content-length', '');
       formData.append('acl', 'public-read');
     }


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

resolves #496 
addresses #1196 

This adds the relevant `Content-Type` metadata to files uploaded to AWS. This fixes a bug introduced with p5 v0.10.2 which checks the header's content-type to determine whether an asset is a GIF.

I have tested this locally with a personal S3 bucket.

Potential issues - I think this only handles assets uploaded through the drag+drop interface. I assume that this is the only way that a user will upload a media asset but I could be wrong.