### PR TITLE
Add prototype of language selector design

### DIFF
--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -6,6 +6,7 @@ import { Link } from 'react-router';
 import classNames from 'classnames';
 import { withTranslation } from 'react-i18next';
 import i18next from 'i18next';
+import { languageKeyToLabel } from '../i18n';
 import * as IDEActions from '../modules/IDE/actions/ide';
 import * as toastActions from '../modules/IDE/actions/toast';
 import * as projectActions from '../modules/IDE/actions/project';
@@ -549,7 +550,7 @@ class Nav extends React.PureComponent {
 
   renderLanguageMenu(navDropdownState) {
     return (
-      <ul className="nav__items-right" title="user-menu">
+      <React.Fragment>
         <li className={navDropdownState.lang}>
           <button
             onClick={this.toggleDropdownForLang}
@@ -561,7 +562,7 @@ class Nav extends React.PureComponent {
               }
             }}
           >
-            <span className="nav__item-header"> {this.props.t('Nav.Lang')}</span>
+            <span className="nav__item-header"> {languageKeyToLabel(this.props.language)}</span>
             <TriangleIcon className="nav__item-header-triangle" focusable="false" aria-hidden="true" />
           </button>
           <ul className="nav__dropdown">
@@ -597,7 +598,7 @@ class Nav extends React.PureComponent {
             </li>
           </ul>
         </li>
-      </ul>
+      </React.Fragment>
     );
   }
 
@@ -605,6 +606,7 @@ class Nav extends React.PureComponent {
   renderUnauthenticatedUserMenu(navDropdownState) {
     return (
       <ul className="nav__items-right" title="user-menu">
+        {getConfig('TRANSLATIONS_ENABLED') && this.renderLanguageMenu(navDropdownState)}
         <li className="nav__item">
           <Link to="/login" className="nav__auth-button">
             <span className="nav__item-header">{this.props.t('Nav.Login')}</span>
@@ -623,6 +625,7 @@ class Nav extends React.PureComponent {
   renderAuthenticatedUserMenu(navDropdownState) {
     return (
       <ul className="nav__items-right" title="user-menu">
+        {getConfig('TRANSLATIONS_ENABLED') && this.renderLanguageMenu(navDropdownState)}
         <li className="nav__item">
           <span>{this.props.t('Nav.Auth.Hello')}, {this.props.user.username}!</span>
         </li>
@@ -755,7 +758,6 @@ class Nav extends React.PureComponent {
       <header>
         <nav className="nav" title="main-navigation" ref={(node) => { this.node = node; }}>
           {this.renderLeftLayout(navDropdownState)}
-          {getConfig('TRANSLATIONS_ENABLED') && this.renderLanguageMenu(navDropdownState)}
           {this.renderUserMenu(navDropdownState)}
         </nav>
       </header>
@@ -809,6 +811,7 @@ Nav.propTypes = {
   }),
   t: PropTypes.func.isRequired,
   setLanguage: PropTypes.func.isRequired,
+  language: PropTypes.string.isRequired,
 };
 
 Nav.defaultProps = {
@@ -829,7 +832,8 @@ function mapStateToProps(state) {
     project: state.project,
     user: state.user,
     unsavedChanges: state.ide.unsavedChanges,
-    rootFile: state.files.filter(file => file.name === 'root')[0]
+    rootFile: state.files.filter(file => file.name === 'root')[0],
+    language: state.preferences.language
   };
 }
 

--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -626,10 +626,6 @@ class Nav extends React.PureComponent {
     return (
       <ul className="nav__items-right" title="user-menu">
         {getConfig('TRANSLATIONS_ENABLED') && this.renderLanguageMenu(navDropdownState)}
-        <li className="nav__item">
-          <span>{this.props.t('Nav.Auth.Hello')}, {this.props.user.username}!</span>
-        </li>
-        <span className="nav__item-spacer">|</span>
         <li className={navDropdownState.account}>
           <button
             className="nav__item-header"
@@ -642,7 +638,7 @@ class Nav extends React.PureComponent {
               }
             }}
           >
-            {this.props.t('Nav.Auth.MyAccount')}
+            <span>{this.props.t('Nav.Auth.Hello')}, {this.props.user.username}!</span>
             <TriangleIcon className="nav__item-header-triangle" focusable="false" aria-hidden="true" />
           </button>
           <ul className="nav__dropdown">

--- a/client/i18n.js
+++ b/client/i18n.js
@@ -6,6 +6,14 @@ import Backend from 'i18next-http-backend';
 const fallbackLng = ['en-US'];
 const availableLanguages = ['en-US', 'es-419'];
 
+export function languageKeyToLabel(lang) {
+  const languageMap = {
+    'en-US': 'English',
+    'es-419': 'Español'
+  };
+  return languageMap[lang];
+}
+
 const options = {
   loadPath: '/locales/{{lng}}/translations.json',
   requestOptions: { // used for fetch, can also be a function (payload) => ({ method: 'GET' })


### PR DESCRIPTION
✨ Requesting feedback ✨ from @andrewn and @oruburos 

Yesterday, @ghalestrilo and I talked about integrating the translations with the mobile design (#1559). In trying to come up a design for how to select languages on mobile, I was messing around with the desktop design to see if that would generate ideas and I came up with this:

<img width="1552" alt="Screen Shot 2020-08-19 at 2 58 17 PM" src="https://user-images.githubusercontent.com/6063380/90679770-a900db00-e22e-11ea-8143-5b1fe1092f42.png">
<img width="1552" alt="Screen Shot 2020-08-19 at 2 58 12 PM" src="https://user-images.githubusercontent.com/6063380/90679830-be760500-e22e-11ea-802a-df033a1e28e6.png">
<img width="1552" alt="Screen Shot 2020-08-19 at 3 12 48 PM" src="https://user-images.githubusercontent.com/6063380/90679843-c5047c80-e22e-11ea-9bf8-712d41829b49.png">


I don't want to step on your toes so feel free to ignore this, change this, etc.—do what you think is best! I figured I would just put it out there 😄 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`