### PR TITLE
Update IDEView.jsx

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -191,6 +191,7 @@ class IDEView extends React.Component {
         <Toolbar />
         {this.props.ide.preferencesIsVisible &&
           <Overlay
+            title="Settings"
             ariaLabel="settings"
             closeOverlay={this.props.closePreferences}
           >
@@ -389,6 +390,7 @@ class IDEView extends React.Component {
         }
         { this.props.location.pathname === '/about' &&
           <Overlay
+            title="About"
             previousPath={this.props.ide.previousPath}
             ariaLabel="about"
           >
@@ -397,6 +399,7 @@ class IDEView extends React.Component {
         }
         { this.props.location.pathname === '/feedback' &&
           <Overlay
+            title="Submit Feedback"
             previousPath={this.props.ide.previousPath}
             ariaLabel="submit-feedback"
           >
@@ -405,6 +408,7 @@ class IDEView extends React.Component {
         }
         { this.props.ide.shareModalVisible &&
           <Overlay
+            title="Share"
             ariaLabel="share"
             closeOverlay={this.props.closeShareModal}
           >
@@ -417,6 +421,7 @@ class IDEView extends React.Component {
         }
         { this.props.ide.keyboardShortcutVisible &&
           <Overlay
+            title="Keyboard Shortcuts"
             ariaLabel="keyboard shortcuts"
             closeOverlay={this.props.closeKeyboardShortcutModal}
           >
@@ -425,6 +430,7 @@ class IDEView extends React.Component {
         }
         { this.props.ide.errorType &&
           <Overlay
+            title="Error"
             ariaLabel="error"
             closeOverlay={this.props.hideErrorModal}
           >


### PR DESCRIPTION
`<Overlay...` has a default `title` of `'Modal'`
https://github.com/processing/p5.js-web-editor/blob/master/client/modules/App/components/Overlay.jsx#L102

many modals are missing a title, so i added some. i made them basically the same as the `ariaLabel` (but capitalized, changed `-` to ` `, etc)