### PR TITLE
Add frane to code editor when selected folder or media file

### DIFF
--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -1,7 +1,4 @@
 .CodeMirror {
-  @include themify() {
-  	border: 1px solid getThemifyVariable('ide-border-color');
-  }
   font-family: Inconsolata, monospace;
   height: 100%;
 }
@@ -328,7 +325,10 @@ pre.CodeMirror-line {
   height: calc(100% - #{29 / $base-font-size}rem);
   width: 100%;
   position: absolute;
-  &.editor-holder--hidden {
+  @include themify() {
+    border: 1px solid getThemifyVariable('ide-border-color');
+  }
+  &.editor-holder--hidden .CodeMirror {
     display: none;
   }
 }


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`