### PR TITLE
[#1563] Added Create Collections Page for Mobile

### DIFF
--- a/client/modules/Mobile/MobileCreateCollections.jsx
+++ b/client/modules/Mobile/MobileCreateCollections.jsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useSelector } from 'react-redux';
+import { withRouter } from 'react-router';
+import { useTranslation } from 'react-i18next';
+
+import IconButton from '../../components/mobile/IconButton';
+import Screen from '../../components/mobile/MobileScreen';
+import Header from '../../components/mobile/Header';
+import { ExitIcon } from '../../common/icons';
+import CollectionCreate from '../User/components/CollectionCreate';
+
+const MobileCreateCollections = ({ params }) => {
+  const user = useSelector((state) => state.user);
+
+  const { t } = useTranslation();
+
+  const ownerName = params.username || user.username;
+
+  return (
+    <Screen fullscreen>
+      <section>
+        <Header transparent title={t('DashboardView.CreateCollectionOverlay')}>
+          <IconButton
+            to={`/${ownerName}/collections`}
+            icon={ExitIcon}
+            aria-label="Return to collections"
+          />
+        </Header>
+        <CollectionCreate />
+      </section>
+    </Screen>
+  );
+};
+
+MobileCreateCollections.propTypes = {
+  params: PropTypes.shape({
+    username: PropTypes.string.isRequired
+  })
+};
+
+MobileCreateCollections.defaultProps = { params: {} };
+
+export default withRouter(MobileCreateCollections);

--- a/client/routes.jsx
+++ b/client/routes.jsx
@@ -6,6 +6,7 @@ import IDEView from './modules/IDE/pages/IDEView';
 import MobileIDEView from './modules/IDE/pages/MobileIDEView';
 import MobileSketchView from './modules/Mobile/MobileSketchView';
 import MobilePreferences from './modules/Mobile/MobilePreferences';
+import MobileCreateCollections from './modules/Mobile/MobileCreateCollections';
 import FullView from './modules/IDE/pages/FullView';
 import LoginView from './modules/User/pages/LoginView';
 import SignupView from './modules/User/pages/SignupView';
@@ -99,7 +100,10 @@ const routes = (store) => (
       component={mobileFirst(MobileDashboardView, DashboardView)}
     />
 
-    <Route path="/:username/collections/create" component={DashboardView} />
+    <Route
+      path="/:username/collections/create"
+      component={mobileFirst(MobileCreateCollections, DashboardView)}
+    />
     <Route
       path="/:username/collections/:collection_id"
       component={CollectionView}


### PR DESCRIPTION
Fixes #1563 

I have added a new page for mobile `:username/collections/create` as the route was available, but the component was of the desktop. The reason not to use modal for this was, 

1) It has already a separate route and adding a modal for a separate route doesn't seem right.
2) Desktop has a setting modal but has a page for it in mobile version.

Ready for review. If changes needed let me know :)

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Preview video:

https://user-images.githubusercontent.com/37347831/111034899-bb966800-843d-11eb-98d6-1ca50d485370.mov

