### PR TITLE
Connect the <PreviewFrame /> Component

### DIFF
--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -366,10 +366,12 @@ PreviewFrame.defaultProps = {
 const mapStateToProps = state => ({
   files: state.files,
   htmlFile: getHTMLFile(state.files),
-  ...state.ide,
-  ...state.preferences,
-  ...state.project,
-  ...state.editorAccessibility
+  isPlaying: state.ide.isPlaying,
+  isAccessibleOutputPlaying: state.ide.isAccessibleOutputPlaying,
+  previewIsRefreshing: state.ide.previewIsRefreshing,
+  textOutput: state.preferences.textOutput,
+  gridOutput: state.preferences.gridOutput,
+  soundOutput: state.preferences.soundOutput,
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(

--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -377,20 +377,17 @@ const mapStateToProps = state => ({
 });
 
 
-const mapDispatchToProps = dispatch => bindActionCreators(
-  Object.assign(
-    {},
-    stopSketch,
-    expandConsole,
-    endSketchRefresh,
-    setTextOutput,
-    setGridOutput,
-    setSoundOutput,
-    setBlobUrl,
-    clearConsole,
-    dispatchConsoleEvent,
-  ),
-  dispatch
-);
+const mapDispatchToProps = {
+  stopSketch,
+  expandConsole,
+  endSketchRefresh,
+  setTextOutput,
+  setGridOutput,
+  setSoundOutput,
+  setBlobUrl,
+  clearConsole,
+  dispatchConsoleEvent
+};
+
 
 export default (connect(mapStateToProps, mapDispatchToProps)(PreviewFrame));

--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -366,13 +366,34 @@ PreviewFrame.defaultProps = {
 const mapStateToProps = state => ({
   files: state.files,
   htmlFile: getHTMLFile(state.files),
+  content:
+    (state.files.find(file => file.isSelectedFile) ||
+    state.files.find(file => file.name === 'sketch.js') ||
+    state.files.find(file => file.name !== 'root')).content,
   isPlaying: state.ide.isPlaying,
   isAccessibleOutputPlaying: state.ide.isAccessibleOutputPlaying,
   previewIsRefreshing: state.ide.previewIsRefreshing,
   textOutput: state.preferences.textOutput,
   gridOutput: state.preferences.gridOutput,
   soundOutput: state.preferences.soundOutput,
+  language: state.preferences.language,
+  autorefresh: state.preferences.autorefresh,
 });
+
+
+/*
+  setTextOutput={this.props.setTextOutput}
+  setGridOutput={this.props.setGridOutput}
+  setSoundOutput={this.props.setSoundOutput}
+  dispatchConsoleEvent={this.props.dispatchConsoleEvent}
+  endSketchRefresh={this.props.endSketchRefresh}
+  stopSketch={this.props.stopSketch}
+  setBlobUrl={this.props.setBlobUrl}
+  expandConsole={this.props.expandConsole}
+  clearConsole={this.props.clearConsole}
+  cmController={this.cmController}
+*/
+
 
 const mapDispatchToProps = dispatch => bindActionCreators(
   Object.assign(

--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -7,6 +7,8 @@ import loopProtect from 'loop-protect';
 import { JSHINT } from 'jshint';
 import decomment from 'decomment';
 import classNames from 'classnames';
+import { bindActionCreators } from 'redux';
+import { connect } from 'react-redux';
 import { getBlobUrl } from '../actions/files';
 import { resolvePathToFile } from '../../../../server/utils/filePath';
 import {
@@ -20,6 +22,18 @@ import {
 import { hijackConsoleErrorsScript, startTag, getAllScriptOffsets }
   from '../../../utils/consoleUtils';
 import { registerFrame } from '../../../utils/dispatcher';
+
+import { getHTMLFile } from '../reducers/files';
+import { getIsUserOwner } from '../selectors/users';
+
+import * as FileActions from '../actions/files';
+import * as IDEActions from '../actions/ide';
+import * as ProjectActions from '../actions/project';
+import * as EditorAccessibilityActions from '../actions/editorAccessibility';
+import * as PreferencesActions from '../actions/preferences';
+import * as UserActions from '../../User/actions';
+import * as ToastActions from '../actions/toast';
+import * as ConsoleActions from '../actions/console';
 
 
 const shouldRenderSketch = (props, prevProps = undefined) => {
@@ -350,4 +364,43 @@ PreviewFrame.defaultProps = {
   cmController: {}
 };
 
-export default PreviewFrame;
+const mapStateToProps = state => ({
+  files: state.files,
+  file:
+    state.files.find(file => file.isSelectedFile) ||
+    state.files.find(file => file.name === 'sketch.js') ||
+    state.files.find(file => file.name !== 'root'),
+  htmlFile: getHTMLFile(state.files),
+  ide: state.ide,
+  preferences: state.preferences,
+  editorAccessibility: state.editorAccessibility,
+  user: state.user,
+  project: state.project,
+  toast: state.toast,
+  console: state.console,
+
+  ...state.preferences,
+  ...state.ide,
+  ...state.project,
+  ...state.editorAccessibility,
+  isExpanded: state.ide.sidebarIsExpanded,
+  projectSavedTime: state.project.updatedAt,
+  isUserOwner: getIsUserOwner(state)
+});
+
+const mapDispatchToProps = dispatch => bindActionCreators(
+  Object.assign(
+    {},
+    EditorAccessibilityActions,
+    FileActions,
+    ProjectActions,
+    IDEActions,
+    PreferencesActions,
+    UserActions,
+    ToastActions,
+    ConsoleActions
+  ),
+  dispatch
+);
+
+export default (connect(mapStateToProps, mapDispatchToProps)(PreviewFrame));

--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -24,7 +24,6 @@ import { hijackConsoleErrorsScript, startTag, getAllScriptOffsets }
 import { registerFrame } from '../../../utils/dispatcher';
 
 import { getHTMLFile } from '../reducers/files';
-import { getIsUserOwner } from '../selectors/users';
 
 import * as FileActions from '../actions/files';
 import * as IDEActions from '../actions/ide';
@@ -366,26 +365,11 @@ PreviewFrame.defaultProps = {
 
 const mapStateToProps = state => ({
   files: state.files,
-  file:
-    state.files.find(file => file.isSelectedFile) ||
-    state.files.find(file => file.name === 'sketch.js') ||
-    state.files.find(file => file.name !== 'root'),
   htmlFile: getHTMLFile(state.files),
-  ide: state.ide,
-  preferences: state.preferences,
-  editorAccessibility: state.editorAccessibility,
-  user: state.user,
-  project: state.project,
-  toast: state.toast,
-  console: state.console,
-
-  ...state.preferences,
   ...state.ide,
+  ...state.preferences,
   ...state.project,
-  ...state.editorAccessibility,
-  isExpanded: state.ide.sidebarIsExpanded,
-  projectSavedTime: state.project.updatedAt,
-  isUserOwner: getIsUserOwner(state)
+  ...state.editorAccessibility
 });
 
 const mapDispatchToProps = dispatch => bindActionCreators(

--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -25,14 +25,10 @@ import { registerFrame } from '../../../utils/dispatcher';
 
 import { getHTMLFile } from '../reducers/files';
 
-import * as FileActions from '../actions/files';
-import * as IDEActions from '../actions/ide';
-import * as ProjectActions from '../actions/project';
-import * as EditorAccessibilityActions from '../actions/editorAccessibility';
-import * as PreferencesActions from '../actions/preferences';
-import * as UserActions from '../../User/actions';
-import * as ToastActions from '../actions/toast';
-import * as ConsoleActions from '../actions/console';
+import { stopSketch, expandConsole, endSketchRefresh } from '../actions/ide';
+import { setTextOutput, setGridOutput, setSoundOutput } from '../actions/preferences';
+import { setBlobUrl } from '../actions/files';
+import { clearConsole, dispatchConsoleEvent } from '../actions/console';
 
 
 const shouldRenderSketch = (props, prevProps = undefined) => {
@@ -381,31 +377,18 @@ const mapStateToProps = state => ({
 });
 
 
-/*
-  setTextOutput={this.props.setTextOutput}
-  setGridOutput={this.props.setGridOutput}
-  setSoundOutput={this.props.setSoundOutput}
-  dispatchConsoleEvent={this.props.dispatchConsoleEvent}
-  endSketchRefresh={this.props.endSketchRefresh}
-  stopSketch={this.props.stopSketch}
-  setBlobUrl={this.props.setBlobUrl}
-  expandConsole={this.props.expandConsole}
-  clearConsole={this.props.clearConsole}
-  cmController={this.cmController}
-*/
-
-
 const mapDispatchToProps = dispatch => bindActionCreators(
   Object.assign(
     {},
-    EditorAccessibilityActions,
-    FileActions,
-    ProjectActions,
-    IDEActions,
-    PreferencesActions,
-    UserActions,
-    ToastActions,
-    ConsoleActions
+    stopSketch,
+    expandConsole,
+    endSketchRefresh,
+    setTextOutput,
+    setGridOutput,
+    setSoundOutput,
+    setBlobUrl,
+    clearConsole,
+    dispatchConsoleEvent,
   ),
   dispatch
 );

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -363,7 +363,7 @@ class IDEView extends React.Component {
                       this.props.ide.isPlaying) ||
                       this.props.ide.isAccessibleOutputPlaying}
                   </div>
-                  <PreviewFrame />
+                  <PreviewFrame cmController={this.cmController} />
                 </div>
               </section>
             </SplitPane>

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -363,31 +363,7 @@ class IDEView extends React.Component {
                       this.props.ide.isPlaying) ||
                       this.props.ide.isAccessibleOutputPlaying}
                   </div>
-                  <PreviewFrame
-                    htmlFile={this.props.htmlFile}
-                    files={this.props.files}
-                    content={this.props.selectedFile.content}
-                    isPlaying={this.props.ide.isPlaying}
-                    isAccessibleOutputPlaying={
-                      this.props.ide.isAccessibleOutputPlaying
-                    }
-                    textOutput={this.props.preferences.textOutput}
-                    gridOutput={this.props.preferences.gridOutput}
-                    soundOutput={this.props.preferences.soundOutput}
-                    setTextOutput={this.props.setTextOutput}
-                    setGridOutput={this.props.setGridOutput}
-                    setSoundOutput={this.props.setSoundOutput}
-                    dispatchConsoleEvent={this.props.dispatchConsoleEvent}
-                    autorefresh={this.props.preferences.autorefresh}
-                    previewIsRefreshing={this.props.ide.previewIsRefreshing}
-                    endSketchRefresh={this.props.endSketchRefresh}
-                    stopSketch={this.props.stopSketch}
-                    setBlobUrl={this.props.setBlobUrl}
-                    expandConsole={this.props.expandConsole}
-                    clearConsole={this.props.clearConsole}
-                    cmController={this.cmController}
-                    language={this.props.preferences.language}
-                  />
+                  <PreviewFrame />
                 </div>
               </section>
             </SplitPane>
@@ -566,7 +542,6 @@ IDEView.propTypes = {
     name: PropTypes.string.isRequired,
     content: PropTypes.string.isRequired,
   }).isRequired,
-  dispatchConsoleEvent: PropTypes.func.isRequired,
   newFile: PropTypes.func.isRequired,
   expandSidebar: PropTypes.func.isRequired,
   collapseSidebar: PropTypes.func.isRequired,
@@ -592,10 +567,7 @@ IDEView.propTypes = {
   }).isRequired,
   route: PropTypes.oneOfType([PropTypes.object, PropTypes.element]).isRequired,
   setTheme: PropTypes.func.isRequired,
-  endSketchRefresh: PropTypes.func.isRequired,
-  setBlobUrl: PropTypes.func.isRequired,
   setPreviousPath: PropTypes.func.isRequired,
-  clearConsole: PropTypes.func.isRequired,
   showErrorModal: PropTypes.func.isRequired,
   hideErrorModal: PropTypes.func.isRequired,
   clearPersistedState: PropTypes.func.isRequired,


### PR DESCRIPTION
[#1590] Turning `<PreviewFrame/>` into a container

I added mapStateToProps() and mapDispatchToProps() to `<PreviewFrame/>`.
`<PreviewFrame/>` does not receive any props from `<IDEView />` anymore.
I added connect() to the export.

Linting and npm test don't throw errors.