### PR TITLE
Enhancement(Esc key hide modal)

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -170,6 +170,14 @@ class IDEView extends React.Component {
       } else {
         this.props.expandConsole();
       }
+    } else if (e.keyCode === 27) {
+      if (this.props.ide.newFolderModalVisible) {
+        this.props.closeNewFolderModal();
+      } else if (this.props.ide.uploadFileModalVisible) {
+        this.props.closeUploadFileModal();
+      } else if (this.props.ide.modalIsVisible) {
+        this.props.closeNewFileModal();
+      }
     }
   }
 
@@ -562,6 +570,7 @@ IDEView.propTypes = {
   closeProjectOptions: PropTypes.func.isRequired,
   newFolder: PropTypes.func.isRequired,
   closeNewFolderModal: PropTypes.func.isRequired,
+  closeNewFileModal: PropTypes.func.isRequired,
   createFolder: PropTypes.func.isRequired,
   closeShareModal: PropTypes.func.isRequired,
   showEditorOptions: PropTypes.func.isRequired,


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Fixes #1312 

I have 2 solution for this enhancement, 
1. add keylistener in every component (File/Folder) and then trigger close modal from those component
2. add global listener for ESC key and close modal from there

I have taken the 2nd approach, as the first looks to add redundant code in all component.
@catarak have a look and suggest changes if any :)