### PR TITLE
Fix bug when switching collection or sketch lists  (fixes #1401)

### DIFF
--- a/client/modules/IDE/components/SketchList.jsx
+++ b/client/modules/IDE/components/SketchList.jsx
@@ -333,8 +333,9 @@ class SketchList extends React.Component {
     };
   }
 
-  componentWillReceiveProps(nextProps) {
-    if (this.props.sketches !== nextProps.sketches && Array.isArray(nextProps.sketches)) {
+  componentDidUpdate(prevProps) {
+    if (this.props.sketches !== prevProps.sketches && Array.isArray(this.props.sketches)) {
+      // eslint-disable-next-line react/no-did-update-set-state
       this.setState({
         isInitialDataLoad: false,
       });

--- a/client/modules/User/pages/DashboardView.jsx
+++ b/client/modules/User/pages/DashboardView.jsx
@@ -98,12 +98,12 @@ class DashboardView extends React.Component {
   renderContent(tabKey, username) {
     switch (tabKey) {
       case TabKey.assets:
-        return <AssetList username={username} />;
+        return <AssetList key={username} username={username} />;
       case TabKey.collections:
-        return <CollectionList username={username} />;
+        return <CollectionList key={username} username={username} />;
       case TabKey.sketches:
       default:
-        return <SketchList username={username} />;
+        return <SketchList key={username} username={username} />;
     }
   }
 


### PR DESCRIPTION
Fixes #1401 using the username as the key prop. This causes the List component to remount when the username changes. This is simpler than tracking username changes in the list components and has the bonus of also resetting the loading animation.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`