### PR TITLE
Allow collection/sketch list modal to scroll if taller than screen (Fixes #1412)

### DIFF
--- a/client/styles/components/_quick-add.scss
+++ b/client/styles/components/_quick-add.scss
@@ -1,5 +1,6 @@
 .quick-add-wrapper {
   min-width: #{600 / $base-font-size}rem;
+  overflow-y: scroll;
 }
 
 .quick-add {


### PR DESCRIPTION
Allows collection list modal to scroll when it overflows (fixes #1412)

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`