### PR TITLE
Fix p5 console being cleared on pause

### DIFF
--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -334,10 +334,10 @@ class PreviewFrame extends React.Component {
   }
 
   renderSketch() {
-    this.props.clearConsole();
     const doc = this.iframeElement;
     const localFiles = this.injectLocalFiles();
     if (this.props.isPlaying) {
+      this.props.clearConsole();
       srcDoc.set(doc, localFiles);
       if (this.props.endSketchRefresh) {
         this.props.endSketchRefresh();


### PR DESCRIPTION
Fixes #1231
The p5 console was being cleared on pause
not allowing a user to view what was outputed
on the last run.  To fix clearConsole function
is now only called if playing. 


I have verified that this pull request:

* [ x] has no linting errors (`npm run lint`)
* [ x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ x] is descriptively named and links to an issue number, i.e. `Fixes #123`