### PR TITLE
extended CREATE_FILE_REGEX to include htm/html files

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -70,4 +70,4 @@ export const TEXT_FILE_REGEX = /.+\.(json|txt|csv|tsv|vert|frag|js|css|html|htm|
 export const NOT_EXTERNAL_LINK_REGEX = /^(?!(http:\/\/|https:\/\/))/;
 export const EXTERNAL_LINK_REGEX = /^(http:\/\/|https:\/\/)/;
 
-export const CREATE_FILE_REGEX = /.+\.(json|txt|csv|tsv|js|css|frag|vert)$/i;
+export const CREATE_FILE_REGEX = /.+\.(json|txt|csv|tsv|js|css|frag|vert|html|htm)$/i;


### PR DESCRIPTION
Fixes #1749 
Extended `CREATE_FILE_REGEX`  to support html/htm extensions.
I have verified that this pull request:

* [ X] has no linting errors (`npm run lint`)
* [ X] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [ X] is descriptively named and links to an issue number, i.e. `Fixes #123`
