### PR TITLE
[#1500] Update sketch media file duplication code

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -16,6 +16,8 @@ import {
 import { clearState, saveState } from '../../../persistState';
 
 const ROOT_URL = getConfig('API_URL');
+const S3_BUCKET_URL_BASE = getConfig('S3_BUCKET_URL_BASE');
+const S3_BUCKET = getConfig('S3_BUCKET');
 
 export function setProject(project) {
   return {
@@ -287,7 +289,7 @@ export function cloneProject(id) {
 
       // duplicate all files hosted on S3
       each(newFiles, (file, callback) => {
-        if (file.url && file.url.includes('amazonaws')) {
+        if (file.url && (file.url.includes(S3_BUCKET_URL_BASE) || file.url.includes(S3_BUCKET))) {
           const formParams = {
             url: file.url
           };

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -28,7 +28,7 @@ function getExtension(filename) {
 export function getObjectKey(url) {
   const urlArray = url.split('/');
   let objectKey;
-  if (urlArray.length === 6) {
+  if (urlArray.length === 5) {
     const key = urlArray.pop();
     const userId = urlArray.pop();
     objectKey = `${userId}/${key}`;


### PR DESCRIPTION
- Sketch duplication code now checks for AWS endpoint via environment
  variable, rather than hard-coded string
- Fixes `aws.controller#getObjectKey`, which was incorrectly generating
  file keys

Fixes #1500

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`