### PR TITLE
Added translations to codemirror-search

### DIFF
--- a/client/utils/codemirror-search.js
+++ b/client/utils/codemirror-search.js
@@ -236,28 +236,28 @@ export default function(CodeMirror) {
   var getQueryDialog = function() {
     return(`
       <h3 class="CodeMirror-search-title">${i18n.t('Nav.Edit.Find')}</h3>
-      <input type="text" class="search-input CodeMirror-search-field" placeholder="Find in files" />
+      <input type="text" class="search-input CodeMirror-search-field" placeholder="${i18n.t('FindAndReplace.FindPlaceholder')}" />
       <div class="CodeMirror-search-actions">
         <div class="CodeMirror-search-modifiers button-wrap">
           <button
-            title="Regular expression"
-            aria-label="Regular expression"
+            title="${i18n.t('FindAndReplace.Regex')}"
+            aria-label="${i18n.t('FindAndReplace.Regex')}"
             role="checkbox"
             class="CodeMirror-search-modifier-button CodeMirror-regexp-button"
           >
             <span aria-hidden="true" class="button">.*</span>
           </button>
           <button
-            title="Case sensitive"
-            aria-label="Case sensitive"
+            title="${i18n.t('FindAndReplace.CaseSensitive')}"
+            aria-label="${i18n.t('FindAndReplace.CaseSensitive')}"
             role="checkbox"
             class="CodeMirror-search-modifier-button CodeMirror-case-button"
           >
             <span aria-hidden="true" class="button">Aa</span>
           </button>
           <button
-            title="Whole words"
-            aria-label="Whole words"
+            title="${i18n.t('FindAndReplace.WholeWords')}"
+            aria-label="${i18n.t('FindAndReplace.WholeWords')}"
             role="checkbox"
             class="CodeMirror-search-modifier-button CodeMirror-word-button"
           >
@@ -267,22 +267,22 @@ export default function(CodeMirror) {
         <div class="CodeMirror-search-nav">
           <button class="CodeMirror-search-results"></button>
           <button
-            title="Previous"
-            aria-label="Previous"
+            title="${i18n.t('FindAndReplace.Previous')}"
+            aria-label="${i18n.t('FindAndReplace.Previous')}"
             class="CodeMirror-search-button icon up-arrow prev"
           >
           </button>
           <button
-            title="Next"
-            aria-label="Next"
+            title="${i18n.t('FindAndReplace.Next')}"
+            aria-label="${i18n.t('FindAndReplace.Next')}"
             class="CodeMirror-search-button icon down-arrow next"
           >
           </button>
         </div>
       </div>
       <button
-        title="Close"
-        aria-label="Close"
+        title="${i18n.t('FindAndReplace.Close')}"
+        aria-label="${i18n.t('FindAndReplace.Close')}"
         class="CodeMirror-close-button close icon">
       </button>
     `);
@@ -346,7 +346,7 @@ export default function(CodeMirror) {
         findNext(cm, rev);
       }
     } else {
-      dialog(cm, queryDialog, "Search for:", q, function(query) {
+      dialog(cm, queryDialog, `${i18n.t('FindAndReplace.Find')}`, q, function(query) {
         if (query && !state.query) cm.operation(function() {
           startSearch(cm, state, query);
           state.posFrom = state.posTo = cm.getCursor();

--- a/client/utils/codemirror-search.js
+++ b/client/utils/codemirror-search.js
@@ -9,6 +9,7 @@
 // Ctrl-G (or whatever is bound to findNext) press. You prevent a
 // replace by making sure the match is no longer selected when hitting
 // Ctrl-G.
+import i18n from '../i18n';
 
 export default function(CodeMirror) {
   "use strict";
@@ -232,58 +233,60 @@ export default function(CodeMirror) {
     return regexp;
   }
 
-  var queryDialog = `
-    <h3 class="CodeMirror-search-title">Find</h3>
-    <input type="text" class="search-input CodeMirror-search-field" placeholder="Find in files" />
-    <div class="CodeMirror-search-actions">
-      <div class="CodeMirror-search-modifiers button-wrap">
-        <button
-          title="Regular expression"
-          aria-label="Regular expression"
-          role="checkbox"
-          class="CodeMirror-search-modifier-button CodeMirror-regexp-button"
-        >
-          <span aria-hidden="true" class="button">.*</span>
-        </button>
-        <button
-          title="Case sensitive"
-          aria-label="Case sensitive"
-          role="checkbox"
-          class="CodeMirror-search-modifier-button CodeMirror-case-button"
-        >
-          <span aria-hidden="true" class="button">Aa</span>
-        </button>
-        <button
-          title="Whole words"
-          aria-label="Whole words"
-          role="checkbox"
-          class="CodeMirror-search-modifier-button CodeMirror-word-button"
-        >
-          <span aria-hidden="true" class="button">" "</span>
-        </button>
+  var getQueryDialog = function() {
+    return(`
+      <h3 class="CodeMirror-search-title">${i18n.t('Nav.Edit.Find')}</h3>
+      <input type="text" class="search-input CodeMirror-search-field" placeholder="Find in files" />
+      <div class="CodeMirror-search-actions">
+        <div class="CodeMirror-search-modifiers button-wrap">
+          <button
+            title="Regular expression"
+            aria-label="Regular expression"
+            role="checkbox"
+            class="CodeMirror-search-modifier-button CodeMirror-regexp-button"
+          >
+            <span aria-hidden="true" class="button">.*</span>
+          </button>
+          <button
+            title="Case sensitive"
+            aria-label="Case sensitive"
+            role="checkbox"
+            class="CodeMirror-search-modifier-button CodeMirror-case-button"
+          >
+            <span aria-hidden="true" class="button">Aa</span>
+          </button>
+          <button
+            title="Whole words"
+            aria-label="Whole words"
+            role="checkbox"
+            class="CodeMirror-search-modifier-button CodeMirror-word-button"
+          >
+            <span aria-hidden="true" class="button">" "</span>
+          </button>
+        </div>
+        <div class="CodeMirror-search-nav">
+          <button class="CodeMirror-search-results"></button>
+          <button
+            title="Previous"
+            aria-label="Previous"
+            class="CodeMirror-search-button icon up-arrow prev"
+          >
+          </button>
+          <button
+            title="Next"
+            aria-label="Next"
+            class="CodeMirror-search-button icon down-arrow next"
+          >
+          </button>
+        </div>
       </div>
-      <div class="CodeMirror-search-nav">
-        <button class="CodeMirror-search-results"></button>
-        <button
-          title="Previous"
-          aria-label="Previous"
-          class="CodeMirror-search-button icon up-arrow prev"
-        >
-        </button>
-        <button
-          title="Next"
-          aria-label="Next"
-          class="CodeMirror-search-button icon down-arrow next"
-        >
-        </button>
-      </div>
-    </div>
-    <button
-      title="Close"
-      aria-label="Close"
-      class="CodeMirror-close-button close icon">
-    </button>
-  `;
+      <button
+        title="Close"
+        aria-label="Close"
+        class="CodeMirror-close-button close icon">
+      </button>
+    `);
+  }
 
   function startSearch(cm, state, originalQuery) {
     state.queryText = originalQuery;
@@ -302,6 +305,7 @@ export default function(CodeMirror) {
   }
 
   function doSearch(cm, rev, persistent, immediate, ignoreQuery) {
+    var queryDialog = getQueryDialog();
     var state = getSearchState(cm);
     if (!ignoreQuery && state.query) return findNext(cm, rev);
     var q = cm.getSelection() || state.lastQuery;

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -48,6 +48,16 @@
       "LogOut": "Log Out"
     }
   },
+  "FindAndReplace": {
+    "Find": "Find",
+    "FindPlaceholder": "Find in files",
+    "Regex": "Regular expression",
+    "CaseSensitive": "Case sensitive",
+    "WholeWords": "Whole words",
+    "Previous": "Previous",
+    "Next": "Next",
+    "Close": "Close"
+  },
   "LoginForm": {
     "UsernameOrEmail": "Email or Username",
     "UsernameOrEmailARIA": "Email or Username",

--- a/translations/locales/es-419/translations.json
+++ b/translations/locales/es-419/translations.json
@@ -48,6 +48,16 @@
       "LogOut": "Cerrar sesión"
     }
   },
+  "FindAndReplace": {
+    "Find": "Buscar",
+    "FindPlaceholder": "Buscar en archivos",
+    "Regex": "Expresión regular",
+    "CaseSensitive": "Distingue mayúsculas y minúsculas",
+    "WholeWords": "Toda palabra",
+    "Previous": "Previo",
+    "Next": "Próximo",
+    "Close": "Cerca"
+  },
   "LoginForm": {
     "UsernameOrEmail": "Correo o Identificación",
     "UsernameOrEmailARIA": "Introduce Correo o Identificación",


### PR DESCRIPTION
Fixes #1588 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

I have tried to pass the translations by directly importing the `i18n` into `codemirror-search.js`. Please check this out (I have added translation for find on line no 238) & let me know if this approach is fine. If its fine, then I will update rest of the words.