### PR TITLE
Always allow localhost CORS requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ API_URL=/editor
 AWS_ACCESS_KEY=<your-aws-access-key>
 AWS_REGION=<your-aws-region>
 AWS_SECRET_KEY=<your-aws-secret-key>
+CORS_ALLOW_LOCALHOST=true
 EMAIL_SENDER=<transactional-email-sender>
 EMAIL_VERIFY_SECRET_TOKEN=whatever_you_want_this_to_be_it_only_matters_for_production
 EXAMPLE_USER_EMAIL=examples@p5js.org

--- a/server/server.js
+++ b/server/server.js
@@ -46,8 +46,9 @@ if (process.env.BASIC_USERNAME && process.env.BASIC_PASSWORD) {
   }));
 }
 
-const corsOriginsWhitelist = [
+const allowedCorsOrigins = [
   /p5js\.org$/,
+  /localhost/ // to allow client-only development
 ];
 
 // Run Webpack dev server in development mode
@@ -55,8 +56,6 @@ if (process.env.NODE_ENV === 'development') {
   const compiler = webpack(config);
   app.use(webpackDevMiddleware(compiler, { noInfo: true, publicPath: config.output.publicPath }));
   app.use(webpackHotMiddleware(compiler));
-
-  corsOriginsWhitelist.push(/localhost/);
 }
 
 const mongoConnectionString = process.env.MONGO_URL;
@@ -65,7 +64,7 @@ app.set('trust proxy', true);
 // Enable Cross-Origin Resource Sharing (CORS) for all origins
 const corsMiddleware = cors({
   credentials: true,
-  origin: corsOriginsWhitelist,
+  origin: allowedCorsOrigins,
 });
 app.use(corsMiddleware);
 // Enable pre-flight OPTIONS route for all end-points

--- a/server/server.js
+++ b/server/server.js
@@ -48,8 +48,12 @@ if (process.env.BASIC_USERNAME && process.env.BASIC_PASSWORD) {
 
 const allowedCorsOrigins = [
   /p5js\.org$/,
-  /localhost/ // to allow client-only development
 ];
+
+// to allow client-only development
+if (process.env.CORS_ALLOW_LOCALHOST === 'true') {
+  allowedCorsOrigins.push(/localhost/);
+}
 
 // Run Webpack dev server in development mode
 if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
In order to allow developers to run only the client app code on their machines (see #1348), they need to be able to send requests from the app running on `localhost` to a remote instance of the Editor API.

Our CORS restrictions currently prohibit `localhost` in production so this PR removes that restriction.

I've thought about the security implications of this, and I think it's OK as the API will still require a user to be authenticated before doing anything.

It _might_ be an idea to parallel deploy to a staging server i.e. `staging.editor.p5js.org` and only allow localhost CORS there to protect developers from accidentally doing anything weird. We'd also probably want a copy of mongo too?

--

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)