### PR TITLE
Server Cache Policy

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -75,7 +75,18 @@ app.use(corsMiddleware);
 app.options('*', corsMiddleware);
 
 // Body parser, cookie parser, sessions, serve public assets
-app.use('/locales', Express.static(path.resolve(__dirname, '../dist/static/locales'), { cacheControl: false }));
+app.use(
+  '/locales',
+  Express.static(
+    path.resolve(__dirname, '../dist/static/locales'),
+    {
+      // Browsers must revalidate for changes to the locale files
+      // It doesn't actually mean "don't cache this file"
+      // See: https://jakearchibald.com/2016/caching-best-practices/
+      setHeaders: res => res.setHeader('Cache-Control', 'no-cache')
+    }
+  )
+);
 app.use(Express.static(path.resolve(__dirname, '../dist/static'), {
   maxAge: process.env.STATIC_MAX_AGE || (process.env.NODE_ENV === 'production' ? '1d' : '0')
 }));


### PR DESCRIPTION
Change in Cache Policy

The line doesn't actually mean "do not use cache", but "revalidate the file with the server".


Fixes #1491 


https://github.com/processing/p5.js-web-editor/pull/1491/files/78f87b6ec17c7546ecb841c870bccab59c70ca28#r453473436I 

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`