### PR TITLE
Fixed a bug that appears on preview due to short file name

### DIFF
--- a/client/utils/consoleUtils.js
+++ b/client/utils/consoleUtils.js
@@ -60,7 +60,7 @@ export const getAllScriptOffsets = (htmlFile) => {
     if (ind === -1) {
       foundJSScript = false;
     } else {
-      endFilenameInd = htmlFile.indexOf('.js', ind + startTag.length + 3);
+      endFilenameInd = htmlFile.indexOf('.js', ind + startTag.length + 1);
       filename = htmlFile.substring(ind + startTag.length, endFilenameInd);
       lineOffset = htmlFile.substring(0, ind).split('\n').length + hijackConsoleErrorsScriptLength;
       offs.push([lineOffset, filename]);


### PR DESCRIPTION
Fixed a bug that appears on preview when a .js files has a 2 or less name length

Fixes #1413
https://github.com/processing/p5.js-web-editor/issues/1413

I have verified that this pull request:

* [x ] has no linting errors (`npm run lint`)
* [ ] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too). **I had some issues with this**
* [x ] is descriptively named and links to an issue number, i.e. `Fixes #123`