### PR TITLE
Extended CREATE_FILE_REGEX to match html/htm files

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -70,4 +70,4 @@ export const TEXT_FILE_REGEX = /.+\.(json|txt|csv|tsv|vert|frag|js|css|html|htm|
 export const NOT_EXTERNAL_LINK_REGEX = /^(?!(http:\/\/|https:\/\/))/;
 export const EXTERNAL_LINK_REGEX = /^(http:\/\/|https:\/\/)/;
 
-export const CREATE_FILE_REGEX = /.+\.(json|txt|csv|tsv|js|css|frag|vert)$/i;
+export const CREATE_FILE_REGEX = /.+\.(json|txt|csv|tsv|js|css|frag|vert|html|htm)$/i;


### PR DESCRIPTION
Fixes #1749
Modified `CREATE_FILE_REGEX` variable to match html/htm file extensions  too.
I have verified that this pull request: 

* [ x] has no linting errors (`npm run lint`)
* [ x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [ x] is descriptively named and links to an issue number, i.e. `Fixes #123`
