### PR TITLE
Add <Console /> to Mobile Views

### DIFF
--- a/client/components/mobile/Footer.jsx
+++ b/client/components/mobile/Footer.jsx
@@ -1,42 +1,15 @@
 import React from 'react';
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
-import { prop, remSize } from '../../theme';
+import { prop } from '../../theme';
 
 
 const background = prop('MobilePanel.default.background');
 const textColor = prop('primaryTextColor');
 
-const FooterWrapper = styled.div`
+export default styled.div`
   position: fixed;
   width: 100%;
   bottom: 0;
-`;
-
-const FooterContent = styled.div`
   background: ${background};
   color: ${textColor};
-  padding: ${remSize(12)};
-  padding-left: ${remSize(32)};
 `;
-
-const Footer = ({ before, children }) => (
-  <FooterWrapper>
-    {before}
-    <FooterContent>
-      {children}
-    </FooterContent>
-  </FooterWrapper>
-);
-
-Footer.propTypes = {
-  before: PropTypes.element,
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]),
-};
-
-Footer.defaultProps = {
-  before: <></>,
-  children: <></>
-};
-
-export default Footer;

--- a/client/components/mobile/Footer.jsx
+++ b/client/components/mobile/Footer.jsx
@@ -1,20 +1,43 @@
 import React from 'react';
 import styled from 'styled-components';
+import PropTypes from 'prop-types';
 import { prop, remSize } from '../../theme';
+
 
 const background = prop('MobilePanel.default.background');
 const textColor = prop('primaryTextColor');
 
-const Footer = styled.div`
+const FooterWrapper = styled.div`
   position: fixed;
   width: 100%;
+  bottom: 0;
+`;
+
+const FooterContent = styled.div`
   background: ${background};
   color: ${textColor};
   padding: ${remSize(12)};
   padding-left: ${remSize(32)};
-  z-index: 1;
-
-  bottom: 0;
 `;
+
+
+const Footer = ({ before, children }) => (
+  <FooterWrapper>
+    {before}
+    <FooterContent>
+      {children}
+    </FooterContent>
+  </FooterWrapper>
+);
+
+Footer.propTypes = {
+  before: PropTypes.element,
+  children: PropTypes.element
+};
+
+Footer.defaultProps = {
+  before: <></>,
+  children: <></>
+};
 
 export default Footer;

--- a/client/components/mobile/Footer.jsx
+++ b/client/components/mobile/Footer.jsx
@@ -20,7 +20,6 @@ const FooterContent = styled.div`
   padding-left: ${remSize(32)};
 `;
 
-
 const Footer = ({ before, children }) => (
   <FooterWrapper>
     {before}
@@ -32,7 +31,7 @@ const Footer = ({ before, children }) => (
 
 Footer.propTypes = {
   before: PropTypes.element,
-  children: PropTypes.element
+  children: PropTypes.oneOfType([PropTypes.element, PropTypes.arrayOf(PropTypes.element)]),
 };
 
 Footer.defaultProps = {

--- a/client/modules/App/App.jsx
+++ b/client/modules/App/App.jsx
@@ -36,6 +36,7 @@ class App extends React.Component {
       <div className="app">
         {/* FIXME: remove "false &&" from line below */}
         {false && this.state.isMounted && !window.devToolsExtension && getConfig('NODE_ENV') === 'development' && <DevTools />}
+        {/* {this.state.isMounted && !window.devToolsExtension && getConfig('NODE_ENV') === 'development' && <DevTools />} */}
         {this.props.children}
       </div>
     );

--- a/client/modules/App/App.jsx
+++ b/client/modules/App/App.jsx
@@ -34,7 +34,8 @@ class App extends React.Component {
   render() {
     return (
       <div className="app">
-        {this.state.isMounted && !window.devToolsExtension && getConfig('NODE_ENV') === 'development' && <DevTools />}
+        {/* FIXME: remove "false &&" from line below */}
+        {false && this.state.isMounted && !window.devToolsExtension && getConfig('NODE_ENV') === 'development' && <DevTools />}
         {this.props.children}
       </div>
     );

--- a/client/modules/App/App.jsx
+++ b/client/modules/App/App.jsx
@@ -34,9 +34,7 @@ class App extends React.Component {
   render() {
     return (
       <div className="app">
-        {/* FIXME: remove "false &&" from line below */}
-        {false && this.state.isMounted && !window.devToolsExtension && getConfig('NODE_ENV') === 'development' && <DevTools />}
-        {/* {this.state.isMounted && !window.devToolsExtension && getConfig('NODE_ENV') === 'development' && <DevTools />} */}
+        {this.state.isMounted && !window.devToolsExtension && getConfig('NODE_ENV') === 'development' && <DevTools />}
         {this.props.children}
       </div>
     );

--- a/client/modules/IDE/components/Console.jsx
+++ b/client/modules/IDE/components/Console.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useSelector, useDispatch, connect } from 'react-redux';
 import classNames from 'classnames';
 import { Console as ConsoleFeed } from 'console-feed';
 import {
@@ -22,7 +23,10 @@ import infoContrastUrl from '../../../images/console-info-contrast.svg?byUrl';
 import UpArrowIcon from '../../../images/up-arrow.svg';
 import DownArrowIcon from '../../../images/down-arrow.svg';
 
-class Console extends React.Component {
+import * as IDEActions from '../../IDE/actions/ide';
+import * as ConsoleActions from '../../IDE/actions/console';
+
+class ConsoleComponent extends React.Component {
   componentDidUpdate(prevProps) {
     this.consoleMessages.scrollTop = this.consoleMessages.scrollHeight;
     if (this.props.theme !== prevProps.theme) {
@@ -132,7 +136,7 @@ class Console extends React.Component {
   }
 }
 
-Console.propTypes = {
+ConsoleComponent.propTypes = {
   consoleEvents: PropTypes.arrayOf(PropTypes.shape({
     method: PropTypes.string.isRequired,
     args: PropTypes.arrayOf(PropTypes.string)
@@ -146,8 +150,45 @@ Console.propTypes = {
   fontSize: PropTypes.number.isRequired
 };
 
-Console.defaultProps = {
+ConsoleComponent.defaultProps = {
   consoleEvents: []
 };
+
+// const Console = () => {
+//   const consoleEvents = useSelector(state => state.console);
+//   const { consoleIsExpanded } = useSelector(state => state.ide);
+//   const { theme, fontSize } = useSelector(state => state.preferences);
+
+//   const dispatch = useDispatch();
+
+//   return (
+//     <ConsoleComponent
+//       consoleEvents={consoleEvents}
+//       isExpanded={consoleIsExpanded}
+//       theme={theme}
+//       fontSize={fontSize}
+//       collapseConsole={() => dispatch({})}
+//       expandConsole={() => dispatch({})}
+//       clearConsole={() => dispatch({})}
+//       dispatchConsoleEvent={() => dispatch({})}
+//     />
+//   );
+// };
+
+
+const Console = connect(
+  state => ({
+    consoleEvents: state.console,
+    isExpanded: state.ide.consoleIsExpanded,
+    theme: state.preferences.theme,
+    fontSize: state.preferences.fontSize
+  }),
+  dispatch => ({
+    collapseConsole: () => dispatch(IDEActions.collapseConsole()),
+    expandConsole: () => dispatch(IDEActions.expandConsole()),
+    clearConsole: () => dispatch(ConsoleActions.clearConsole()),
+    dispatchConsoleEvent: msgs => dispatch(ConsoleActions.dispatchConsoleEvent(msgs)),
+  })
+)(ConsoleComponent);
 
 export default Console;

--- a/client/modules/IDE/components/Console.jsx
+++ b/client/modules/IDE/components/Console.jsx
@@ -154,27 +154,29 @@ ConsoleComponent.defaultProps = {
   consoleEvents: []
 };
 
-// const Console = () => {
-//   const consoleEvents = useSelector(state => state.console);
-//   const { consoleIsExpanded } = useSelector(state => state.ide);
-//   const { theme, fontSize } = useSelector(state => state.preferences);
+// TODO: Use Hooks implementation. Requires react-redux 7.1.0
+/*
+const Console = () => {
+  const consoleEvents = useSelector(state => state.console);
+  const { consoleIsExpanded } = useSelector(state => state.ide);
+  const { theme, fontSize } = useSelector(state => state.preferences);
 
-//   const dispatch = useDispatch();
+  const dispatch = useDispatch();
 
-//   return (
-//     <ConsoleComponent
-//       consoleEvents={consoleEvents}
-//       isExpanded={consoleIsExpanded}
-//       theme={theme}
-//       fontSize={fontSize}
-//       collapseConsole={() => dispatch({})}
-//       expandConsole={() => dispatch({})}
-//       clearConsole={() => dispatch({})}
-//       dispatchConsoleEvent={() => dispatch({})}
-//     />
-//   );
-// };
-
+  return (
+    <ConsoleComponent
+      consoleEvents={consoleEvents}
+      isExpanded={consoleIsExpanded}
+      theme={theme}
+      fontSize={fontSize}
+      collapseConsole={() => dispatch({})}
+      expandConsole={() => dispatch({})}
+      clearConsole={() => dispatch({})}
+      dispatchConsoleEvent={() => dispatch({})}
+    />
+  );
+};
+ */
 
 const Console = connect(
   state => ({

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -324,16 +324,7 @@ class IDEView extends React.Component {
                   runtimeErrorWarningVisible={this.props.ide.runtimeErrorWarningVisible}
                   provideController={(ctl) => { this.cmController = ctl; }}
                 />
-                <Console
-                  fontSize={this.props.preferences.fontSize}
-                  consoleEvents={this.props.console}
-                  isExpanded={this.props.ide.consoleIsExpanded}
-                  expandConsole={this.props.expandConsole}
-                  collapseConsole={this.props.collapseConsole}
-                  clearConsole={this.props.clearConsole}
-                  dispatchConsoleEvent={this.props.dispatchConsoleEvent}
-                  theme={this.props.preferences.theme}
-                />
+                <Console />
               </SplitPane>
               <section className="preview-frame-holder">
                 <header className="preview-frame__header">
@@ -649,6 +640,4 @@ function mapDispatchToProps(dispatch) {
   );
 }
 
-
 export default withTranslation('WebEditor')(withRouter(connect(mapStateToProps, mapDispatchToProps)(IDEView)));
-

--- a/client/modules/IDE/pages/MobileIDEView.jsx
+++ b/client/modules/IDE/pages/MobileIDEView.jsx
@@ -43,11 +43,6 @@ const MobileIDEView = (props) => {
   const [tmController, setTmController] = useState(null); // eslint-disable-line
   const [overlay, setOverlay] = useState(null); // eslint-disable-line
 
-  // FIXME:
-  const dispatchConsoleEvent = () => {};
-  const expandConsole = () => {};
-  const collapseConsole = () => {};
-
   return (
     <Screen fullscreen>
       <Header

--- a/client/modules/IDE/pages/MobileIDEView.jsx
+++ b/client/modules/IDE/pages/MobileIDEView.jsx
@@ -31,6 +31,11 @@ import { remSize } from '../../../theme';
 
 const isUserOwner = ({ project, user }) => (project.owner && project.owner.id === user.id);
 
+const BottomBarContent = styled.h2`
+  padding: ${remSize(12)};
+  padding-left: ${remSize(32)};
+`;
+
 const MobileIDEView = (props) => {
   const {
     preferences, ide, editorAccessibility, project, updateLintMessage, clearLintMessage,
@@ -97,8 +102,9 @@ const MobileIDEView = (props) => {
           provideController={setTmController}
         />
       </IDEWrapper>
-      <Footer before={<Console />} >
-        <h2>Bottom Bar</h2>
+      <Footer>
+        <Console />
+        <BottomBarContent>Bottom Bar</BottomBarContent>
       </Footer>
     </Screen>
   );

--- a/client/modules/IDE/pages/MobileIDEView.jsx
+++ b/client/modules/IDE/pages/MobileIDEView.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
 import { useState } from 'react';
+import styled from 'styled-components';
 
 // Imports to be Refactored
 import { bindActionCreators } from 'redux';
@@ -25,6 +26,8 @@ import Header from '../../../components/mobile/Header';
 import Screen from '../../../components/mobile/MobileScreen';
 import Footer from '../../../components/mobile/Footer';
 import IDEWrapper from '../../../components/mobile/IDEWrapper';
+import Console from '../components/Console';
+import { remSize } from '../../../theme';
 
 const isUserOwner = ({ project, user }) => (project.owner && project.owner.id === user.id);
 
@@ -39,6 +42,11 @@ const MobileIDEView = (props) => {
 
   const [tmController, setTmController] = useState(null); // eslint-disable-line
   const [overlay, setOverlay] = useState(null); // eslint-disable-line
+
+  // FIXME:
+  const dispatchConsoleEvent = () => {};
+  const expandConsole = () => {};
+  const collapseConsole = () => {};
 
   return (
     <Screen fullscreen>
@@ -94,7 +102,19 @@ const MobileIDEView = (props) => {
           provideController={setTmController}
         />
       </IDEWrapper>
-      <Footer><h2>Bottom Bar</h2></Footer>
+      <Footer before={<Console
+        fontSize={preferences.fontSize}
+        consoleEvents={console}
+        isExpanded={ide.consoleIsExpanded}
+        clearConsole={clearConsole}
+        theme={preferences.theme}
+        dispatchConsoleEvent={dispatchConsoleEvent}
+        expandConsole={expandConsole}
+        collapseConsole={collapseConsole}
+      />}
+      >
+        <h2>Bottom Bar</h2>
+      </Footer>
     </Screen>
   );
 };

--- a/client/modules/IDE/pages/MobileIDEView.jsx
+++ b/client/modules/IDE/pages/MobileIDEView.jsx
@@ -102,17 +102,7 @@ const MobileIDEView = (props) => {
           provideController={setTmController}
         />
       </IDEWrapper>
-      <Footer before={<Console
-        fontSize={preferences.fontSize}
-        consoleEvents={console}
-        isExpanded={ide.consoleIsExpanded}
-        clearConsole={clearConsole}
-        theme={preferences.theme}
-        dispatchConsoleEvent={dispatchConsoleEvent}
-        expandConsole={expandConsole}
-        collapseConsole={collapseConsole}
-      />}
-      >
+      <Footer before={<Console />} >
         <h2>Bottom Bar</h2>
       </Footer>
     </Screen>

--- a/client/modules/Mobile/MobileSketchView.jsx
+++ b/client/modules/Mobile/MobileSketchView.jsx
@@ -84,7 +84,9 @@ const MobileSketchView = (props) => {
           clearConsole={clearConsole}
         />
       </Content>
-      <Footer before={<Console />} />
+      <Footer>
+        <Console />
+      </Footer>
     </Screen>);
 };
 

--- a/client/modules/Mobile/MobileSketchView.jsx
+++ b/client/modules/Mobile/MobileSketchView.jsx
@@ -87,17 +87,7 @@ const MobileSketchView = (props) => {
           clearConsole={clearConsole}
         />
       </Content>
-      <Footer before={<Console
-        fontSize={preferences.fontSize}
-        consoleEvents={console}
-        isExpanded={ide.consoleIsExpanded}
-        clearConsole={clearConsole}
-        theme={preferences.theme}
-        dispatchConsoleEvent={dispatchConsoleEvent}
-        expandConsole={expandConsole}
-        collapseConsole={collapseConsole}
-      />}
-      />
+      <Footer before={<Console />} />
     </Screen>);
 };
 

--- a/client/modules/Mobile/MobileSketchView.jsx
+++ b/client/modules/Mobile/MobileSketchView.jsx
@@ -7,6 +7,7 @@ import Header from '../../components/mobile/Header';
 import IconButton from '../../components/mobile/IconButton';
 import PreviewFrame from '../IDE/components/PreviewFrame';
 import Screen from '../../components/mobile/MobileScreen';
+import Console from '../IDE/components/Console';
 import * as ProjectActions from '../IDE/actions/project';
 import * as IDEActions from '../IDE/actions/ide';
 import * as PreferencesActions from '../IDE/actions/preferences';
@@ -18,6 +19,7 @@ import { getHTMLFile } from '../IDE/reducers/files';
 
 import { ExitIcon } from '../../common/icons';
 import { remSize } from '../../theme';
+import Footer from '../../components/mobile/Footer';
 
 
 const Content = styled.div`
@@ -39,12 +41,15 @@ const MobileSketchView = (props) => {
   // Actions
   const {
     setTextOutput, setGridOutput, setSoundOutput,
-    endSketchRefresh, stopSketch,
+    endSketchRefresh, stopSketch, console,
     dispatchConsoleEvent, expandConsole, clearConsole,
     setBlobUrl,
   } = props;
 
   const { preferences, ide } = props;
+
+  // FIXME:
+  const collapseConsole = () => {};
 
   return (
     <Screen fullscreen>
@@ -82,6 +87,17 @@ const MobileSketchView = (props) => {
           clearConsole={clearConsole}
         />
       </Content>
+      <Footer before={<Console
+        fontSize={preferences.fontSize}
+        consoleEvents={console}
+        isExpanded={ide.consoleIsExpanded}
+        clearConsole={clearConsole}
+        theme={preferences.theme}
+        dispatchConsoleEvent={dispatchConsoleEvent}
+        expandConsole={expandConsole}
+        collapseConsole={collapseConsole}
+      />}
+      />
     </Screen>);
 };
 
@@ -146,7 +162,6 @@ MobileSketchView.propTypes = {
     justOpenedProject: PropTypes.bool.isRequired,
     errorType: PropTypes.string,
     runtimeErrorWarningVisible: PropTypes.bool.isRequired,
-    uploadFileModalVisible: PropTypes.bool.isRequired
   }).isRequired,
 
   projectName: PropTypes.string.isRequired,
@@ -160,6 +175,11 @@ MobileSketchView.propTypes = {
   setBlobUrl: PropTypes.func.isRequired,
   expandConsole: PropTypes.func.isRequired,
   clearConsole: PropTypes.func.isRequired,
+
+  console: PropTypes.arrayOf(PropTypes.shape({
+    method: PropTypes.string.isRequired,
+    args: PropTypes.arrayOf(PropTypes.string)
+  })).isRequired,
 };
 
 function mapStateToProps(state) {
@@ -169,6 +189,7 @@ function mapStateToProps(state) {
     files: state.files,
     ide: state.ide,
     preferences: state.preferences,
+    console: state.console,
     selectedFile: state.files.find(file => file.isSelectedFile) ||
       state.files.find(file => file.name === 'sketch.js') ||
       state.files.find(file => file.name !== 'root'),

--- a/client/modules/Mobile/MobileSketchView.jsx
+++ b/client/modules/Mobile/MobileSketchView.jsx
@@ -41,15 +41,12 @@ const MobileSketchView = (props) => {
   // Actions
   const {
     setTextOutput, setGridOutput, setSoundOutput,
-    endSketchRefresh, stopSketch, console,
+    endSketchRefresh, stopSketch,
     dispatchConsoleEvent, expandConsole, clearConsole,
     setBlobUrl,
   } = props;
 
   const { preferences, ide } = props;
-
-  // FIXME:
-  const collapseConsole = () => {};
 
   return (
     <Screen fullscreen>
@@ -165,11 +162,6 @@ MobileSketchView.propTypes = {
   setBlobUrl: PropTypes.func.isRequired,
   expandConsole: PropTypes.func.isRequired,
   clearConsole: PropTypes.func.isRequired,
-
-  console: PropTypes.arrayOf(PropTypes.shape({
-    method: PropTypes.string.isRequired,
-    args: PropTypes.arrayOf(PropTypes.string)
-  })).isRequired,
 };
 
 function mapStateToProps(state) {
@@ -179,7 +171,6 @@ function mapStateToProps(state) {
     files: state.files,
     ide: state.ide,
     preferences: state.preferences,
-    console: state.console,
     selectedFile: state.files.find(file => file.isSelectedFile) ||
       state.files.find(file => file.name === 'sketch.js') ||
       state.files.find(file => file.name !== 'root'),

--- a/package-lock.json
+++ b/package-lock.json
@@ -11017,7 +11017,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -34869,7 +34870,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },


### PR DESCRIPTION
Fixes #1496 and #1497 

Part of the Mobile UI project. Adds the `<Console />` component to `<MobileIDEView />` and `<MobileSketchView />`. Transforms `<Console />` into a container

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`