### PR TITLE
Added Remember me option using Passport remember-me strategy

### DIFF
--- a/client/modules/User/components/LoginForm.jsx
+++ b/client/modules/User/components/LoginForm.jsx
@@ -15,7 +15,7 @@ function LoginForm(props) {
 
   return (
     <Form
-      fields={['email', 'password']}
+      fields={['email', 'password', 'remember']}
       validate={validateLogin}
       onSubmit={onSubmit}
     >
@@ -57,6 +57,14 @@ function LoginForm(props) {
                   <span className="form-error">{field.meta.error}</span>
                 )}
               </p>
+            )}
+          </Field>
+          <Field name="remember">
+            {(field) => (
+              <div className="form__field">
+                <p style={{ display: 'inline-block' }}>Remember me</p>
+                <input type="checkbox" id="remember-me" {...field.input} />
+              </div>
             )}
           </Field>
           <Button type="submit" disabled={submitting || invalid || pristine}>

--- a/package-lock.json
+++ b/package-lock.json
@@ -12575,7 +12575,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },
@@ -19274,7 +19275,8 @@
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
@@ -30956,6 +30958,26 @@
         "utils-merge": "1.x.x"
       }
     },
+    "passport-remember-me": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/passport-remember-me/-/passport-remember-me-0.0.1.tgz",
+      "integrity": "sha1-CqYJXIJID0RhlFau82PMuSm8K8M=",
+      "requires": {
+        "passport": "~0.1.1",
+        "pkginfo": "0.2.x"
+      },
+      "dependencies": {
+        "passport": {
+          "version": "0.1.18",
+          "resolved": "https://registry.npmjs.org/passport/-/passport-0.1.18.tgz",
+          "integrity": "sha1-yCZEedy2QUytu2Z1LRKzfgtlJaE=",
+          "requires": {
+            "pause": "0.0.1",
+            "pkginfo": "0.2.x"
+          }
+        }
+      }
+    },
     "passport-strategy": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
@@ -31149,6 +31171,11 @@
           "dev": true
         }
       }
+    },
+    "pkginfo": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.2.3.tgz",
+      "integrity": "sha1-cjnEKl72wwuPMoQ52bn/cQQkkPg="
     },
     "please-upgrade-node": {
       "version": "3.2.0",
@@ -36951,7 +36978,8 @@
         },
         "kind-of": {
           "version": "6.0.2",
-          "resolved": ""
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -193,6 +193,7 @@
     "passport-google-oauth20": "^1.0.0",
     "passport-http": "^0.3.0",
     "passport-local": "^1.0.0",
+    "passport-remember-me": "0.0.1",
     "pretty-bytes": "^3.0.1",
     "primer-tooltips": "^1.5.11",
     "prop-types": "^15.6.2",

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -9,6 +9,10 @@ import GoogleStrategy from 'passport-google-oauth20';
 import { BasicStrategy } from 'passport-http';
 
 import User from '../models/user';
+import generateToken from '../utils/generateToken';
+import Token from '../models/token';
+
+const RememberMeStrategy = require('passport-remember-me').Strategy;
 
 function generateUniqueUsername(username) {
   const adj =
@@ -266,6 +270,34 @@ passport.use(
           }
         }
       );
+    }
+  )
+);
+
+/**
+ * Passport Remember me Strategy
+ */
+passport.use(
+  new RememberMeStrategy(
+    (token, done) => {
+      Token.findOneAndRemove({ value: token })
+        .populate('user')
+        .exec((err, doc) => {
+          if (err) return done(err);
+          if (!doc) return done(null, false);
+          return done(null, doc.user);
+        });
+    },
+    (user, done) => {
+      const value = generateToken(64);
+      const token = new Token({
+        value,
+        user: user._id
+      });
+      token.save((err) => {
+        if (err) return done(err);
+        return done(null, value);
+      });
     }
   )
 );

--- a/server/controllers/session.controller.js
+++ b/server/controllers/session.controller.js
@@ -1,6 +1,8 @@
 import passport from 'passport';
 
 import { userResponse } from './user.controller';
+import generateToken from '../utils/generateToken';
+import Token from '../models/token';
 
 export function createSession(req, res, next) {
   passport.authenticate('local', (err, user) => {
@@ -12,13 +14,31 @@ export function createSession(req, res, next) {
       res.status(401).json({ message: 'Invalid username or password.' });
       return;
     }
-
-    req.logIn(user, (innerErr) => {
-      if (innerErr) {
-        next(innerErr);
-        return;
+    // eslint-disable-line consistent-return
+    req.logIn(user, async (innerErr) => {
+      if (!req.body.remember) {
+        if (innerErr) {
+          return next(innerErr);
+        }
+        return res.json(userResponse(req.user));
       }
-      res.json(userResponse(req.user));
+      const value = generateToken(64);
+      const maxAge = 30 * 24 * 60 * 60 * 1000; // 30 days
+      const token = {
+        value,
+        user: user._id
+      };
+      await Token.create(token, (error, doc) => {
+        if (err) {
+          return next(error);
+        }
+        res.cookie('remember_me', value, { path: '/', maxAge });
+        if (innerErr) {
+          return next(innerErr);
+        }
+        return res.json(userResponse(req.user));
+      });
+      return null;
     });
   })(req, res, next);
 }
@@ -31,6 +51,7 @@ export function getSession(req, res) {
 }
 
 export function destroySession(req, res) {
+  res.clearCookie('remember_me');
   req.logout();
   res.json({ success: true });
 }

--- a/server/models/token.js
+++ b/server/models/token.js
@@ -1,0 +1,17 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+const TokenSchema = Schema({
+  value: {
+    type: String,
+    required: true
+  },
+
+  user: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  }
+});
+
+module.exports = mongoose.model('Token', TokenSchema);

--- a/server/server.js
+++ b/server/server.js
@@ -130,6 +130,7 @@ app.use(
 
 app.use(passport.initialize());
 app.use(passport.session());
+app.use(passport.authenticate('remember-me'));
 app.use('/editor', requestsOfTypeJSON(), users);
 app.use('/editor', requestsOfTypeJSON(), sessions);
 app.use('/editor', requestsOfTypeJSON(), files);

--- a/server/utils/generateToken.js
+++ b/server/utils/generateToken.js
@@ -1,0 +1,15 @@
+function getRandomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+export default function generateToken(len) {
+  const buf = [];
+  const chars =
+    'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+  const charlen = chars.length;
+
+  for (let i = 0; i < len; i += 1) {
+    buf.push(chars[getRandomInt(0, charlen - 1)]);
+  }
+
+  return buf.join('');
+}


### PR DESCRIPTION
Fixes #1671 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

@catarak  In my earlier PR #1719, I had made some errors during rebasing and hence the remember-me functionality wasn't working properly. I have made this new PR with all the required changes, please close the earlier one and review this one once.
Sorry for the inconvenience caused. Thanks!
