### PR TITLE
Fixes Issue#1246, Second Command + F in find modal does not highlight text as expected

### DIFF
--- a/client/utils/codemirror-search.js
+++ b/client/utils/codemirror-search.js
@@ -143,6 +143,7 @@ export default function(CodeMirror) {
       }
     } else {
       searchField.focus();
+      searchField.select();
     }
   }
 


### PR DESCRIPTION
I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`