### PR TITLE
fix(file.controller.js): set headers for file extensions from MIME -I1218

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13939,16 +13939,16 @@
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="
     },
     "mime-db": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+      "integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
     },
     "mime-types": {
-      "version": "2.1.24",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "version": "2.1.26",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+      "integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
       "requires": {
-        "mime-db": "1.40.0"
+        "mime-db": "1.43.0"
       }
     },
     "mimer": {

--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
     "jshint": "^2.11.0",
     "lodash": "^4.17.15",
     "loop-protect": "github:catarak/loop-protect",
+    "mime-types": "^2.1.26",
     "mjml": "^3.3.2",
     "mockingoose": "^2.13.2",
     "mongoose": "^5.9.2",

--- a/server/controllers/file.controller.js
+++ b/server/controllers/file.controller.js
@@ -1,4 +1,5 @@
 import each from 'async/each';
+import mime from 'mime-types';
 import isBefore from 'date-fns/is_before';
 import Project from '../models/project';
 import { resolvePathToFile } from '../utils/filePath';
@@ -120,6 +121,8 @@ export function getFileContent(req, res) {
       res.status(404).send({ success: false, message: 'File with that name and path does not exist.' });
       return;
     }
+    const contentType = mime.lookup(resolvedFile);
+    res.set('Content-Type', contentType);
     res.send(resolvedFile.content);
   });
 }

--- a/server/controllers/file.controller.js
+++ b/server/controllers/file.controller.js
@@ -121,7 +121,7 @@ export function getFileContent(req, res) {
       res.status(404).send({ success: false, message: 'File with that name and path does not exist.' });
       return;
     }
-    const contentType = mime.lookup(resolvedFile);
+    const contentType = mime.lookup(resolvedFile.name) || 'application/octet-stream';
     res.set('Content-Type', contentType);
     res.send(resolvedFile.content);
   });


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Fixes #1218 

- Adds [mime-types](https://www.npmjs.com/package/mime-types) as a dependency to check for the file's MIME and then set an appropriate header.