### PR TITLE
Fix add file modal not closing after creating a file

### DIFF
--- a/client/modules/IDE/components/NewFileForm.jsx
+++ b/client/modules/IDE/components/NewFileForm.jsx
@@ -18,8 +18,8 @@ class NewFileForm extends React.Component {
       <form
         className="new-file-form"
         onSubmit={(data) => {
-          this.props.focusOnModal();
           handleSubmit(this.createFile)(data);
+          this.props.closeModal();
         }}
       >
         <label className="new-file-form__name-label" htmlFor="name">Name:</label>
@@ -44,7 +44,8 @@ NewFileForm.propTypes = {
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   createFile: PropTypes.func.isRequired,
-  focusOnModal: PropTypes.func.isRequired
+  focusOnModal: PropTypes.func.isRequired,
+  closeModal: PropTypes.func.isRequired
 };
 
 export default NewFileForm;


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Fixes #1227