### PR TITLE
Add Editor component to the Mobile IDE View

### DIFF
--- a/client/common/Icons.jsx
+++ b/client/common/Icons.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { remSize, prop } from '../theme';
 import SortArrowUp from '../images/sort-arrow-up.svg';
 import SortArrowDown from '../images/sort-arrow-down.svg';
 import Github from '../images/github.svg';
 import Google from '../images/google.svg';
 import Plus from '../images/plus-icon.svg';
 import Close from '../images/close.svg';
+import Exit from '../images/exit.svg';
 import DropdownArrow from '../images/down-filled-triangle.svg';
 
 // HOC that adds the right web accessibility props
@@ -15,16 +18,33 @@ import DropdownArrow from '../images/down-filled-triangle.svg';
 // Need to add size to these - like small icon, medium icon, large icon. etc.
 function withLabel(SvgComponent) {
   const Icon = (props) => {
+    const StyledIcon = styled(SvgComponent)`
+      &&& {
+        color: ${prop('Icon.default')};
+        & g, & path, & polygon {
+          opacity: 1;
+          fill: ${prop('Icon.default')};
+        }
+        &:hover {
+          color: ${prop('Icon.hover')};
+          & g, & path, & polygon {
+            opacity: 1;
+            fill: ${prop('Icon.hover')};
+          }
+        }
+      }
+    `;
+
     const { 'aria-label': ariaLabel } = props;
     if (ariaLabel) {
-      return (<SvgComponent
+      return (<StyledIcon
         {...props}
         aria-label={ariaLabel}
         role="img"
         focusable="false"
       />);
     }
-    return (<SvgComponent
+    return (<StyledIcon
       {...props}
       aria-hidden
       focusable="false"
@@ -48,4 +68,5 @@ export const GithubIcon = withLabel(Github);
 export const GoogleIcon = withLabel(Google);
 export const PlusIcon = withLabel(Plus);
 export const CloseIcon = withLabel(Close);
+export const ExitIcon = withLabel(Exit);
 export const DropdownArrowIcon = withLabel(DropdownArrow);

--- a/client/common/icons.jsx
+++ b/client/common/icons.jsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import styled from 'styled-components';
+import { remSize, prop } from '../theme';
 import SortArrowUp from '../images/sort-arrow-up.svg';
 import SortArrowDown from '../images/sort-arrow-down.svg';
 import Github from '../images/github.svg';
 import Google from '../images/google.svg';
 import Plus from '../images/plus-icon.svg';
 import Close from '../images/close.svg';
+import Exit from '../images/exit.svg';
 import DropdownArrow from '../images/down-filled-triangle.svg';
 
 // HOC that adds the right web accessibility props
@@ -15,16 +18,33 @@ import DropdownArrow from '../images/down-filled-triangle.svg';
 // Need to add size to these - like small icon, medium icon, large icon. etc.
 function withLabel(SvgComponent) {
   const Icon = (props) => {
+    const StyledIcon = styled(SvgComponent)`
+      &&& {
+        color: ${prop('Icon.default')};
+        & g, & path, & polygon {
+          opacity: 1;
+          fill: ${prop('Icon.default')};
+        }
+        &:hover {
+          color: ${prop('Icon.hover')};
+          & g, & path, & polygon {
+            opacity: 1;
+            fill: ${prop('Icon.hover')};
+          }
+        }
+      }
+    `;
+
     const { 'aria-label': ariaLabel } = props;
     if (ariaLabel) {
-      return (<SvgComponent
+      return (<StyledIcon
         {...props}
         aria-label={ariaLabel}
         role="img"
         focusable="false"
       />);
     }
-    return (<SvgComponent
+    return (<StyledIcon
       {...props}
       aria-hidden
       focusable="false"
@@ -48,4 +68,5 @@ export const GithubIcon = withLabel(Github);
 export const GoogleIcon = withLabel(Google);
 export const PlusIcon = withLabel(Plus);
 export const CloseIcon = withLabel(Close);
+export const ExitIcon = withLabel(Exit);
 export const DropdownArrowIcon = withLabel(DropdownArrow);

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -1,14 +1,33 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { Link } from 'react-router';
+// import { Link } from 'react-router';
+import { connect } from 'react-redux';
+import { withRouter } from 'react-router';
+import { useState } from 'react';
 
+// Imports to be Refactored
+import { bindActionCreators } from 'redux';
+import * as FileActions from '../actions/files';
+import * as IDEActions from '../actions/ide';
+import * as ProjectActions from '../actions/project';
+import * as EditorAccessibilityActions from '../actions/editorAccessibility';
+import * as PreferencesActions from '../actions/preferences';
+import * as UserActions from '../../User/actions';
+import * as ToastActions from '../actions/toast';
+import * as ConsoleActions from '../actions/console';
+import { getHTMLFile } from '../reducers/files';
+
+// Local Imports
+import Editor from '../components/Editor';
 import { prop, remSize } from '../../../theme';
+
 
 const background = prop('Button.default.background');
 const textColor = prop('primaryTextColor');
 
 const Header = styled.div`
+  position: fixed;
   width: 100%;
   background-color: ${background};
   color: ${textColor};
@@ -17,12 +36,17 @@ const Header = styled.div`
 
 const Footer = styled.div`
   width: 100%;
-  position: absolute;
+  position: fixed;
   bottom: 0;
   background: ${background};
   color: ${textColor};
   padding-left: ${remSize(32)};
 `;
+
+const Content = styled.div`
+`;
+
+const f = x => x;
 
 const Screen = ({ children }) => (
   <div className="fullscreen-preview">
@@ -33,16 +57,201 @@ Screen.propTypes = {
   children: PropTypes.node.isRequired
 };
 
-export default () => (
-  <Screen>
-    <Header><h1>Mobile View</h1></Header>
+const IDEViewMobile = (props) => {
+  // const
+  // const {
+  //   preferences, ide, editorAccessibility, project, updateLintMessage, clearLintMessage, selectedFile, updateFileContent, files, closeEditorOptions, showEditorOptions, showKeyboardShortcutModal, setUnsavedChanges, startRefreshSketch, stopSketch, expandSidebar, collapseSidebar, clearConsole, console, showRuntimeErrorWarning, hideRuntimeErrorWarning
+  // } = props;
+
+  const [tmController, setTmController] = useState(null);
+
+  return (
+    <Screen>
+      <Header><h1>Mobile View</h1></Header>
+      {/* <div>
+        { [preferences, ide, editorAccessibility, project, updateLintMessage, clearLintMessage, selectedFile, updateFileContent, files, closeEditorOptions, showEditorOptions, showKeyboardShortcutModal, setUnsavedChanges, startRefreshSketch, stopSketch, expandSidebar, collapseSidebar, clearConsole, console, showRuntimeErrorWarning, hideRuntimeErrorWarning]
+          .map(pr => <h5>{pr.toString()}</h5>) }
+      </div> */}
+
+      <Editor
+        lintWarning={props.preferences.lintWarning}
+        linewrap={props.preferences.linewrap}
+        lintMessages={props.editorAccessibility.lintMessages}
+        updateLintMessage={props.updateLintMessage}
+        clearLintMessage={props.clearLintMessage}
+        file={props.selectedFile}
+        updateFileContent={props.updateFileContent}
+        fontSize={props.preferences.fontSize}
+        lineNumbers={props.preferences.lineNumbers}
+        files={props.files}
+        editorOptionsVisible={props.ide.editorOptionsVisible}
+        showEditorOptions={props.showEditorOptions}
+        closeEditorOptions={props.closeEditorOptions}
+        showKeyboardShortcutModal={props.showKeyboardShortcutModal}
+        setUnsavedChanges={props.setUnsavedChanges}
+        isPlaying={props.ide.isPlaying}
+        theme={props.preferences.theme}
+        startRefreshSketch={props.startRefreshSketch}
+        stopSketch={props.stopSketch}
+        autorefresh={props.preferences.autorefresh}
+        unsavedChanges={props.ide.unsavedChanges}
+        projectSavedTime={props.project.updatedAt}
+        isExpanded={props.ide.sidebarIsExpanded}
+        expandSidebar={props.expandSidebar}
+        collapseSidebar={props.collapseSidebar}
+        isUserOwner={setTmController}
+        clearConsole={props.clearConsole}
+        consoleEvents={props.console}
+        showRuntimeErrorWarning={props.showRuntimeErrorWarning}
+        hideRuntimeErrorWarning={props.hideRuntimeErrorWarning}
+        runtimeErrorWarningVisible={props.ide.runtimeErrorWarningVisible}
+        provideController={setTmController}
+      />
+
+      <Footer><h1>Bottom Bar</h1></Footer>
+    </Screen>
+  );
+};
 
 
-    <h3>
-      <br />This page is under construction.
-      <br /><Link to="/">Click here</Link> to return to the regular editor
-    </h3>
+IDEViewMobile.propTypes = {
 
-    <Footer><h1>Bottom Bar</h1></Footer>
-  </Screen>
-);
+  preferences: PropTypes.shape({
+    fontSize: PropTypes.number.isRequired,
+    autosave: PropTypes.bool.isRequired,
+    linewrap: PropTypes.bool.isRequired,
+    lineNumbers: PropTypes.bool.isRequired,
+    lintWarning: PropTypes.bool.isRequired,
+    textOutput: PropTypes.bool.isRequired,
+    gridOutput: PropTypes.bool.isRequired,
+    soundOutput: PropTypes.bool.isRequired,
+    theme: PropTypes.string.isRequired,
+    autorefresh: PropTypes.bool.isRequired
+  }).isRequired,
+
+  ide: PropTypes.shape({
+    isPlaying: PropTypes.bool.isRequired,
+    isAccessibleOutputPlaying: PropTypes.bool.isRequired,
+    consoleEvent: PropTypes.array,
+    modalIsVisible: PropTypes.bool.isRequired,
+    sidebarIsExpanded: PropTypes.bool.isRequired,
+    consoleIsExpanded: PropTypes.bool.isRequired,
+    preferencesIsVisible: PropTypes.bool.isRequired,
+    projectOptionsVisible: PropTypes.bool.isRequired,
+    newFolderModalVisible: PropTypes.bool.isRequired,
+    shareModalVisible: PropTypes.bool.isRequired,
+    shareModalProjectId: PropTypes.string.isRequired,
+    shareModalProjectName: PropTypes.string.isRequired,
+    shareModalProjectUsername: PropTypes.string.isRequired,
+    editorOptionsVisible: PropTypes.bool.isRequired,
+    keyboardShortcutVisible: PropTypes.bool.isRequired,
+    unsavedChanges: PropTypes.bool.isRequired,
+    infiniteLoop: PropTypes.bool.isRequired,
+    previewIsRefreshing: PropTypes.bool.isRequired,
+    infiniteLoopMessage: PropTypes.string.isRequired,
+    projectSavedTime: PropTypes.string,
+    previousPath: PropTypes.string.isRequired,
+    justOpenedProject: PropTypes.bool.isRequired,
+    errorType: PropTypes.string,
+    runtimeErrorWarningVisible: PropTypes.bool.isRequired,
+    uploadFileModalVisible: PropTypes.bool.isRequired
+  }).isRequired,
+
+  editorAccessibility: PropTypes.shape({
+    lintMessages: PropTypes.array.isRequired,
+  }).isRequired,
+
+  project: PropTypes.shape({
+    id: PropTypes.string,
+    name: PropTypes.string.isRequired,
+    owner: PropTypes.shape({
+      username: PropTypes.string,
+      id: PropTypes.string
+    }),
+    updatedAt: PropTypes.string
+  }).isRequired,
+
+  updateLintMessage: PropTypes.func.isRequired,
+
+  clearLintMessage: PropTypes.func.isRequired,
+
+  selectedFile: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    content: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired
+  }).isRequired,
+
+  updateFileContent: PropTypes.func.isRequired,
+
+  files: PropTypes.arrayOf(PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    content: PropTypes.string.isRequired
+  })).isRequired,
+
+  closeEditorOptions: PropTypes.func.isRequired,
+
+  showEditorOptions: PropTypes.func.isRequired,
+
+  showKeyboardShortcutModal: PropTypes.func.isRequired,
+
+  setUnsavedChanges: PropTypes.func.isRequired,
+
+  startRefreshSketch: PropTypes.func.isRequired,
+
+  stopSketch: PropTypes.func.isRequired,
+
+  expandSidebar: PropTypes.func.isRequired,
+
+  collapseSidebar: PropTypes.func.isRequired,
+
+  clearConsole: PropTypes.func.isRequired,
+
+  console: PropTypes.arrayOf(PropTypes.shape({
+    method: PropTypes.string.isRequired,
+    args: PropTypes.arrayOf(PropTypes.string)
+  })).isRequired,
+
+  showRuntimeErrorWarning: PropTypes.func.isRequired,
+
+  hideRuntimeErrorWarning: PropTypes.func.isRequired,
+
+};
+
+
+function mapStateToProps(state) {
+  return {
+    files: state.files,
+    selectedFile: state.files.find(file => file.isSelectedFile) ||
+      state.files.find(file => file.name === 'sketch.js') ||
+      state.files.find(file => file.name !== 'root'),
+    htmlFile: getHTMLFile(state.files),
+    ide: state.ide,
+    preferences: state.preferences,
+    editorAccessibility: state.editorAccessibility,
+    user: state.user,
+    project: state.project,
+    toast: state.toast,
+    console: state.console
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators(
+    Object.assign(
+      {},
+      EditorAccessibilityActions,
+      FileActions,
+      ProjectActions,
+      IDEActions,
+      PreferencesActions,
+      UserActions,
+      ToastActions,
+      ConsoleActions
+    ),
+    dispatch
+  );
+}
+
+
+export default withRouter(connect(mapStateToProps, mapDispatchToProps)(IDEViewMobile));

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
-// import { Link } from 'react-router';
+import { Link } from 'react-router';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { useState } from 'react';
@@ -21,7 +21,7 @@ import { getHTMLFile } from '../reducers/files';
 // Local Imports
 import Editor from '../components/Editor';
 import { prop, remSize } from '../../../theme';
-import CloseIcon from '../../../images/exit.svg';
+import { CloseIcon } from '../../../common/Icons';
 
 const background = prop('Button.default.background');
 const textColor = prop('primaryTextColor');
@@ -40,7 +40,7 @@ const Header = styled.div`
   display: flex;
   flex: 1;
   flex-direction: row;
-  // justify-content: space-between;
+  justify-content: flex-start;
   align-items: center;
 `;
 
@@ -82,7 +82,6 @@ Screen.propTypes = {
 const isUserOwner = ({ project, user }) => (project.owner && project.owner.id === user.id);
 
 const IDEViewMobile = (props) => {
-  // const
   const {
     preferences, ide, editorAccessibility, project, updateLintMessage, clearLintMessage, selectedFile, updateFileContent, files, closeEditorOptions, showEditorOptions, showKeyboardShortcutModal, setUnsavedChanges, startRefreshSketch, stopSketch, expandSidebar, collapseSidebar, clearConsole, console, showRuntimeErrorWarning, hideRuntimeErrorWarning
   } = props;
@@ -92,18 +91,14 @@ const IDEViewMobile = (props) => {
   return (
     <Screen>
       <Header>
+        <Link to="/" style={{ width: '3rem', marginRight: '1.25rem' }}>
+          <CloseIcon viewBox="20 21 60 60" aria-hidden="true" aria-label="close header" />
+        </Link>
         <div>
           <h2>{project.name}</h2>
           <h3>{selectedFile.name}</h3>
         </div>
-        <Icon href="/">
-          <CloseIcon focusable="false" aria-hidden="true" />
-        </Icon>
       </Header>
-      {/* <div>
-        { [preferences, ide, editorAccessibility, project, updateLintMessage, clearLintMessage, selectedFile, updateFileContent, files, closeEditorOptions, showEditorOptions, showKeyboardShortcutModal, setUnsavedChanges, startRefreshSketch, stopSketch, expandSidebar, collapseSidebar, clearConsole, console, showRuntimeErrorWarning, hideRuntimeErrorWarning]
-          .map(pr => <h5>{pr.toString()}</h5>) }
-      </div> */}
 
       <Content>
         <Editor

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -31,7 +31,9 @@ const Header = styled.div`
   width: 100%;
   background-color: ${background};
   color: ${textColor};
+  padding: ${remSize(12)};
   padding-left: ${remSize(32)};
+  z-index: 1;
 `;
 
 const Footer = styled.div`
@@ -44,9 +46,10 @@ const Footer = styled.div`
 `;
 
 const Content = styled.div`
+  z-index: 0;
+  margin-top: ${remSize(16)};
 `;
 
-const f = x => x;
 
 const Screen = ({ children }) => (
   <div className="fullscreen-preview">
@@ -59,55 +62,60 @@ Screen.propTypes = {
 
 const IDEViewMobile = (props) => {
   // const
-  // const {
-  //   preferences, ide, editorAccessibility, project, updateLintMessage, clearLintMessage, selectedFile, updateFileContent, files, closeEditorOptions, showEditorOptions, showKeyboardShortcutModal, setUnsavedChanges, startRefreshSketch, stopSketch, expandSidebar, collapseSidebar, clearConsole, console, showRuntimeErrorWarning, hideRuntimeErrorWarning
-  // } = props;
+  const {
+    preferences, ide, editorAccessibility, project, updateLintMessage, clearLintMessage, selectedFile, updateFileContent, files, closeEditorOptions, showEditorOptions, showKeyboardShortcutModal, setUnsavedChanges, startRefreshSketch, stopSketch, expandSidebar, collapseSidebar, clearConsole, console, showRuntimeErrorWarning, hideRuntimeErrorWarning
+  } = props;
 
   const [tmController, setTmController] = useState(null);
 
   return (
     <Screen>
-      <Header><h1>Mobile View</h1></Header>
+      <Header>
+        {/* <h1>Mobile View</h1> */}
+        <h2>{project.name}</h2>
+        <h3>{selectedFile.name}</h3>
+      </Header>
       {/* <div>
         { [preferences, ide, editorAccessibility, project, updateLintMessage, clearLintMessage, selectedFile, updateFileContent, files, closeEditorOptions, showEditorOptions, showKeyboardShortcutModal, setUnsavedChanges, startRefreshSketch, stopSketch, expandSidebar, collapseSidebar, clearConsole, console, showRuntimeErrorWarning, hideRuntimeErrorWarning]
           .map(pr => <h5>{pr.toString()}</h5>) }
       </div> */}
 
-      <Editor
-        lintWarning={props.preferences.lintWarning}
-        linewrap={props.preferences.linewrap}
-        lintMessages={props.editorAccessibility.lintMessages}
-        updateLintMessage={props.updateLintMessage}
-        clearLintMessage={props.clearLintMessage}
-        file={props.selectedFile}
-        updateFileContent={props.updateFileContent}
-        fontSize={props.preferences.fontSize}
-        lineNumbers={props.preferences.lineNumbers}
-        files={props.files}
-        editorOptionsVisible={props.ide.editorOptionsVisible}
-        showEditorOptions={props.showEditorOptions}
-        closeEditorOptions={props.closeEditorOptions}
-        showKeyboardShortcutModal={props.showKeyboardShortcutModal}
-        setUnsavedChanges={props.setUnsavedChanges}
-        isPlaying={props.ide.isPlaying}
-        theme={props.preferences.theme}
-        startRefreshSketch={props.startRefreshSketch}
-        stopSketch={props.stopSketch}
-        autorefresh={props.preferences.autorefresh}
-        unsavedChanges={props.ide.unsavedChanges}
-        projectSavedTime={props.project.updatedAt}
-        isExpanded={props.ide.sidebarIsExpanded}
-        expandSidebar={props.expandSidebar}
-        collapseSidebar={props.collapseSidebar}
-        isUserOwner={setTmController}
-        clearConsole={props.clearConsole}
-        consoleEvents={props.console}
-        showRuntimeErrorWarning={props.showRuntimeErrorWarning}
-        hideRuntimeErrorWarning={props.hideRuntimeErrorWarning}
-        runtimeErrorWarningVisible={props.ide.runtimeErrorWarningVisible}
-        provideController={setTmController}
-      />
-
+      <Content>
+        <Editor
+          lintWarning={props.preferences.lintWarning}
+          linewrap={props.preferences.linewrap}
+          lintMessages={props.editorAccessibility.lintMessages}
+          updateLintMessage={props.updateLintMessage}
+          clearLintMessage={props.clearLintMessage}
+          file={props.selectedFile}
+          updateFileContent={props.updateFileContent}
+          fontSize={props.preferences.fontSize}
+          lineNumbers={props.preferences.lineNumbers}
+          files={props.files}
+          editorOptionsVisible={props.ide.editorOptionsVisible}
+          showEditorOptions={props.showEditorOptions}
+          closeEditorOptions={props.closeEditorOptions}
+          showKeyboardShortcutModal={props.showKeyboardShortcutModal}
+          setUnsavedChanges={props.setUnsavedChanges}
+          isPlaying={props.ide.isPlaying}
+          theme={props.preferences.theme}
+          startRefreshSketch={props.startRefreshSketch}
+          stopSketch={props.stopSketch}
+          autorefresh={props.preferences.autorefresh}
+          unsavedChanges={props.ide.unsavedChanges}
+          projectSavedTime={props.project.updatedAt}
+          isExpanded={props.ide.sidebarIsExpanded}
+          expandSidebar={props.expandSidebar}
+          collapseSidebar={props.collapseSidebar}
+          isUserOwner={setTmController}
+          clearConsole={props.clearConsole}
+          consoleEvents={props.console}
+          showRuntimeErrorWarning={props.showRuntimeErrorWarning}
+          hideRuntimeErrorWarning={props.hideRuntimeErrorWarning}
+          runtimeErrorWarningVisible={props.ide.runtimeErrorWarningVisible}
+          provideController={setTmController}
+        />
+      </Content>
       <Footer><h1>Bottom Bar</h1></Footer>
     </Screen>
   );

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -69,7 +69,7 @@ const Icon = styled.a`
   }
 `;
 
-const StyledLink = styled(Link)`
+const IconLinkWrapper = styled(Link)`
   width: 3rem;
   margin-right: 1.25rem;
   margin-left: none;
@@ -97,9 +97,9 @@ const IDEViewMobile = (props) => {
   return (
     <Screen>
       <Header>
-        <StyledLink to="/">
-          <CloseIcon viewBox="20 21 60 60" aria-hidden="true" aria-label="close header" />
-        </StyledLink>
+        <IconLinkWrapper to="/" aria-label="Return to original editor">
+          <CloseIcon viewBox="20 21 60 60" />
+        </IconLinkWrapper>
         <div>
           <h2>{project.name}</h2>
           <h3>{selectedFile.name}</h3>

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -21,7 +21,7 @@ import { getHTMLFile } from '../reducers/files';
 // Local Imports
 import Editor from '../components/Editor';
 import { prop, remSize } from '../../../theme';
-import { CloseIcon } from '../../../common/Icons';
+import { ExitIcon } from '../../../common/icons';
 
 const background = prop('Button.default.background');
 const textColor = prop('primaryTextColor');
@@ -98,7 +98,7 @@ const IDEViewMobile = (props) => {
     <Screen>
       <Header>
         <IconLinkWrapper to="/" aria-label="Return to original editor">
-          <CloseIcon viewBox="20 21 60 60" />
+          <ExitIcon />
         </IconLinkWrapper>
         <div>
           <h2>{project.name}</h2>

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -105,37 +105,37 @@ const IDEViewMobile = (props) => {
 
       <Content>
         <Editor
-          lintWarning={props.preferences.lintWarning}
-          linewrap={props.preferences.linewrap}
-          lintMessages={props.editorAccessibility.lintMessages}
-          updateLintMessage={props.updateLintMessage}
-          clearLintMessage={props.clearLintMessage}
-          file={props.selectedFile}
-          updateFileContent={props.updateFileContent}
-          fontSize={props.preferences.fontSize}
-          lineNumbers={props.preferences.lineNumbers}
-          files={props.files}
-          editorOptionsVisible={props.ide.editorOptionsVisible}
-          showEditorOptions={props.showEditorOptions}
-          closeEditorOptions={props.closeEditorOptions}
-          showKeyboardShortcutModal={props.showKeyboardShortcutModal}
-          setUnsavedChanges={props.setUnsavedChanges}
-          isPlaying={props.ide.isPlaying}
-          theme={props.preferences.theme}
-          startRefreshSketch={props.startRefreshSketch}
-          stopSketch={props.stopSketch}
-          autorefresh={props.preferences.autorefresh}
-          unsavedChanges={props.ide.unsavedChanges}
-          projectSavedTime={props.project.updatedAt}
-          isExpanded={props.ide.sidebarIsExpanded}
-          expandSidebar={props.expandSidebar}
-          collapseSidebar={props.collapseSidebar}
+          lintWarning={preferences.lintWarning}
+          linewrap={preferences.linewrap}
+          lintMessages={editorAccessibility.lintMessages}
+          updateLintMessage={updateLintMessage}
+          clearLintMessage={clearLintMessage}
+          file={selectedFile}
+          updateFileContent={updateFileContent}
+          fontSize={preferences.fontSize}
+          lineNumbers={preferences.lineNumbers}
+          files={files}
+          editorOptionsVisible={ide.editorOptionsVisible}
+          showEditorOptions={showEditorOptions}
+          closeEditorOptions={closeEditorOptions}
+          showKeyboardShortcutModal={showKeyboardShortcutModal}
+          setUnsavedChanges={setUnsavedChanges}
+          isPlaying={ide.isPlaying}
+          theme={preferences.theme}
+          startRefreshSketch={startRefreshSketch}
+          stopSketch={stopSketch}
+          autorefresh={preferences.autorefresh}
+          unsavedChanges={ide.unsavedChanges}
+          projectSavedTime={project.updatedAt}
+          isExpanded={ide.sidebarIsExpanded}
+          expandSidebar={expandSidebar}
+          collapseSidebar={collapseSidebar}
           isUserOwner={setTmController}
-          clearConsole={props.clearConsole}
-          consoleEvents={props.console}
-          showRuntimeErrorWarning={props.showRuntimeErrorWarning}
-          hideRuntimeErrorWarning={props.hideRuntimeErrorWarning}
-          runtimeErrorWarningVisible={props.ide.runtimeErrorWarningVisible}
+          clearConsole={clearConsole}
+          consoleEvents={console}
+          showRuntimeErrorWarning={showRuntimeErrorWarning}
+          hideRuntimeErrorWarning={hideRuntimeErrorWarning}
+          runtimeErrorWarningVisible={ide.runtimeErrorWarningVisible}
           provideController={setTmController}
         />
       </Content>

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -69,6 +69,12 @@ const Icon = styled.a`
   }
 `;
 
+const StyledLink = styled(Link)`
+  width: 3rem;
+  margin-right: 1.25rem;
+  margin-left: none;
+`;
+
 
 const Screen = ({ children }) => (
   <div className="fullscreen-preview">
@@ -91,9 +97,9 @@ const IDEViewMobile = (props) => {
   return (
     <Screen>
       <Header>
-        <Link to="/" style={{ width: '3rem', marginRight: '1.25rem' }}>
+        <StyledLink to="/">
           <CloseIcon viewBox="20 21 60 60" aria-hidden="true" aria-label="close header" />
-        </Link>
+        </StyledLink>
         <div>
           <h2>{project.name}</h2>
           <h3>{selectedFile.name}</h3>

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -79,6 +79,8 @@ Screen.propTypes = {
   children: PropTypes.node.isRequired
 };
 
+const isUserOwner = ({ project, user }) => (project.owner && project.owner.id === user.id);
+
 const IDEViewMobile = (props) => {
   // const
   const {
@@ -130,7 +132,7 @@ const IDEViewMobile = (props) => {
           isExpanded={ide.sidebarIsExpanded}
           expandSidebar={expandSidebar}
           collapseSidebar={collapseSidebar}
-          isUserOwner={setTmController}
+          isUserOwner={isUserOwner(props)}
           clearConsole={clearConsole}
           consoleEvents={console}
           showRuntimeErrorWarning={showRuntimeErrorWarning}
@@ -247,6 +249,11 @@ IDEViewMobile.propTypes = {
 
   hideRuntimeErrorWarning: PropTypes.func.isRequired,
 
+  user: PropTypes.shape({
+    authenticated: PropTypes.bool.isRequired,
+    id: PropTypes.string,
+    username: PropTypes.string
+  }).isRequired,
 };
 
 

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -21,33 +21,52 @@ import { getHTMLFile } from '../reducers/files';
 // Local Imports
 import Editor from '../components/Editor';
 import { prop, remSize } from '../../../theme';
-
+import CloseIcon from '../../../images/exit.svg';
 
 const background = prop('Button.default.background');
 const textColor = prop('primaryTextColor');
 
+
 const Header = styled.div`
   position: fixed;
   width: 100%;
-  background-color: ${background};
+  background: ${background};
+  color: ${textColor};
+  padding: ${remSize(12)};
+  padding-left: ${remSize(32)};
+  padding-right: ${remSize(32)};
+  z-index: 1;
+  
+  display: flex;
+  flex: 1;
+  flex-direction: row;
+  // justify-content: space-between;
+  align-items: center;
+`;
+
+const Footer = styled.div`
+  position: fixed;
+  width: 100%;
+  background: ${background};
   color: ${textColor};
   padding: ${remSize(12)};
   padding-left: ${remSize(32)};
   z-index: 1;
-`;
 
-const Footer = styled.div`
-  width: 100%;
-  position: fixed;
   bottom: 0;
-  background: ${background};
-  color: ${textColor};
-  padding-left: ${remSize(32)};
 `;
 
 const Content = styled.div`
   z-index: 0;
   margin-top: ${remSize(16)};
+`;
+
+const Icon = styled.a`
+  > svg {
+    fill: ${textColor};
+    color: ${textColor};
+    margin: 8px
+  }
 `;
 
 
@@ -71,9 +90,13 @@ const IDEViewMobile = (props) => {
   return (
     <Screen>
       <Header>
-        {/* <h1>Mobile View</h1> */}
-        <h2>{project.name}</h2>
-        <h3>{selectedFile.name}</h3>
+        <div>
+          <h2>{project.name}</h2>
+          <h3>{selectedFile.name}</h3>
+        </div>
+        <Icon href="/">
+          <CloseIcon focusable="false" aria-hidden="true" />
+        </Icon>
       </Header>
       {/* <div>
         { [preferences, ide, editorAccessibility, project, updateLintMessage, clearLintMessage, selectedFile, updateFileContent, files, closeEditorOptions, showEditorOptions, showKeyboardShortcutModal, setUnsavedChanges, startRefreshSketch, stopSketch, expandSidebar, collapseSidebar, clearConsole, console, showRuntimeErrorWarning, hideRuntimeErrorWarning]
@@ -116,7 +139,7 @@ const IDEViewMobile = (props) => {
           provideController={setTmController}
         />
       </Content>
-      <Footer><h1>Bottom Bar</h1></Footer>
+      <Footer><h2>Bottom Bar</h2></Footer>
     </Screen>
   );
 };

--- a/client/modules/IDE/pages/IDEViewMobile.jsx
+++ b/client/modules/IDE/pages/IDEViewMobile.jsx
@@ -65,7 +65,7 @@ const Icon = styled.a`
   > svg {
     fill: ${textColor};
     color: ${textColor};
-    margin: 8px
+    margin-left: ${remSize(16)};
   }
 `;
 

--- a/client/theme.js
+++ b/client/theme.js
@@ -85,6 +85,10 @@ export default {
         border: grays.middleLight,
       },
     },
+    Icon: {
+      default: grays.middleGray,
+      hover: grays.darker
+    }
   },
   [Theme.dark]: {
     colors,
@@ -113,6 +117,10 @@ export default {
         border: grays.middleDark,
       },
     },
+    Icon: {
+      default: grays.middleLight,
+      hover: grays.lightest
+    }
   },
   [Theme.contrast]: {
     colors,
@@ -141,5 +149,9 @@ export default {
         border: grays.middleDark,
       },
     },
+    Icon: {
+      default: grays.mediumLight,
+      hover: colors.yellow
+    }
   },
 };


### PR DESCRIPTION
This PR mounts the `<Editor />` component on the Mobile IDE View (`/mobile`), and places a button for exiting the mobile view.

Functionality is only partially implement, as expected: running the code will require a new overlay component.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`