### PR TITLE
Add responsive width to collection metadata

### DIFF
--- a/client/styles/components/_collection.scss
+++ b/client/styles/components/_collection.scss
@@ -8,7 +8,8 @@
 }
 
 .collection-metadata {
-  width: #{1012 / $base-font-size}rem;
+  max-width: #{1012 / $base-font-size}rem;
+  width: 100%;
   margin: 0 auto;
   margin-bottom: #{24 / $base-font-size}rem;
 }


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`