### PR TITLE
Fixes #1361 - upload option missing for folder

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -185,40 +185,50 @@ export class FileNode extends React.Component {
                     {(() => { // eslint-disable-line
                       if (this.props.fileType === 'folder') {
                         return (
-                          <li>
-                            <button
-                              aria-label="add file"
-                              onClick={() => {
-                                this.props.newFile(this.props.id);
-                                setTimeout(() => this.hideFileOptions(), 0);
-                              }}
-                              onBlur={this.onBlurComponent}
-                              onFocus={this.onFocusComponent}
-                              className="sidebar__file-item-option"
-                            >
-                              Add File
-                            </button>
-                          </li>
-                        );
-                      }
-                    })()}
-                    {(() => { // eslint-disable-line
-                      if (this.props.fileType === 'folder') {
-                        return (
-                          <li>
-                            <button
-                              aria-label="add folder"
-                              onClick={() => {
-                                this.props.newFolder(this.props.id);
-                                setTimeout(() => this.hideFileOptions(), 0);
-                              }}
-                              onBlur={this.onBlurComponent}
-                              onFocus={this.onFocusComponent}
-                              className="sidebar__file-item-option"
-                            >
-                              Add Folder
-                            </button>
-                          </li>
+                          <React.Fragment>
+                            <li>
+                              <button
+                                aria-label="add folder"
+                                onClick={() => {
+                                  this.props.newFolder(this.props.id);
+                                  setTimeout(this.hideFileOptions, 0);
+                                }}
+                                onBlur={this.onBlurComponent}
+                                onFocus={this.onFocusComponent}
+                                className="sidebar__file-item-option"
+                              >
+                                Create folder
+                              </button>
+                            </li>
+                            <li>
+                              <button
+                                aria-label="add file"
+                                onClick={() => {
+                                  this.props.newFile(this.props.id);
+                                  setTimeout(this.hideFileOptions, 0);
+                                }}
+                                onBlur={this.onBlurComponent}
+                                onFocus={this.onFocusComponent}
+                                className="sidebar__file-item-option"
+                              >
+                                Create file
+                              </button>
+                            </li>
+                            <li>
+                              <button
+                                aria-label="upload file"
+                                onClick={() => {
+                                  this.props.openUploadFileModal(this.props.id);
+                                  setTimeout(this.hideFileOptions, 0);
+                                }}
+                                onBlur={this.onBlurComponent}
+                                onFocus={this.onFocusComponent}
+                              >
+                                Upload file
+                              </button>
+                            </li>
+
+                          </React.Fragment>
                         );
                       }
                     })()}
@@ -289,7 +299,8 @@ FileNode.propTypes = {
   newFolder: PropTypes.func.isRequired,
   showFolderChildren: PropTypes.func.isRequired,
   hideFolderChildren: PropTypes.func.isRequired,
-  canEdit: PropTypes.bool.isRequired
+  canEdit: PropTypes.bool.isRequired,
+  openUploadFileModal: PropTypes.func.isRequired
 };
 
 FileNode.defaultProps = {


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`