### PR TITLE
Adds lang="en" to all `<html>` instances

### DIFF
--- a/client/modules/IDE/reducers/files.js
+++ b/client/modules/IDE/reducers/files.js
@@ -11,7 +11,7 @@ function draw() {
 
 const defaultHTML =
 `<!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.10.2/p5.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.10.2/addons/p5.sound.min.js"></script>

--- a/server/scripts/examples-gg-latest.js
+++ b/server/scripts/examples-gg-latest.js
@@ -19,7 +19,7 @@ const clientSecret = process.env.GITHUB_SECRET;
 
 const defaultHTML =
   `<!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/p5.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.7.3/addons/p5.dom.min.js"></script>

--- a/server/scripts/examples.js
+++ b/server/scripts/examples.js
@@ -9,7 +9,7 @@ import Project from '../models/project';
 
 const defaultHTML =
 `<!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.10.2/p5.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/0.10.2/addons/p5.sound.min.js"></script>

--- a/server/views/404Page.js
+++ b/server/views/404Page.js
@@ -127,7 +127,7 @@ export function get404Sketch(callback) {
       });
     } else {
       callback(insertErrorMessage(`<!DOCTYPE html>
-        <html>
+        <html lang="en">
           <head>
             <meta charset="utf-8" />
           </head>

--- a/server/views/index.js
+++ b/server/views/index.js
@@ -2,7 +2,7 @@ export function renderIndex() {
   const assetsManifest = process.env.webpackAssets && JSON.parse(process.env.webpackAssets);
   return `
   <!DOCTYPE html>
-  <html>
+  <html lang="en">
     <head>
       <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`