### PR TITLE
Added sorting options on collections

### DIFF
--- a/client/modules/IDE/selectors/collections.js
+++ b/client/modules/IDE/selectors/collections.js
@@ -4,7 +4,12 @@ import find from 'lodash/find';
 import orderBy from 'lodash/orderBy';
 import { DIRECTION } from '../actions/sorting';
 
-const getCollections = state => state.collections;
+const getCollections = (state, id) => {
+  if (id !== undefined) {
+    return find(state.collections, { id });
+  }
+  return state.collections;
+};
 const getField = state => state.sorting.field;
 const getDirection = state => state.sorting.direction;
 const getSearchTerm = state => state.search.collectionSearchTerm;
@@ -32,30 +37,49 @@ const getSortedCollections = createSelector(
   getField,
   getDirection,
   (collections, field, direction) => {
-    if (field === 'name') {
-      if (direction === DIRECTION.DESC) {
-        return orderBy(collections, 'name', 'desc');
+    console.log(collections);
+    if (Array.isArray(collections)) {
+      if (field === 'name') {
+        if (direction === DIRECTION.DESC) {
+          return orderBy(collections, 'name', 'desc');
+        }
+        return orderBy(collections, 'name', 'asc');
+      } else if (field === 'numItems') {
+        if (direction === DIRECTION.DESC) {
+          return orderBy(collections, 'items.length', 'desc');
+        }
+        return orderBy(collections, 'items.length', 'asc');
       }
-      return orderBy(collections, 'name', 'asc');
-    } else if (field === 'numItems') {
-      if (direction === DIRECTION.DESC) {
-        return orderBy(collections, 'items.length', 'desc');
+      const sortedCollections = [...collections].sort((a, b) => {
+        const result =
+          direction === DIRECTION.ASC
+            ? differenceInMilliseconds(new Date(a[field]), new Date(b[field]))
+            : differenceInMilliseconds(new Date(b[field]), new Date(a[field]));
+        return result;
+      });
+      return sortedCollections;
+    } else if (typeof collections === 'object') {
+      if (field === 'name') {
+        if (direction === DIRECTION.DESC) {
+          return { ...collections, items: orderBy(collections.items, 'project.name', 'desc') };
+        }
+        return { ...collections, items: orderBy(collections.items, 'project.name', 'asc') };
+      } else if (field === 'user') {
+        if (direction === DIRECTION.DESC) {
+          return { ...collections, items: orderBy(collections.items, 'project.user.username', 'desc') };
+        }
+        return { ...collections, items: orderBy(collections.items, 'project.user.username', 'asc') };
       }
-      return orderBy(collections, 'items.length', 'asc');
+      const sortedCollections = [...collections.items].sort((a, b) => {
+        const result =
+          direction === DIRECTION.ASC
+            ? differenceInMilliseconds(new Date(a[field]), new Date(b[field]))
+            : differenceInMilliseconds(new Date(b[field]), new Date(a[field]));
+        return result;
+      });
+      return { ...collections, items: sortedCollections };
     }
-    const sortedCollections = [...collections].sort((a, b) => {
-      const result =
-        direction === DIRECTION.ASC
-          ? differenceInMilliseconds(new Date(a[field]), new Date(b[field]))
-          : differenceInMilliseconds(new Date(b[field]), new Date(a[field]));
-      return result;
-    });
-    return sortedCollections;
+    return collections;
   }
 );
-
-export function getCollection(state, id) {
-  return find(getCollections(state), { id });
-}
-
 export default getSortedCollections;

--- a/client/modules/User/components/Collection.jsx
+++ b/client/modules/User/components/Collection.jsx
@@ -15,7 +15,7 @@ import * as CollectionsActions from '../../IDE/actions/collections';
 import * as ToastActions from '../../IDE/actions/toast';
 import * as SortingActions from '../../IDE/actions/sorting';
 import * as IdeActions from '../../IDE/actions/ide';
-import { getCollection } from '../../IDE/selectors/collections';
+import getSortedCollections, { getCollection } from '../../IDE/selectors/collections';
 import Loader from '../../App/components/loader';
 import EditableInput from '../../IDE/components/EditableInput';
 import Overlay from '../../App/components/Overlay';
@@ -196,7 +196,7 @@ class Collection extends React.Component {
   }
 
   hasCollectionItems() {
-    return this.hasCollection() && this.props.collection.items.length > 0;
+    return this.hasCollection() && this.props.collection && this.props.collection.items.length > 0;
   }
 
   _renderLoader() {
@@ -303,8 +303,7 @@ class Collection extends React.Component {
 
   _renderEmptyTable() {
     const isLoading = this.props.loading;
-    const hasCollectionItems = this.props.collection != null &&
-      this.props.collection.items.length > 0;
+    const hasCollectionItems = this.props.collection != null && this.props.collection && this.props.collection.items.length > 0;
 
     if (!isLoading && !hasCollectionItems) {
       return (<p className="collection-empty-message">{this.props.t('Collection.NoSketches')}</p>);
@@ -332,7 +331,7 @@ class Collection extends React.Component {
   _renderFieldHeader(fieldName, displayName) {
     const { field, direction } = this.props.sorting;
     const headerClass = classNames({
-      'arrowDown': true,
+      'sketches-table__header': true,
       'sketches-table__header--selected': field === fieldName
     });
     const buttonLabel = this._getButtonLabel(fieldName, displayName);
@@ -459,7 +458,7 @@ Collection.defaultProps = {
 function mapStateToProps(state, ownProps) {
   return {
     user: state.user,
-    collection: getCollection(state, ownProps.collectionId),
+    collection: getSortedCollections(state, ownProps.collectionId),
     sorting: state.sorting,
     loading: state.loading,
     project: state.project


### PR DESCRIPTION
Fixes #1652 

I have added the code for sorting via various parameters present on the table on the given routes:
```
1) /:username/collections
2) /:username/collections/:collection_id
```
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
