### PR TITLE
Fix contrast theme active button issue

### DIFF
--- a/client/styles/abstracts/_variables.scss
+++ b/client/styles/abstracts/_variables.scss
@@ -135,7 +135,7 @@ $themes: (
     toolbar-button-color: #333333,
     toolbar-button-background-color: #C1C1C1,
     button-background-hover-color: $yellow,
-    button-background-active-color: #f10046,
+    button-background-active-color: $yellow,
     button-nav-inactive-color: #a0a0a0,
     button-hover-color: #333333,
     button-active-color: #333333,


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Fixes #1296 