### PR TITLE
removed linting from webpack

### DIFF
--- a/webpack/config.dev.js
+++ b/webpack/config.dev.js
@@ -1,128 +1,121 @@
-const webpack = require('webpack');
-const path = require('path');
-const CopyWebpackPlugin = require('copy-webpack-plugin')
+const webpack = require("webpack");
+const path = require("path");
+const CopyWebpackPlugin = require("copy-webpack-plugin");
 
-if (process.env.NODE_ENV === 'development') {
-  require('dotenv').config();
+if (process.env.NODE_ENV === "development") {
+  require("dotenv").config();
 }
-
 
 // react hmr being fucked up has to do with the multiple entries!!! cool.
 module.exports = {
-  mode: 'development',
-  devtool: 'cheap-module-eval-source-map',
+  mode: "development",
+  devtool: "cheap-module-eval-source-map",
   entry: {
     app: [
-      'core-js/modules/es6.promise',
-      'core-js/modules/es6.array.iterator',
-      'webpack-hot-middleware/client',
-      'react-hot-loader/patch',
-      './client/index.jsx',
+      "core-js/modules/es6.promise",
+      "core-js/modules/es6.array.iterator",
+      "webpack-hot-middleware/client",
+      "react-hot-loader/patch",
+      "./client/index.jsx",
     ],
     previewScripts: [
-       path.resolve(__dirname, '../client/utils/previewEntry.js')
-    ]
+      path.resolve(__dirname, "../client/utils/previewEntry.js"),
+    ],
   },
   output: {
     path: `${__dirname}`,
-    filename: '[name].js',
-    publicPath: '/'
+    filename: "[name].js",
+    publicPath: "/",
   },
   resolve: {
-    extensions: ['.js', '.jsx'],
-    modules: [
-      'client',
-      'node_modules'
-    ]
+    extensions: [".js", ".jsx"],
+    modules: ["client", "node_modules"],
   },
   plugins: [
     new webpack.HotModuleReplacementPlugin(),
     new webpack.DefinePlugin({
-      'process.env': {
-        NODE_ENV: JSON.stringify('development')
-      }
+      "process.env": {
+        NODE_ENV: JSON.stringify("development"),
+      },
     }),
     new CopyWebpackPlugin({
-        patterns: [
-          {from: path.resolve(__dirname, '../translations/locales') , to: path.resolve(__dirname, 'locales')}
-        ]
-      }
-    )
+      patterns: [
+        {
+          from: path.resolve(__dirname, "../translations/locales"),
+          to: path.resolve(__dirname, "locales"),
+        },
+      ],
+    }),
   ],
   module: {
     rules: [
       {
         test: /\.jsx?$/,
         exclude: [/node_modules/, /.+\.config.js/],
-        use: [{
-          loader: 'babel-loader',
-          options: {
-            cacheDirectory: true,
-            plugins: ['react-hot-loader/babel'],
-          }
-        }, {
-          loader: 'eslint-loader'
-        }]
-        // use: {
-        //   loader: 'babel-loader',
-        //   options: {
-        //     cacheDirectory: true,
-        //     plugins: ['react-hot-loader/babel'],
-        //   }
-        // }
+        use: [
+          {
+            loader: "babel-loader",
+            options: {
+              cacheDirectory: true,
+              plugins: ["react-hot-loader/babel"],
+            },
+          },
+        ],
       },
       {
         test: /main\.scss$/,
-        use: ['style-loader', 'css-loader', 'sass-loader']
+        use: ["style-loader", "css-loader", "sass-loader"],
       },
       {
         test: /\.(mp3)$/,
-        use: 'file-loader'
+        use: "file-loader",
       },
       {
         test: /\.(png)$/,
         use: {
-          loader: 'file-loader',
+          loader: "file-loader",
           options: {
-            name: '[name].[ext]',
-            outputPath: 'images/'
-          }
-         }
+            name: "[name].[ext]",
+            outputPath: "images/",
+          },
+        },
       },
       {
         test: /fonts\/.*\.(eot|ttf|woff|woff2)$/,
-        use: 'file-loader'
+        use: "file-loader",
       },
       {
         test: /\.svg$/,
         oneOf: [
           {
             resourceQuery: /byUrl/,
-            use: 'file-loader'
+            use: "file-loader",
           },
           {
             use: {
-              loader: '@svgr/webpack',
+              loader: "@svgr/webpack",
               options: {
                 svgoConfig: {
                   plugins: {
-                    removeViewBox: false
-                  }
-                }
-              }
-            }
-          }
-        ]
+                    removeViewBox: false,
+                  },
+                },
+              },
+            },
+          },
+        ],
       },
       {
         test: /_console-feed.scss/,
         use: {
-          loader: 'sass-extract-loader',
+          loader: "sass-extract-loader",
           options: {
-            plugins: [{ plugin: 'sass-extract-js', options: { camelCase: false } }]
-          }
-        }
-      }
+            plugins: [
+              { plugin: "sass-extract-js", options: { camelCase: false } },
+            ],
+          },
+        },
+      },
     ],
   },
 };


### PR DESCRIPTION
Fixes #625 

Removed linting from Webpack. Now Webpack build is much faster than before. On my system, Webpack build with linting took  130540ms and Webpack build without linting took 57886ms. The build time has reduced by 60%. 

Hey @catarak, please review this PR.


