### PR TITLE
[#1760] Edit Project Name - SCSS to Styled Components

### DIFF
--- a/client/modules/IDE/components/ProjectName.jsx
+++ b/client/modules/IDE/components/ProjectName.jsx
@@ -28,18 +28,20 @@ const EditNameButton = styled(EditProjectNameIcon)`
 `;
 
 const Name = styled.button`
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  color: ${prop('secondaryTextColor')};
-  &:hover {
-    color: ${prop('logoColor')};
-    & ${EditNameButton} path {
-      fill: ${prop('logoColor')};
+  &&& {
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    color: ${prop('secondaryTextColor')};
+    &:hover {
+      color: ${prop('logoColor')};
+      & ${EditNameButton} path {
+        fill: ${prop('logoColor')};
+      }
     }
-  }
 
-  ${({ isEditingName }) => isEditingName && `display: none;`}
+    ${({ isEditingName }) => isEditingName && `display: none;`}
+  }
 `;
 
 const Input = styled.input`

--- a/client/modules/IDE/components/ProjectName.jsx
+++ b/client/modules/IDE/components/ProjectName.jsx
@@ -1,0 +1,164 @@
+import React, { useState, useRef } from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import styled from 'styled-components';
+import { Link } from 'react-router';
+
+import { prop, remSize } from '../../../theme';
+
+import EditProjectNameIcon from '../../../images/pencil.svg';
+
+const Container = styled.div`
+  margin-left: ${remSize(10)};
+  padding-left: ${remSize(10)};
+  height: 70%;
+  display: flex;
+  align-items: center;
+  border-color: ${prop('inactiveTextColor')};
+`;
+
+const EditNameButton = styled(EditProjectNameIcon)`
+  display: inline-block;
+  vertical-align: top;
+  width: ${remSize(18)};
+  height: ${remSize(18)};
+  & path {
+    fill: ${prop('secondaryTextColor')};
+  }
+`;
+
+const Name = styled.button`
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  color: ${prop('secondaryTextColor')};
+  &:hover {
+    color: ${prop('logoColor')};
+    & ${EditNameButton} path {
+      fill: ${prop('logoColor')};
+    }
+  }
+
+  ${({ isEditingName }) => isEditingName && `display: none;`}
+`;
+
+const Input = styled.input`
+  display: none;
+  border: 0px;
+  ${({ isEditingName }) => isEditingName && `display: block;`}
+`;
+
+const Owner = styled.p`
+  margin-left: ${remSize(5)};
+  color: ${prop('secondaryTextColor')};
+`;
+
+const ProjectName = (props) => {
+  const {
+    owner,
+    currentUser,
+    project,
+    showEditProjectName,
+    setProjectName,
+    hideEditProjectName,
+    saveProject
+  } = props;
+
+  const { t } = useTranslation();
+
+  const [projectNameInputValue, setProjectNameInputValue] = useState(
+    project.name
+  );
+
+  const projectNameInputRef = useRef(null);
+
+  const canEditProjectName =
+    (owner && owner.username && owner.username === currentUser) ||
+    !owner ||
+    !owner.username;
+
+  const handleProjectNameChange = (event) => {
+    setProjectNameInputValue(event.target.value);
+  };
+
+  const handleProjectNameSave = () => {
+    const newProjectName = projectNameInputValue.trim();
+    if (newProjectName.length === 0) {
+      setProjectNameInputValue(project.name);
+    } else {
+      setProjectName(newProjectName);
+      hideEditProjectName();
+      if (project.id) {
+        saveProject();
+      }
+    }
+  };
+
+  const handleKeyPress = (event) => {
+    if (event.key === 'Enter') {
+      hideEditProjectName();
+      projectNameInputRef.current.blur();
+    }
+  };
+
+  return (
+    <Container>
+      <Name
+        onClick={() => {
+          if (canEditProjectName) {
+            showEditProjectName();
+            setTimeout(() => projectNameInputRef.current.focus(), 0);
+          }
+        }}
+        disabled={!canEditProjectName}
+        aria-label={t('Toolbar.EditSketchARIA')}
+        isEditingName={project.isEditingName}
+      >
+        <span>{project.name}</span>
+        {canEditProjectName && (
+          <EditNameButton focusable="false" aria-hidden="true" />
+        )}
+      </Name>
+      <Input
+        type="text"
+        maxLength="128"
+        aria-label={t('Toolbar.NewSketchNameARIA')}
+        value={projectNameInputValue}
+        onChange={handleProjectNameChange}
+        ref={projectNameInputRef}
+        onBlur={handleProjectNameSave}
+        onKeyPress={handleKeyPress}
+        isEditingName={project.isEditingName}
+      />
+      {owner && (
+        <Owner>
+          {t('Toolbar.By')}
+          <Link to={`/${owner.username}/sketches`}>{owner.username}</Link>
+        </Owner>
+      )}
+    </Container>
+  );
+};
+
+ProjectName.propTypes = {
+  setProjectName: PropTypes.func.isRequired,
+  currentUser: PropTypes.string,
+  owner: PropTypes.shape({
+    username: PropTypes.string
+  }),
+  project: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    isEditingName: PropTypes.bool,
+    id: PropTypes.string
+  }).isRequired,
+  showEditProjectName: PropTypes.func.isRequired,
+  hideEditProjectName: PropTypes.func.isRequired,
+  saveProject: PropTypes.func.isRequired
+};
+
+ProjectName.defaultProps = {
+  owner: undefined,
+  currentUser: undefined
+};
+
+export default ProjectName;

--- a/client/modules/IDE/components/Toolbar.test.jsx
+++ b/client/modules/IDE/components/Toolbar.test.jsx
@@ -45,8 +45,13 @@ const renderComponent = (extraProps = {}) => {
 
   const store = configureStore(initialState);
 
-  render(<Provider store={store}><ThemeProvider><ToolbarComponent {...props} /></ThemeProvider></Provider>);
-
+  render(
+    <Provider store={store}>
+      <ThemeProvider>
+        <ToolbarComponent {...props} />
+      </ThemeProvider>
+    </Provider>
+  );
   return props;
 };
 

--- a/client/modules/IDE/components/Toolbar.test.jsx
+++ b/client/modules/IDE/components/Toolbar.test.jsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import lodash from 'lodash';
+import { Provider } from 'react-redux';
 
+import configureStore from '../../../store';
+import ThemeProvider from '../../App/components/ThemeProvider';
 import { fireEvent, render, screen, waitFor } from '../../../test-utils';
 import { ToolbarComponent } from './Toolbar';
 
@@ -38,7 +41,11 @@ const renderComponent = (extraProps = {}) => {
     extraProps
   );
 
-  render(<ToolbarComponent {...props} />);
+  const initialState = window.__INITIAL_STATE__;
+
+  const store = configureStore(initialState);
+
+  render(<Provider store={store}><ThemeProvider><ToolbarComponent {...props} /></ThemeProvider></Provider>);
 
   return props;
 };

--- a/client/styles/components/_toolbar.scss
+++ b/client/styles/components/_toolbar.scss
@@ -97,50 +97,6 @@
 	}
 }
 
-.toolbar__project-name-container {
-	@include themify() {
-		border-color: getThemifyVariable('inactive-text-color');
-	}
-	margin-left: #{10 / $base-font-size}rem;
-	padding-left: #{10 / $base-font-size}rem;
-  display: flex;
-  align-items: center;
-}
-
-.toolbar__project-name {
-	@include themify() {
-		color: getThemifyVariable('secondary-text-color');
-		&:hover {
-		color: getThemifyVariable('logo-color');
-		  & .toolbar__edit-name-button path {
-		  	fill: getThemifyVariable('logo-color');
-		  }
-		}
-	}
-	cursor: pointer;
-	display: flex;
-	align-items: center;
-
-	.toolbar__project-name-container--editing & {
-		display: none;
-	}
-}
-
-.toolbar__project-name-input {
-	display: none;
-	border: 0px;
-	.toolbar__project-name-container--editing & {
-		display: block;
-	}
-}
-
-.toolbar__project-owner {
-	margin-left: #{5 / $base-font-size}rem;
-	@include themify() {
-		color: getThemifyVariable('secondary-text-color');
-	}
-}
-
 .toolbar__autorefresh-label {
 	@include themify() {
 		color: getThemifyVariable('secondary-text-color');
@@ -156,16 +112,4 @@
 
 .checkbox__autorefresh{
 	cursor: pointer;
-}
-
-.toolbar__edit-name-button {
-	display: inline-block;
-	vertical-align: top;
-	width: #{18 / $base-font-size}rem;
-	height: #{18 / $base-font-size}rem;
-	@include themify() {
-		& path {
-			fill: getThemifyVariable('secondary-text-color');
-		}
-	}
 }

--- a/client/theme.js
+++ b/client/theme.js
@@ -62,7 +62,10 @@ export default {
   [Theme.light]: {
     colors,
     ...common,
+    logoColor: colors.p5jsPink,
     primaryTextColor: grays.dark,
+    secondaryTextColor: grays.mediumDark,
+    inactiveTextColor: grays.middleDark,
     backgroundColor: grays.lighter,
 
     Button: {
@@ -115,7 +118,10 @@ export default {
   [Theme.dark]: {
     colors,
     ...common,
+    logoColor: colors.p5jsPink,
     primaryTextColor: grays.lightest,
+    secondaryTextColor: grays.mediumLight,
+    inactiveTextColor: grays.middleLight,
     backgroundColor: grays.darker,
 
     Button: {
@@ -168,7 +174,10 @@ export default {
   [Theme.contrast]: {
     colors,
     ...common,
+    logoColor: colors.yellow,
     primaryTextColor: grays.lightest,
+    secondaryTextColor: grays.lighter,
+    inactiveTextColor: grays.light,
     backgroundColor: grays.darker,
 
     Button: {


### PR DESCRIPTION
Partially Fixes #1760

1. Abstracted `Project Name` from `Toolbar` into a new component for reusability in the future i.e. For the mobile version.
2. Migrated all `Project Name` related SCSS to Styled Components.
3. Added necessary theme color in `theme.js`
4. Converted `Toolbar` from class-based to the functional component as `Toolbar` does not have any state.

I have verified that there is no change in UI and it's working.

Before: 
![image](https://user-images.githubusercontent.com/37347831/111081046-633b9500-8527-11eb-87fa-2efa51c3f2b3.png)
![image](https://user-images.githubusercontent.com/37347831/111081051-6c2c6680-8527-11eb-8d24-28102e98363c.png)

After:
![image](https://user-images.githubusercontent.com/37347831/111081060-75b5ce80-8527-11eb-9274-71c174448573.png)
![image](https://user-images.githubusercontent.com/37347831/111081064-7cdcdc80-8527-11eb-8495-b486e539d293.png)




I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
