### PR TITLE
Create Mobile Editor Endpoint

### DIFF
--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -22,7 +22,7 @@ const Screen = ({ children }) => (
   </div>
 );
 Screen.propTypes = {
-  children: PropTypes.element.isRequired
+  children: PropTypes.node.isRequired
 };
 
 export default () => (

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Link } from 'react-router';
 
-import Editor from '../components/Editor';
 import { prop, remSize } from '../../../theme';
 
 const background = prop('Button.default.background');
@@ -41,7 +40,7 @@ export default () => (
 
     <h3>
       <br />This page is under construction.
-      <br /><a href="/">Click here</a> to return to the regular editor
+      <br /><Link to="/">Click here</Link> to return to the regular editor
     </h3>
 
     <Footer><h1>Bottom Bar</h1></Footer>

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -1,5 +1,33 @@
 import React from 'react';
+import PropTypes from 'prop-types';
+import styled from 'styled-components';
 
-export default () => (<div>
-  <h1>Test</h1>
-</div>); //eslint-disable-line
+const Header = styled.div`
+  width: 100%;
+  color: orange;
+  background: red;
+`;
+
+const Footer = styled.div`
+  width: 100%;
+  color: orange;
+  background: blue;
+  position: absolute;
+  bottom: 0;
+`;
+
+const Screen = ({ children }) => (
+  <div className="fullscreen-preview">
+    {children}
+  </div>
+);
+Screen.propTypes = {
+  children: PropTypes.element.isRequired
+};
+
+export default () => (
+  <Screen>
+    <Header><h1>Test</h1></Header>
+    <Footer><h1>Actionbar</h1></Footer>
+  </Screen>
+);

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -1,19 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { prop, remSize } from '../../../theme';
+
+const background = prop('Button.default.background');
+const textColor = prop('primaryTextColor');
 
 const Header = styled.div`
   width: 100%;
-  color: orange;
-  background: red;
+  background-color: ${background} !important;
+  color: ${textColor};
+  padding-left: ${remSize(32)};
 `;
 
 const Footer = styled.div`
   width: 100%;
-  color: orange;
-  background: blue;
   position: absolute;
   bottom: 0;
+  background: ${background};
+  color: ${textColor};
+  padding-left: ${remSize(32)};
 `;
 
 const Screen = ({ children }) => (
@@ -27,7 +33,11 @@ Screen.propTypes = {
 
 export default () => (
   <Screen>
-    <Header><h1>Test</h1></Header>
-    <Footer><h1>Actionbar</h1></Footer>
+    <Header><h1>Mobile View</h1></Header>
+    <h3>
+      <br />This page is under construction.
+      <br /><a href="/?ignoremobile" >Click here</a> to return to the regular editor
+    </h3>
+    <Footer><h1>Bottom Bar</h1></Footer>
   </Screen>
 );

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
+import { Link } from 'react-router';
+
+import Editor from '../components/Editor';
 import { prop, remSize } from '../../../theme';
 
 const background = prop('Button.default.background');
@@ -34,10 +37,13 @@ Screen.propTypes = {
 export default () => (
   <Screen>
     <Header><h1>Mobile View</h1></Header>
+
+
     <h3>
       <br />This page is under construction.
-      <br /><a href="/?ignoremobile" >Click here</a> to return to the regular editor
+      <br /><a href="/">Click here</a> to return to the regular editor
     </h3>
+
     <Footer><h1>Bottom Bar</h1></Footer>
   </Screen>
 );

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default () => (<div>
+  <h1>Test</h1>
+</div>); //eslint-disable-line

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -10,7 +10,7 @@ const textColor = prop('primaryTextColor');
 
 const Header = styled.div`
   width: 100%;
-  background-color: ${background} !important;
+  background-color: ${background};
   color: ${textColor};
   padding-left: ${remSize(32)};
 `;

--- a/client/routes.jsx
+++ b/client/routes.jsx
@@ -2,6 +2,7 @@ import { Route, IndexRoute } from 'react-router';
 import React from 'react';
 import App from './modules/App/App';
 import IDEView from './modules/IDE/pages/IDEView';
+import IDEViewMobile from './modules/IDE/pages/IDEViewMobile';
 import FullView from './modules/IDE/pages/FullView';
 import LoginView from './modules/User/pages/LoginView';
 import SignupView from './modules/User/pages/SignupView';
@@ -24,9 +25,11 @@ const onRouteChange = (store) => {
   store.dispatch(stopSketch());
 };
 
+const isMobile = () => window.innerWidth <= 760;
+
 const routes = store => (
   <Route path="/" component={App} onChange={() => { onRouteChange(store); }}>
-    <IndexRoute component={IDEView} onEnter={checkAuth(store)} />
+    <IndexRoute component={isMobile() ? IDEViewMobile : IDEView} onEnter={checkAuth(store)} />
     <Route path="/login" component={userIsNotAuthenticated(LoginView)} />
     <Route path="/signup" component={userIsNotAuthenticated(SignupView)} />
     <Route path="/reset-password" component={userIsNotAuthenticated(ResetPasswordView)} />
@@ -49,6 +52,7 @@ const routes = store => (
     <Route path="/:username/collections/create" component={DashboardView} />
     <Route path="/:username/collections/:collection_id" component={CollectionView} />
     <Route path="/about" component={IDEView} />
+
   </Route>
 );
 

--- a/client/routes.jsx
+++ b/client/routes.jsx
@@ -25,12 +25,6 @@ const onRouteChange = (store) => {
   store.dispatch(stopSketch());
 };
 
-// TODO: Investigate using react-router for this switch
-// const ignoreMobile = () => window.location.search.substring(1).includes('ignoremobile');
-// const isMobile = () => window.innerWidth <= 760;
-// const IDEView = isMobile() && !ignoreMobile() ? IDEViewMobileScreen : IDEViewScreen;
-
-// How to use URL as a prop?
 const routes = store => (
   <Route path="/" component={App} onChange={() => { onRouteChange(store); }}>
     <IndexRoute component={IDEView} onEnter={checkAuth(store)} />

--- a/client/routes.jsx
+++ b/client/routes.jsx
@@ -1,8 +1,8 @@
 import { Route, IndexRoute } from 'react-router';
 import React from 'react';
 import App from './modules/App/App';
-import IDEView from './modules/IDE/pages/IDEView';
-import IDEViewMobile from './modules/IDE/pages/IDEViewMobile';
+import IDEViewScreen from './modules/IDE/pages/IDEView';
+import IDEViewMobileScreen from './modules/IDE/pages/IDEViewMobile';
 import FullView from './modules/IDE/pages/FullView';
 import LoginView from './modules/User/pages/LoginView';
 import SignupView from './modules/User/pages/SignupView';
@@ -26,10 +26,11 @@ const onRouteChange = (store) => {
 };
 
 const isMobile = () => window.innerWidth <= 760;
+const IDEView = isMobile() ? IDEViewMobileScreen : IDEViewScreen;
 
 const routes = store => (
   <Route path="/" component={App} onChange={() => { onRouteChange(store); }}>
-    <IndexRoute component={isMobile() ? IDEViewMobile : IDEView} onEnter={checkAuth(store)} />
+    <IndexRoute component={IDEView} onEnter={checkAuth(store)} />
     <Route path="/login" component={userIsNotAuthenticated(LoginView)} />
     <Route path="/signup" component={userIsNotAuthenticated(SignupView)} />
     <Route path="/reset-password" component={userIsNotAuthenticated(ResetPasswordView)} />

--- a/client/routes.jsx
+++ b/client/routes.jsx
@@ -1,8 +1,8 @@
 import { Route, IndexRoute } from 'react-router';
 import React from 'react';
 import App from './modules/App/App';
-import IDEViewScreen from './modules/IDE/pages/IDEView';
-import IDEViewMobileScreen from './modules/IDE/pages/IDEViewMobile';
+import IDEView from './modules/IDE/pages/IDEView';
+import IDEViewMobile from './modules/IDE/pages/IDEViewMobile';
 import FullView from './modules/IDE/pages/FullView';
 import LoginView from './modules/User/pages/LoginView';
 import SignupView from './modules/User/pages/SignupView';
@@ -25,11 +25,12 @@ const onRouteChange = (store) => {
   store.dispatch(stopSketch());
 };
 
-const ignoreMobile = () => window.location.search.substring(1).includes('ignoremobile');
+// TODO: Investigate using react-router for this switch
+// const ignoreMobile = () => window.location.search.substring(1).includes('ignoremobile');
+// const isMobile = () => window.innerWidth <= 760;
+// const IDEView = isMobile() && !ignoreMobile() ? IDEViewMobileScreen : IDEViewScreen;
 
-const isMobile = () => window.innerWidth <= 760;
-const IDEView = isMobile() && !ignoreMobile() ? IDEViewMobileScreen : IDEViewScreen;
-
+// How to use URL as a prop?
 const routes = store => (
   <Route path="/" component={App} onChange={() => { onRouteChange(store); }}>
     <IndexRoute component={IDEView} onEnter={checkAuth(store)} />
@@ -55,6 +56,7 @@ const routes = store => (
     <Route path="/:username/collections/create" component={DashboardView} />
     <Route path="/:username/collections/:collection_id" component={CollectionView} />
     <Route path="/about" component={IDEView} />
+    <Route path="/mobile" component={IDEViewMobile} />
 
   </Route>
 );

--- a/client/routes.jsx
+++ b/client/routes.jsx
@@ -25,8 +25,10 @@ const onRouteChange = (store) => {
   store.dispatch(stopSketch());
 };
 
+const ignoreMobile = () => window.location.search.substring(1).includes('ignoremobile');
+
 const isMobile = () => window.innerWidth <= 760;
-const IDEView = isMobile() ? IDEViewMobileScreen : IDEViewScreen;
+const IDEView = isMobile() && !ignoreMobile() ? IDEViewMobileScreen : IDEViewScreen;
 
 const routes = store => (
   <Route path="/" component={App} onChange={() => { onRouteChange(store); }}>

--- a/client/theme.js
+++ b/client/theme.js
@@ -111,8 +111,11 @@ export default {
         foreground: grays.light,
         background: grays.dark,
         border: grays.middleDark,
+
       },
     },
+
+
   },
   [Theme.contrast]: {
     colors,

--- a/client/theme.js
+++ b/client/theme.js
@@ -111,11 +111,8 @@ export default {
         foreground: grays.light,
         background: grays.dark,
         border: grays.middleDark,
-
       },
     },
-
-
   },
   [Theme.contrast]: {
     colors,

--- a/server/routes/server.routes.js
+++ b/server/routes/server.routes.js
@@ -114,9 +114,11 @@ router.get('/about', (req, res) => {
   res.send(renderIndex());
 });
 
-router.get('/feedback', (req, res) => {
-  res.send(renderIndex());
-});
+if (process.env.MOBILE_ENABLED) {
+  router.get('/mobile', (req, res) => {
+    res.send(renderIndex());
+  });
+}
 
 router.get('/:username/collections/create', (req, res) => {
   userExists(req.params.username, (exists) => {

--- a/server/views/index.js
+++ b/server/views/index.js
@@ -32,6 +32,7 @@ export function renderIndex() {
         window.process.env.UI_ACCESS_TOKEN_ENABLED = ${process.env.UI_ACCESS_TOKEN_ENABLED === 'false' ? false : true};
         window.process.env.UI_COLLECTIONS_ENABLED = ${process.env.UI_COLLECTIONS_ENABLED === 'false' ? false : true};
         window.process.env.UPLOAD_LIMIT = ${process.env.UPLOAD_LIMIT ? `${process.env.UPLOAD_LIMIT}` : undefined};
+        window.process.env.MOBILE_ENABLED = ${process.env.MOBILE_ENABLED ? `${process.env.MOBILE_ENABLED}` : undefined};
       </script>
     </head>
     <body>


### PR DESCRIPTION
Part of the Mobile Web Editor project.

This PR creates a `/mobile` endpoint, rendering a new screen, which will be used for the development of the mobile web editor. This screen is enabled/disabled through the `MOBILE_ENABLED` environment variable.
Currently it's just groundwork getting done. Future PRs will implement its design and behavior.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`