### PR TITLE
Allow deleted sketches in collections to be removed (fixes #1465)

### DIFF
--- a/client/styles/components/_sketch-list.scss
+++ b/client/styles/components/_sketch-list.scss
@@ -85,6 +85,10 @@
   }
 }
 
+.sketches-table__row.is-deleted > * {
+  font-style: italic;
+}
+
 .sketches-table thead {
   font-size: #{12 / $base-font-size}rem;
   @include themify() {

--- a/server/controllers/collection.controller/addProjectToCollection.js
+++ b/server/controllers/collection.controller/addProjectToCollection.js
@@ -32,7 +32,7 @@ export default function addProjectToCollection(req, res) {
       return null;
     }
 
-    const projectInCollection = collection.items.find(p => p.project._id === project._id);
+    const projectInCollection = collection.items.find(p => p.projectId === project._id);
 
     if (projectInCollection) {
       sendFailure(404, 'Project already in collection');

--- a/server/controllers/collection.controller/removeProjectFromCollection.js
+++ b/server/controllers/collection.controller/removeProjectFromCollection.js
@@ -23,7 +23,7 @@ export default function addProjectToCollection(req, res) {
       return null;
     }
 
-    const project = collection.items.find(p => p.project._id === projectId);
+    const project = collection.items.find(p => p.projectId === projectId);
 
     if (project != null) {
       project.remove();

--- a/server/models/collection.js
+++ b/server/models/collection.js
@@ -15,6 +15,14 @@ collectedProjectSchema.virtual('id').get(function getId() {
   return this._id.toHexString();
 });
 
+collectedProjectSchema.virtual('projectId').get(function projectId() {
+  return this.populated('project');
+});
+
+collectedProjectSchema.virtual('isDeleted').get(function isDeleted() {
+  return this.project == null;
+});
+
 collectedProjectSchema.set('toJSON', {
   virtuals: true
 });


### PR DESCRIPTION
After the discussion about this bug in #1465, I decided that deleted sketches in collections shouldn't disappear. Instead, they should appear in the collection as "Deleted". The user can then decide if they want to remove the item from the collection.

I think this is less confusing and also means we don't have to complicate the sketch-deletion code with finding and deleting collections that reference the deleted project.

<img width="1047" alt="Screenshot 2020-06-29 11 27 52" src="https://user-images.githubusercontent.com/1762/85998096-a93ce100-ba0a-11ea-80d3-ffe8c9488a78.png">


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`