### PR TITLE
Added File/Folder Name length limit

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -160,6 +160,7 @@ export class FileNode extends React.Component {
                   type="text"
                   className="sidebar__file-item-input"
                   value={this.props.name}
+                  maxLength="128"
                   onChange={this.handleFileNameChange}
                   ref={(element) => { this.fileNameInput = element; }}
                   onBlur={() => {

--- a/client/modules/IDE/components/NewFileForm.jsx
+++ b/client/modules/IDE/components/NewFileForm.jsx
@@ -26,6 +26,7 @@ class NewFileForm extends React.Component {
         <input
           className="new-file-form__name-input"
           id="name"
+          maxLength="128"
           type="text"
           placeholder="Name"
           {...domOnlyProps(name)}

--- a/client/modules/IDE/components/NewFolderForm.jsx
+++ b/client/modules/IDE/components/NewFolderForm.jsx
@@ -29,6 +29,7 @@ class NewFolderForm extends React.Component {
         <input
           className="new-folder-form__name-input"
           id="name"
+          maxLength="128"
           type="text"
           placeholder="Name"
           ref={(element) => { this.fileName = element; }}


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Fixes #1311 
I used 128 length limit because in issue #1131 @catarak suggest this and we already have project name length limit. So maintaining the consistency I also used this. 