### PR TITLE
Prevent browser default unload behavior

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -66,7 +66,6 @@ function warnIfUnsavedChanges(props) {
       return false;
     }
     props.setUnsavedChanges(false);
-    return true;
   }
   return true;
 }
@@ -247,7 +246,13 @@ class IDEView extends React.Component {
     }
   }
 
-  handleUnsavedChanges = () => warnIfUnsavedChanges(this.props);
+  handleUnsavedChanges = (event) => {
+    if (!warnIfUnsavedChanges(this.props)) {
+      // See https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload
+      event.preventDefault();
+      event.returnValue = undefined;
+    }
+  }
 
   render() {
     return (


### PR DESCRIPTION
When returning a non-null and non-undefined value from an onbeforeunload handler, causes the browser to show a generic warning dialog.

Before this change, the handle would determine that there are no unsaved changes if there are none, but it would still return a value that signals the browser to show the default dialog.

This change achieves that no dialog is shown if there are no unsaved changes or if we're in a view state where this behavior is undesirable.

Fixes #1633

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`