### PR TITLE
RE #1421 - Fix bug pointing to wrong dockerhub url in deployment script

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -20,4 +20,4 @@ gcloud --quiet container clusters get-credentials $CLUSTER_NAME_PRD
 kubectl config view
 kubectl config current-context
 
-kubectl set image deployment/${KUBE_DEPLOYMENT_NAME} ${KUBE_DEPLOYMENT_CONTAINER_NAME}=index.docker.io/$DOCKER_USERNAME/$DOCKER_REPOSITORY:$TRAVIS_COMMIT
+kubectl set image deployment/${KUBE_DEPLOYMENT_NAME} ${KUBE_DEPLOYMENT_CONTAINER_NAME}=index.docker.io/$DOCKER_USERNAME/$DOCKER_REPOSITORY:$TRAVIS_TAG


### PR DESCRIPTION
I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`