### PR TITLE
Fixes #1425 - Removes sketch title from <title> for unsaved, new sketch

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -123,6 +123,11 @@ class IDEView extends React.Component {
     this.autosaveInterval = null;
   }
 
+  getTitle = () => {
+    const { id } = this.props.project;
+    return id ? `p5.js Web Editor | ${this.props.project.name}` : 'p5.js Web Editor';
+  }
+
   isUserOwner() {
     return this.props.project.owner && this.props.project.owner.id === this.props.user.id;
   }
@@ -203,7 +208,7 @@ class IDEView extends React.Component {
     return (
       <div className="ide">
         <Helmet>
-          <title>p5.js Web Editor | {this.props.project.name}</title>
+          <title>{this.getTitle()}</title>
         </Helmet>
         {this.props.toast.isVisible && <Toast />}
         <Nav


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`