### PR TITLE
Fix #358 - migrate to S3 policy v4 to support AWS4-HMAC-SHA256

### DIFF
--- a/client/modules/IDE/actions/uploader.js
+++ b/client/modules/IDE/actions/uploader.js
@@ -77,9 +77,6 @@ export function dropzoneSendingCallback(file, xhr, formData) {
       Object.keys(file.postData).forEach((key) => {
         formData.append(key, file.postData[key]);
       });
-      formData.append('Content-type', file.type);
-      formData.append('Content-length', '');
-      formData.append('acl', 'public-read');
     }
   };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12926,6 +12926,11 @@
         "randomfill": "^1.0.3"
       }
     },
+    "crypto-js": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
+      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+    },
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
@@ -33865,10 +33870,26 @@
         "tslib": "^1.9.0"
       }
     },
-    "s3-policy": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/s3-policy/-/s3-policy-0.2.0.tgz",
-      "integrity": "sha1-g8NFMBrv7HSJzmnialFTk1BluKw="
+    "s3-policy-v4": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/s3-policy-v4/-/s3-policy-v4-0.0.3.tgz",
+      "integrity": "sha1-tz7ID4YYDnWE4HUTxzzmKwYLrdc=",
+      "requires": {
+        "buffer": "^4.6.0",
+        "crypto-js": "^3.1.6"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.2",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+          "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "request": "^2.88.2",
     "request-promise": "^4.2.5",
     "reselect": "^4.0.0",
-    "s3-policy": "^0.2.0",
+    "s3-policy-v4": "0.0.3",
     "sass-extract": "^2.1.0",
     "sass-extract-js": "^0.4.0",
     "sass-extract-loader": "^1.1.0",

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -20,9 +20,8 @@ const client = s3.createClient({
   },
 });
 
-const bucketBase = process.env.S3_BUCKET_URL_BASE;
-const s3Url = `https://s3-${process.env.AWS_REGION}.amazonaws.com/${process.env.S3_BUCKET}/`;
-const s3Bucket = bucketBase || s3Url;
+const s3Bucket = process.env.S3_BUCKET_URL_BASE ||
+  `https://s3-${process.env.AWS_REGION}.amazonaws.com/${process.env.S3_BUCKET}/`;
 
 function getExtension(filename) {
   const i = filename.lastIndexOf('.');

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -1,8 +1,11 @@
 import uuid from 'node-uuid';
 import S3Policy from 's3-policy-v4';
 import s3 from '@auth0/s3';
+import mongoose from 'mongoose';
 import { getProjectsForUserId } from './project.controller';
 import { findUserByUsername } from './user.controller';
+
+const { ObjectId } = mongoose.Types;
 
 const client = s3.createClient({
   maxAsyncS3: 20,
@@ -27,15 +30,12 @@ function getExtension(filename) {
 }
 
 export function getObjectKey(url) {
-  const matchResults = url.split(s3Bucket);
-  // if, for some reason, the object is not using the default bucket url
-  if (matchResults.length === 1) {
-    if (bucketBase) {
-      return url.split(s3Url)[1];
-    }
-    return url.split(bucketBase)[1];
+  const urlArray = url.split('/');
+  const objectKey = urlArray.pop();
+  const userId = urlArray.pop();
+  if (ObjectId.isValid(userId) && userId === new ObjectId(userId).toString()) {
+    return `${userId}/${objectKey}`;
   }
-  const objectKey = matchResults[1];
   return objectKey;
 }
 

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -80,7 +80,7 @@ export function signS3(req, res) {
   }
   const fileExtension = getExtension(req.body.name);
   const filename = uuid.v4() + fileExtension;
-  const acl = 'private';
+  const acl = 'public-read';
   const policy = S3Policy.generate({
     acl,
     key: `${req.body.userId}/${filename}`,
@@ -89,7 +89,6 @@ export function signS3(req, res) {
     region: process.env.AWS_REGION,
     accessKey: process.env.AWS_ACCESS_KEY,
     secretKey: process.env.AWS_SECRET_KEY,
-    // metadata: {'x-amz-meta-lat': '41.891',...} (optional)
     metadata: []
   });
   res.json(policy);

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -83,7 +83,7 @@ export function signS3(req, res) {
   const acl = 'private';
   const policy = S3Policy.generate({
     acl,
-    key: filename,
+    key: `${req.body.userId}/${filename}`,
     bucket: process.env.S3_BUCKET,
     contentType: req.body.type,
     region: process.env.AWS_REGION,

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -17,8 +17,9 @@ const client = s3.createClient({
   },
 });
 
-const s3Bucket = process.env.S3_BUCKET_URL_BASE ||
-                 `https://s3-${process.env.AWS_REGION}.amazonaws.com/${process.env.S3_BUCKET}/`;
+const bucketBase = process.env.S3_BUCKET_URL_BASE;
+const s3Url = `https://s3-${process.env.AWS_REGION}.amazonaws.com/${process.env.S3_BUCKET}/`;
+const s3Bucket = bucketBase || s3Url;
 
 function getExtension(filename) {
   const i = filename.lastIndexOf('.');
@@ -26,16 +27,15 @@ function getExtension(filename) {
 }
 
 export function getObjectKey(url) {
-  const urlArray = url.split('/');
-  let objectKey;
-  if (urlArray.length === 5) {
-    const key = urlArray.pop();
-    const userId = urlArray.pop();
-    objectKey = `${userId}/${key}`;
-  } else {
-    const key = urlArray.pop();
-    objectKey = key;
+  const matchResults = url.split(s3Bucket);
+  // if, for some reason, the object is not using the default bucket url
+  if (matchResults.length === 1) {
+    if (bucketBase) {
+      return url.split(s3Url)[1];
+    }
+    return url.split(bucketBase)[1];
   }
+  const objectKey = matchResults[1];
   return objectKey;
 }
 

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -1,5 +1,5 @@
 import uuid from 'node-uuid';
-import policy from 's3-policy';
+import S3Policy from 's3-policy-v4';
 import s3 from '@auth0/s3';
 import { getProjectsForUserId } from './project.controller';
 import { findUserByUsername } from './user.controller';
@@ -80,22 +80,19 @@ export function signS3(req, res) {
   }
   const fileExtension = getExtension(req.body.name);
   const filename = uuid.v4() + fileExtension;
-  const acl = 'public-read';
-  const p = policy({
+  const acl = 'private';
+  const policy = S3Policy.generate({
     acl,
-    secret: process.env.AWS_SECRET_KEY,
-    length: 5000000, // in bytes?
-    bucket: process.env.S3_BUCKET,
     key: filename,
-    expires: new Date(Date.now() + 60000),
+    bucket: process.env.S3_BUCKET,
+    contentType: req.body.type,
+    region: process.env.AWS_REGION,
+    accessKey: process.env.AWS_ACCESS_KEY,
+    secretKey: process.env.AWS_SECRET_KEY,
+    // metadata: {'x-amz-meta-lat': '41.891',...} (optional)
+    metadata: []
   });
-  const result = {
-    AWSAccessKeyId: process.env.AWS_ACCESS_KEY,
-    key: `${req.body.userId}/${filename}`,
-    policy: p.policy,
-    signature: p.signature
-  };
-  res.json(result);
+  res.json(policy);
 }
 
 export function copyObjectInS3(url, userId) {


### PR DESCRIPTION
Fixes #358 so that it works on more AWS regions. I hope it fits your development guidelines, I'm not too acquainted with JS. For some reason I still didn't manage to get it running on non-Amazon S3 services. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`