### PR TITLE
Added Open Example Shortcut

### DIFF
--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -335,7 +335,7 @@ class Nav extends React.PureComponent {
                   onBlur={this.handleBlur}
                   onClick={this.setDropdownForNone}
                 >
-                  Examples
+                  Examples <span className="nav__keyboard-shortcut">{metaKeyName}+e</span>
                 </Link>
               </li> }
             </ul>

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -156,6 +156,9 @@ class IDEView extends React.Component {
     } else if (e.keyCode === 49 && ((e.metaKey && this.isMac) || (e.ctrlKey && !this.isMac)) && e.shiftKey) {
       e.preventDefault();
       this.props.setAllAccessibleOutput(true);
+    } else if (e.keyCode === 69 && ((e.metaKey && this.isMac) || (e.ctrlKey && !this.isMac))) {
+      e.preventDefault();
+      this.props.router.push('/p5/sketches');
     }
   }
 
@@ -567,7 +570,8 @@ IDEView.propTypes = {
   }).isRequired,
   autosaveProject: PropTypes.func.isRequired,
   router: PropTypes.shape({
-    setRouteLeaveHook: PropTypes.func
+    setRouteLeaveHook: PropTypes.func,
+    push: PropTypes.func.isRequired
   }).isRequired,
   route: PropTypes.oneOfType([PropTypes.object, PropTypes.element]).isRequired,
   setUnsavedChanges: PropTypes.func.isRequired,


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Fixes #1300 

Note:- Its only for open example modal, didn't create to toggle example modal feature because in most cases for these thing I found only open modal shortcuts that's why created that feature only. If you recommend to extend this to make it toggle, I can add that too. Waiting for you suggestion on this @catarak 