### PR TITLE
Adding Translation Keys in QuickAddList Component

### DIFF
--- a/client/modules/IDE/components/QuickAddList/QuickAddList.jsx
+++ b/client/modules/IDE/components/QuickAddList/QuickAddList.jsx
@@ -8,7 +8,7 @@ import Icons from './Icons';
 const Item = ({
   isAdded, onSelect, name, url, t
 }) => {
-  const buttonLabel = isAdded ? 'Remove from collection' : 'Add to collection';
+  const buttonLabel = isAdded ? t('QuickAddList.ButtonRemoveARIA') : t('QuickAddList.ButtonAddToCollectionARIA');
   return (
     <li className="quick-add__item" onClick={onSelect}> { /* eslint-disable-line */ }
       <button className="quick-add__item-toggle" onClick={onSelect} aria-label={buttonLabel}>

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -444,8 +444,8 @@
     "AriaLabel": "Close {{title}} overlay"
   },
   "QuickAddList":{
-    "ButtonLabelRemove": "Remove from collection",
-    "ButtonLabelAddToCollection": "Add to collection",
+    "ButtonRemoveARIA": "Remove from collection",
+    "ButtonAddToCollectionARIA": "Add to collection",
     "View": "View"
   },
   "SketchList": {

--- a/translations/locales/es-419/translations.json
+++ b/translations/locales/es-419/translations.json
@@ -444,8 +444,8 @@
     "AriaLabel": "Cerrar la capa {{title}}"
   },
   "QuickAddList":{
-    "ButtonLabelRemove": "Remove from collection",
-    "ButtonLabelAddToCollection": "Add to collection",
+    "ButtonRemoveARIA": "Remover de colección",
+    "ButtonAddToCollectionARIA": "Agregar a colección",
     "View": "Ver"
   },
   "SketchList": {


### PR DESCRIPTION
Fixes #1570

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number`