### PR TITLE
Fix broken link in developer docs

### DIFF
--- a/developer_docs/README.md
+++ b/developer_docs/README.md
@@ -1,7 +1,7 @@
 This folder contains documents intended for developers of the p5.js Web Editor. 
 
 ## List of Documents
-* [Getting Started](getting_started.md) - A place to get started!
+* [Contribution Guide](https://github.com/processing/p5.js-web-editor/blob/master/.github/CONTRIBUTING.md) - A place to get started!
 * [Installation](installation.md) - A guide for setting up your development environment
 * [Development](development.md) - A guide for adding code to the web editor
 * [Preparing a pull-request](preparing_a_pull_request.md) - Instructions for how to make a pull-request


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`