### PR TITLE
Fix outdated terminology

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Hello! We welcome community contributions to the p5.js Web Editor. Contributing 
 
 ## Code of Conduct
 
-Please follow the guidelines in the [Code of Conduct](https://github.com/processing/p5.js-web-editor/blob/master/.github/CODE_OF_CONDUCT.md).
+Please follow the guidelines in the [Code of Conduct](https://github.com/processing/p5.js-web-editor/blob/develop/.github/CODE_OF_CONDUCT.md).
 
 ## How Can I Contribute?
 If you're new to open source, [read about how to contribute to open source](https://opensource.guide/how-to-contribute/).
@@ -60,7 +60,7 @@ If you feel like an issue is tagged incorrectly (e.g. it's low priority and you 
 
 If you'd like to work on an issue, please comment on it to let the maintainers know, so that they can assign it to you. If someone else has already commented and taken up that issue, please refrain from working on it and submitting a PR without asking the maintainers as it leads to unnecessary duplication of effort.
 
-Then, look at the [development guide](https://github.com/processing/p5.js-web-editor/blob/master/developer_docs/development.md) for instructions on how to install the project locally and follow the right development workflow.
+Then, look at the [development guide](https://github.com/processing/p5.js-web-editor/blob/develop/developer_docs/development.md) for instructions on how to install the project locally and follow the right development workflow.
 
 ### Contribution Guides
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,5 +3,5 @@ Fixes #issue-number
 I have verified that this pull request:
 
 * [ ] has no linting errors (`npm run lint`)
-* [ ] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
+* [ ] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
 * [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -10,7 +10,7 @@ newIssueWelcomeComment: >
 
 # Comment to be posted to on PRs from first time contributors in your repository
 newPRWelcomeComment: >
-  🎉 Thanks for opening this pull request! Please check out our [contributing guidelines](https://github.com/processing/p5.js-web-editor/blob/master/.github/CONTRIBUTING.md) if you haven't already.
+  🎉 Thanks for opening this pull request! Please check out our [contributing guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/.github/CONTRIBUTING.md) if you haven't already.
 
 # Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 Documentation is also available in the following languages:
 
-[한국어](https://github.com/processing/p5.js-web-editor/blob/master/translations/ko)
+[한국어](https://github.com/processing/p5.js-web-editor/blob/develop/translations/ko)
 
 ## Welcome! 👋👋🏿👋🏽👋🏻👋🏾👋🏼
 
@@ -23,7 +23,7 @@ All contributors to the p5.js Web Editor are expected to follow the [Code of Con
 
 The p5.js Web Editor is a collaborative project created by many individuals, and you are invited to help. All types of involvement are welcome! Please check out the [contribution guide](./.github/CONTRIBUTING.md) for more details.
 
-Developers, check the [developer docs](https://github.com/processing/p5.js-web-editor/blob/master/developer_docs/) details about contributing code, bug fixes, and documentation. To start writing code, a great place to start is the [development guide](https://github.com/processing/p5.js-web-editor/blob/master/developer_docs/development.md).
+Developers, check the [developer docs](https://github.com/processing/p5.js-web-editor/blob/develop/developer_docs/) details about contributing code, bug fixes, and documentation. To start writing code, a great place to start is the [development guide](https://github.com/processing/p5.js-web-editor/blob/develop/developer_docs/development.md).
 
 ## Issues
 

--- a/developer_docs/README.md
+++ b/developer_docs/README.md
@@ -1,7 +1,7 @@
 This folder contains documents intended for developers of the p5.js Web Editor. 
 
 ## List of Documents
-* [Contribution Guide](https://github.com/processing/p5.js-web-editor/blob/master/.github/CONTRIBUTING.md) - A place to get started!
+* [Contribution Guide](https://github.com/processing/p5.js-web-editor/blob/develop/.github/CONTRIBUTING.md) - A place to get started!
 * [Installation](installation.md) - A guide for setting up your development environment
 * [Development](development.md) - A guide for adding code to the web editor
 * [Preparing a pull-request](preparing_a_pull_request.md) - Instructions for how to make a pull-request
@@ -11,6 +11,6 @@ This folder contains documents intended for developers of the p5.js Web Editor.
 * [Release](./release.md) - A guide to creating a production release.
 
 ## Documents to Create
-* Design Principles - reference [p5.js design principles](https://github.com/processing/p5.js/edit/master/contributor_docs/design_principles.md)
-* Issue Labels - reference [p5.js issue labels](https://github.com/processing/p5.js/blob/master/contributor_docs/issue_labels.md)
+* Design Principles - reference [p5.js design principles](https://github.com/processing/p5.js/edit/develop/contributor_docs/design_principles.md)
+* Issue Labels - reference [p5.js issue labels](https://github.com/processing/p5.js/blob/develop/contributor_docs/issue_labels.md)
 * File Structure - An explanation of the file structure of this application.

--- a/developer_docs/accessibility.md
+++ b/developer_docs/accessibility.md
@@ -8,13 +8,13 @@ The code for the p5.js web editor adheres to web accessibility standards. The fo
 
 * Screen Readers are an assistive technology for vision loss which helps users to navigate a web page. They are able to prioritize content based on the semantic meaning of HTML tags. Therefore, it is important to use specific tags, such as `nav`, `ul`, `li`, `section`, and so on. `div` is the least screen reader friendly tag. For example, [here is the semantic meaning of the `body` tag](http://html5doctor.com/element-index/#body)
 * All buttons/links/windows need to be accessible by the keyboard ( By tabbing, pressing space etc.)
-* In cases where tags are not screen reader friendly, we can take advantage of [tabIndex](http://webaim.org/techniques/keyboard/tabindex). Using tabIndex ensures that all elements are accessible via keyboard. [code example](https://github.com/processing/p5.js-web-editor/blob/master/client/modules/IDE/components/Editor.jsx#L249)
-* When opening a new window or pop up window, ensure the keyboard focus also moves to the new window. [code example](https://github.com/processing/p5.js-web-editor/blob/master/client/modules/IDE/components/NewFileForm.jsx#L16)
+* In cases where tags are not screen reader friendly, we can take advantage of [tabIndex](http://webaim.org/techniques/keyboard/tabindex). Using tabIndex ensures that all elements are accessible via keyboard. [code example](https://github.com/processing/p5.js-web-editor/blob/develop/client/modules/IDE/components/Editor.jsx#L249)
+* When opening a new window or pop up window, ensure the keyboard focus also moves to the new window. [code example](https://github.com/processing/p5.js-web-editor/blob/develop/client/modules/IDE/components/NewFileForm.jsx#L16)
 
 **Labeling**
 
-* When creating button icons, images, or something without text (this does not include an HTML5 `<button>`), use [aria-labels](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute). [code example](https://github.com/processing/p5.js-web-editor/blob/master/client/modules/IDE/components/Toolbar.jsx#L67)
-* All `<table>`s need to have a `summary` attribute. This will ensure user is given context to what the table is. [code example](https://github.com/processing/p5.js-web-editor/blob/master/client/modules/IDE/components/SketchList.jsx#L39)
-* `ul`s and `nav`s menus need to include a title. [code example](https://github.com/processing/p5.js-web-editor/blob/master/client/components/Nav.jsx#L7)
+* When creating button icons, images, or something without text (this does not include an HTML5 `<button>`), use [aria-labels](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute). [code example](https://github.com/processing/p5.js-web-editor/blob/develop/client/modules/IDE/components/Toolbar.jsx#L67)
+* All `<table>`s need to have a `summary` attribute. This will ensure user is given context to what the table is. [code example](https://github.com/processing/p5.js-web-editor/blob/develop/client/modules/IDE/components/SketchList.jsx#L39)
+* `ul`s and `nav`s menus need to include a title. [code example](https://github.com/processing/p5.js-web-editor/blob/develop/client/components/Nav.jsx#L7)
 
 For more information on accessibility see the [teach access tutorial](https://teachaccess.github.io/tutorial/)

--- a/developer_docs/deployment.md
+++ b/developer_docs/deployment.md
@@ -17,7 +17,7 @@ WIP.
 
 These are the steps that happen when you deploy the application.
 
-1. Push to `master` branch, or merge in a pull request to the `master` branch.
+1. Push to `develop` branch, or merge in a pull request to the `develop` branch.
 2. This triggers a build on [Travis CI](https://travis-ci.org/processing/p5.js-web-editor).
 3. Travis CI builds a (development) Docker image of the whole application.
 4. Travis CI runs some tests, which in this case, is just `npm run lint`. This could be updated in the future to include more extensive tests. If the tests fail, the build stops here.
@@ -46,7 +46,7 @@ _Note_: The installation steps assume you are using a Unix-like shell. If you ar
 If you are interested in hosting and deploying your own p5.js Web Editor instance, you can! It would be the same as the official editor instance at editor.p5js.org, except with a different domain, and you would be in charge of the maintenance. We recommend using Heroku as you can host it for free.
 
 1. Sign up for a free account at: [Heroku](https://www.heroku.com/)
-2. Click here: [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/processing/p5.js-web-editor/tree/master)
+2. Click here: [![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/processing/p5.js-web-editor/tree/develop)
 3. Enter a unique *App name*, this will become part of the url (i.e. https://app-name.herokuapp.com/)
 4. Update any configuration variables, or accept the defaults for a quick evaluation (they can be changed later to enable full functionality)
 5. Click on the "Deploy app" button

--- a/developer_docs/preparing_a_pull_request.md
+++ b/developer_docs/preparing_a_pull_request.md
@@ -28,11 +28,11 @@ Then ask git about the latest changes.
 ### Just in case: make a copy of your changes in a new branch
     git branch your-branch-name-backup
 
-### Apply changes from master branch, adds your changes *after*
-    git rebase upstream/master
+### Apply changes from develop branch, adds your changes *after*
+    git rebase upstream/develop
 
-### Switches back to master branch
-    git checkout master
+### Switches back to develop branch
+    git checkout develop
 
 ### Helps other contributors fully understand the changes that you made
     git commit -m "Fixed documentation typos"   
@@ -41,7 +41,7 @@ Then ask git about the latest changes.
     git status       
 
 ## CONFLICTS
-You may have some conflicts! It's okay. Feel free to ask for help. If merging with the latest upstream master causes conflicts, you can always make a pull request with the upstream repository, which makes the merge conflicts public.
+You may have some conflicts! It's okay. Feel free to ask for help. If merging with the latest upstream `develop` branch causes conflicts, you can always make a pull request with the upstream repository, which makes the merge conflicts public.
 
 ## And finally, for great glory
     git push --set-upstream origin your-branch-name-backup

--- a/server/views/404Page.js
+++ b/server/views/404Page.js
@@ -110,11 +110,11 @@ export function get404Sketch(callback) {
         // Fix links to assets
         htmlFile = htmlFile.replace(
           /'assets/g,
-          "'https://rawgit.com/processing/p5.js-website/master/dist/assets/examples/assets/"
+          "'https://rawgit.com/processing/p5.js-website/main/dist/assets/examples/assets/"
         );
         htmlFile = htmlFile.replace(
           /"assets/g,
-          '"https://rawgit.com/processing/p5.js-website/master/dist/assets/examples/assets/'
+          '"https://rawgit.com/processing/p5.js-website/main/dist/assets/examples/assets/'
         );
 
         // Change canvas size

--- a/translations/ko/CONTRIBUTING.md
+++ b/translations/ko/CONTRIBUTING.md
@@ -20,7 +20,7 @@
   
 ## 행동 수칙
 
-[행동 수칙](https://github.com/processing/p5.js-web-editor/blob/master/.github/CODE_OF_CONDUCT.md)에 있는 가이드라인을 따라주시기 바랍니다.
+[행동 수칙](https://github.com/processing/p5.js-web-editor/blob/develop/.github/CODE_OF_CONDUCT.md)에 있는 가이드라인을 따라주시기 바랍니다.
 
 ## 어떻게 기여할 수 있을까요?
 만약 오픈 소스에 기여하는 게 처음이신 경우라면, [오픈 소스에 어떻게 기여할 수 있는지](https://opensource.guide/how-to-contribute/)를 읽어주시기 바랍니다.
@@ -60,7 +60,7 @@
 
 어떤 이슈를 위한 작업을 시작하고 싶다면, 해당 이슈에 댓글을 달아서 관리자들에게 이를 알려 이슈를 할당 받으시기 바랍니다. 만약 다른 사람이 이미 해당 이슈에 댓글을 달았고 작업을 하기로 되어 있다면, 불필요한 중복 문제를 피하기 위해 해당 이슈와 관련된 작업을 하거나 관리자에게 묻지 않은 채로 풀 리퀘스트를 제출하는 일은 삼가주시기 바랍니다.
 
-이제 여러분의 컴퓨터에서 프로젝트를 빌드하고 작업을 하기 위해 [설치 가이드](https://github.com/processing/p5.js-web-editor/blob/master/developer_docs/installation.md)를 따라 주시기 바랍니다.
+이제 여러분의 컴퓨터에서 프로젝트를 빌드하고 작업을 하기 위해 [설치 가이드](https://github.com/processing/p5.js-web-editor/blob/develop/developer_docs/installation.md)를 따라 주시기 바랍니다.
 
 ### 기여 가이드
 

--- a/translations/ko/README.md
+++ b/translations/ko/README.md
@@ -16,7 +16,7 @@ p5.js 웹 에디터의 모든 컨트리뷰터들은 다음의 [행동 수칙](./
 
 p5.js 웹 에디터는 다수의 개인들에 의해 만들어진 협력 프로젝트이며, 여러분 역시 도움을 주실 수 있습니다. 모든 종류의 참여를 환영합니다! 더 자세한 사항을 위해서는 [기여 안내](./.github/CONTRIBUTING.md)를 확인하시기 바랍니다.
 
-개발자 분들은 코드 기여, 버그 수정, 문서화에 대한 세부 사항을 [개발자 문서](https://github.com/processing/p5.js-web-editor/blob/master/developer_docs/)에서 확인하시기 바랍니다. 코드 작성을 시작하기 위한 좋은 시작점은 [개발 안내](https://github.com/processing/p5.js-web-editor/blob/master/developer_docs/development.md)를 살펴보는 것입니다.
+개발자 분들은 코드 기여, 버그 수정, 문서화에 대한 세부 사항을 [개발자 문서](https://github.com/processing/p5.js-web-editor/blob/develop/developer_docs/)에서 확인하시기 바랍니다. 코드 작성을 시작하기 위한 좋은 시작점은 [개발 안내](https://github.com/processing/p5.js-web-editor/blob/develop/developer_docs/development.md)를 살펴보는 것입니다.
 
 ## 이슈
 


### PR DESCRIPTION
The new branch names have not made it into all the documentation yet. This change fixes that.

If I need to create a dedicated issue prior to this, please let me know.

I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`