### PR TITLE
Add Docker instructions

### DIFF
--- a/developer_docs/installation.md
+++ b/developer_docs/installation.md
@@ -24,6 +24,7 @@ _Note_: The installation steps assume you are using a Unix-like shell. If you ar
 6. Install MongoDB and make sure it is running
    * For Mac OSX with [homebrew](http://brew.sh/): `brew tap mongodb/brew` then `brew install mongodb-community` and finally start the server with `brew services start mongodb-community` or you can visit the installation guide here [Installation Guide For MacOS](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/)
    * For Windows and Linux: [MongoDB Installation](https://docs.mongodb.com/manual/installation/)
+   * For Docker on any platform use: `docker run -d -p 27017:27017 mongo`
 7. `$ cp .env.example .env`
 8. (Optional) Update `.env` with necessary keys to enable certain app behaviors, i.e. add Github ID and Github Secret if you want to be able to log in with Github.
 9. `$ npm run fetch-examples` - this downloads the example sketches into a user called 'p5'


### PR DESCRIPTION
If users already have access to Docker, starting a MongoDB instance in Docker can be a very quick and convenient way to get started with development.

Fixes #1646

I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] is from a uniquely-named feature branch and has been rebased on top of the latest master. (If I was asked to make more changes, I have made sure to rebase onto master then too)
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`