### PR TITLE
Fix(overflow option over sticky head issue)

### DIFF
--- a/client/styles/components/_sketch-list.scss
+++ b/client/styles/components/_sketch-list.scss
@@ -19,6 +19,7 @@
   height: #{32 / $base-font-size}rem;
   position: sticky;
   top: 0;
+  z-index: 1;
   @include themify() {
     background-color: getThemifyVariable('background-color');
   }


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

actually its a very small issue so don't want to create a new issue

Issue
In the Example table, the last option has a button that has an arrow-down icon which is scrolling over the header i.e. not obeying the normal behavior which the others are following.
![OptionScrolled](https://user-images.githubusercontent.com/30585570/80832233-e141c680-8c09-11ea-9fd1-c03168359f75.gif)
