### PR TITLE
Fix PropTypes.object() linting errors

### DIFF
--- a/client/components/mobile/ActionStrip.jsx
+++ b/client/components/mobile/ActionStrip.jsx
@@ -38,7 +38,7 @@ const ActionStrip = ({ actions }) => (
 
 ActionStrip.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.shape({
-    icon: PropTypes.any,
+    icon: PropTypes.any, //eslint-disable-line
     aria: PropTypes.string.isRequired,
     action: PropTypes.func.isRequired,
     inverted: PropTypes.bool

--- a/client/components/mobile/ActionStrip.jsx
+++ b/client/components/mobile/ActionStrip.jsx
@@ -38,7 +38,7 @@ const ActionStrip = ({ actions }) => (
 
 ActionStrip.propTypes = {
   actions: PropTypes.arrayOf(PropTypes.shape({
-    icon: PropTypes.any, //eslint-disable-line
+    icon: PropTypes.component,
     aria: PropTypes.string.isRequired,
     action: PropTypes.func.isRequired,
     inverted: PropTypes.bool

--- a/client/modules/IDE/components/NewFileForm.jsx
+++ b/client/modules/IDE/components/NewFileForm.jsx
@@ -58,7 +58,7 @@ class NewFileForm extends React.Component {
 
 NewFileForm.propTypes = {
   fields: PropTypes.shape({
-    name: PropTypes.objectOf(PropTypes.shape())
+    name: PropTypes.objectOf(PropTypes.shape()).isRequired
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   createFile: PropTypes.func.isRequired,

--- a/client/modules/IDE/components/NewFileForm.jsx
+++ b/client/modules/IDE/components/NewFileForm.jsx
@@ -58,7 +58,7 @@ class NewFileForm extends React.Component {
 
 NewFileForm.propTypes = {
   fields: PropTypes.shape({
-    name: PropTypes.object.isRequired
+    name: PropTypes.objectOf(PropTypes.shape())
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   createFile: PropTypes.func.isRequired,

--- a/client/modules/IDE/components/NewFolderForm.jsx
+++ b/client/modules/IDE/components/NewFolderForm.jsx
@@ -56,7 +56,7 @@ class NewFolderForm extends React.Component {
 
 NewFolderForm.propTypes = {
   fields: PropTypes.shape({
-    name: PropTypes.object.isRequired
+    name: PropTypes.objectOf(PropTypes.shape())
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   createFolder: PropTypes.func.isRequired,

--- a/client/modules/IDE/components/NewFolderForm.jsx
+++ b/client/modules/IDE/components/NewFolderForm.jsx
@@ -56,7 +56,7 @@ class NewFolderForm extends React.Component {
 
 NewFolderForm.propTypes = {
   fields: PropTypes.shape({
-    name: PropTypes.objectOf(PropTypes.shape())
+    name: PropTypes.objectOf(PropTypes.shape()).isRequired
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   createFolder: PropTypes.func.isRequired,

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -495,7 +495,7 @@ IDEView.propTypes = {
     updatedAt: PropTypes.string,
   }).isRequired,
   editorAccessibility: PropTypes.shape({
-    lintMessages: PropTypes.objectOf(PropTypes.shape()),
+    lintMessages: PropTypes.objectOf(PropTypes.shape()).isRequired,
   }).isRequired,
   preferences: PropTypes.shape({
     autosave: PropTypes.bool.isRequired,

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -495,7 +495,7 @@ IDEView.propTypes = {
     updatedAt: PropTypes.string,
   }).isRequired,
   editorAccessibility: PropTypes.shape({
-    lintMessages: PropTypes.array.isRequired, // eslint-disable-line
+    lintMessages: PropTypes.objectOf(PropTypes.shape()),
   }).isRequired,
   preferences: PropTypes.shape({
     autosave: PropTypes.bool.isRequired,

--- a/client/modules/User/components/APIKeyForm.jsx
+++ b/client/modules/User/components/APIKeyForm.jsx
@@ -7,8 +7,8 @@ import CopyableInput from '../../IDE/components/CopyableInput';
 import APIKeyList from './APIKeyList';
 
 export const APIKeyPropType = PropTypes.shape({
-  id: PropTypes.object.isRequired, // eslint-disable-line
-  token: PropTypes.object, // eslint-disable-line
+  id: PropTypes.objectOf(PropTypes.shape()),
+  token: PropTypes.objectOf(PropTypes.shape()),
   label: PropTypes.string.isRequired,
   createdAt: PropTypes.string.isRequired,
   lastUsedAt: PropTypes.string

--- a/client/modules/User/components/APIKeyForm.jsx
+++ b/client/modules/User/components/APIKeyForm.jsx
@@ -7,7 +7,7 @@ import CopyableInput from '../../IDE/components/CopyableInput';
 import APIKeyList from './APIKeyList';
 
 export const APIKeyPropType = PropTypes.shape({
-  id: PropTypes.objectOf(PropTypes.shape()),
+  id: PropTypes.objectOf(PropTypes.shape()).isRequired,
   token: PropTypes.objectOf(PropTypes.shape()),
   label: PropTypes.string.isRequired,
   createdAt: PropTypes.string.isRequired,

--- a/client/modules/User/components/AccountForm.jsx
+++ b/client/modules/User/components/AccountForm.jsx
@@ -109,10 +109,10 @@ function AccountForm(props) {
 
 AccountForm.propTypes = {
   fields: PropTypes.shape({
-    username: PropTypes.objectOf(PropTypes.shape()),
-    email: PropTypes.objectOf(PropTypes.shape()),
-    currentPassword: PropTypes.objectOf(PropTypes.shape()),
-    newPassword: PropTypes.objectOf(PropTypes.shape()),
+    username: PropTypes.objectOf(PropTypes.shape()).isRequired,
+    email: PropTypes.objectOf(PropTypes.shape()).isRequired,
+    currentPassword: PropTypes.objectOf(PropTypes.shape()).isRequired,
+    newPassword: PropTypes.objectOf(PropTypes.shape()).isRequired,
   }).isRequired,
   user: PropTypes.shape({
     verified: PropTypes.string.isRequired,

--- a/client/modules/User/components/AccountForm.jsx
+++ b/client/modules/User/components/AccountForm.jsx
@@ -109,10 +109,10 @@ function AccountForm(props) {
 
 AccountForm.propTypes = {
   fields: PropTypes.shape({
-    username: PropTypes.object.isRequired, // eslint-disable-line
-    email: PropTypes.object.isRequired, // eslint-disable-line
-    currentPassword: PropTypes.object.isRequired, // eslint-disable-line
-    newPassword: PropTypes.object.isRequired, // eslint-disable-line
+    username: PropTypes.objectOf(PropTypes.shape()),
+    email: PropTypes.objectOf(PropTypes.shape()),
+    currentPassword: PropTypes.objectOf(PropTypes.shape()),
+    newPassword: PropTypes.objectOf(PropTypes.shape()),
   }).isRequired,
   user: PropTypes.shape({
     verified: PropTypes.string.isRequired,

--- a/client/modules/User/components/LoginForm.jsx
+++ b/client/modules/User/components/LoginForm.jsx
@@ -54,8 +54,8 @@ function LoginForm(props) {
 
 LoginForm.propTypes = {
   fields: PropTypes.shape({
-    email: PropTypes.object.isRequired, // eslint-disable-line
-    password: PropTypes.object.isRequired, // eslint-disable-line
+    email: PropTypes.objectOf(PropTypes.shape()),
+    password: PropTypes.objectOf(PropTypes.shape()),
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   validateAndLoginUser: PropTypes.func.isRequired,

--- a/client/modules/User/components/LoginForm.jsx
+++ b/client/modules/User/components/LoginForm.jsx
@@ -54,8 +54,8 @@ function LoginForm(props) {
 
 LoginForm.propTypes = {
   fields: PropTypes.shape({
-    email: PropTypes.objectOf(PropTypes.shape()),
-    password: PropTypes.objectOf(PropTypes.shape()),
+    email: PropTypes.objectOf(PropTypes.shape()).isRequired,
+    password: PropTypes.objectOf(PropTypes.shape()).isRequired,
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   validateAndLoginUser: PropTypes.func.isRequired,

--- a/client/modules/User/components/NewPasswordForm.jsx
+++ b/client/modules/User/components/NewPasswordForm.jsx
@@ -47,8 +47,8 @@ function NewPasswordForm(props) {
 
 NewPasswordForm.propTypes = {
   fields: PropTypes.shape({
-    password: PropTypes.objectOf(PropTypes.shape()),
-    confirmPassword: PropTypes.objectOf(PropTypes.shape()),
+    password: PropTypes.objectOf(PropTypes.shape()).isRequired,
+    confirmPassword: PropTypes.objectOf(PropTypes.shape()).isRequired,
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   updatePassword: PropTypes.func.isRequired,

--- a/client/modules/User/components/NewPasswordForm.jsx
+++ b/client/modules/User/components/NewPasswordForm.jsx
@@ -47,8 +47,8 @@ function NewPasswordForm(props) {
 
 NewPasswordForm.propTypes = {
   fields: PropTypes.shape({
-    password: PropTypes.object.isRequired, // eslint-disable-line
-    confirmPassword: PropTypes.object.isRequired, // eslint-disable-line
+    password: PropTypes.objectOf(PropTypes.shape()),
+    confirmPassword: PropTypes.objectOf(PropTypes.shape()),
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   updatePassword: PropTypes.func.isRequired,

--- a/client/modules/User/components/ResetPasswordForm.jsx
+++ b/client/modules/User/components/ResetPasswordForm.jsx
@@ -37,7 +37,7 @@ function ResetPasswordForm(props) {
 
 ResetPasswordForm.propTypes = {
   fields: PropTypes.shape({
-    email: PropTypes.object.isRequired
+    email: PropTypes.objectOf(PropTypes.shape())
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   initiateResetPassword: PropTypes.func.isRequired,

--- a/client/modules/User/components/ResetPasswordForm.jsx
+++ b/client/modules/User/components/ResetPasswordForm.jsx
@@ -37,7 +37,7 @@ function ResetPasswordForm(props) {
 
 ResetPasswordForm.propTypes = {
   fields: PropTypes.shape({
-    email: PropTypes.objectOf(PropTypes.shape())
+    email: PropTypes.objectOf(PropTypes.shape()).isRequired
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   initiateResetPassword: PropTypes.func.isRequired,

--- a/client/modules/User/components/SignupForm.jsx
+++ b/client/modules/User/components/SignupForm.jsx
@@ -83,10 +83,10 @@ function SignupForm(props) {
 
 SignupForm.propTypes = {
   fields: PropTypes.shape({
-    username: PropTypes.object.isRequired, // eslint-disable-line
-    email: PropTypes.object.isRequired, // eslint-disable-line
-    password: PropTypes.object.isRequired, // eslint-disable-line
-    confirmPassword: PropTypes.object.isRequired, // eslint-disable-line
+    username: PropTypes.objectOf(PropTypes.shape()),
+    email: PropTypes.objectOf(PropTypes.shape()),
+    password: PropTypes.objectOf(PropTypes.shape()),
+    confirmPassword: PropTypes.objectOf(PropTypes.shape()),
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   signUpUser: PropTypes.func.isRequired,

--- a/client/modules/User/components/SignupForm.jsx
+++ b/client/modules/User/components/SignupForm.jsx
@@ -83,10 +83,10 @@ function SignupForm(props) {
 
 SignupForm.propTypes = {
   fields: PropTypes.shape({
-    username: PropTypes.objectOf(PropTypes.shape()),
-    email: PropTypes.objectOf(PropTypes.shape()),
-    password: PropTypes.objectOf(PropTypes.shape()),
-    confirmPassword: PropTypes.objectOf(PropTypes.shape()),
+    username: PropTypes.objectOf(PropTypes.shape()).isRequired,
+    email: PropTypes.objectOf(PropTypes.shape()).isRequired,
+    password: PropTypes.objectOf(PropTypes.shape()).isRequired,
+    confirmPassword: PropTypes.objectOf(PropTypes.shape()).isRequired,
   }).isRequired,
   handleSubmit: PropTypes.func.isRequired,
   signUpUser: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixes #1514 
I have replaced all the instances of `PropTypes.object.isRequired` with `PropTypes.objectOf(PropTypes.shape())` in the following files:
- IDEView.jsx
- AccountForm.jsx
- LoginForm.jsx
- NewPasswordForm.jsx
- SignupForm.jsx
- ResetPasswordForm.jsx
- APIKeyForm.jsx
- NewFileForm.jsx
- NewFolderForm.jsx

Also, while debugging those errors I encountered a linting error with `PropTypes.any` in **ActionStrip.jsx** which I disabled by using `//eslint-disable-line` for the time being.

I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`
