### PR TITLE
[#1807] Added ThemeProvider for tests

### DIFF
--- a/client/test-utils.js
+++ b/client/test-utils.js
@@ -1,12 +1,13 @@
 /**
  * This file re-exports @testing-library but ensures that
- * any calls to render have translations available.
+ * any calls to render have translations and theme available.
  *
  * This means tested components will be able to call
  * `t()` and have the translations of the default
- * language
+ * language also components will be able to call
+ * `prop()` and have the theming of the default theme.
  *
- * See: https://react.i18next.com/misc/testing#testing-without-stubbing
+ * For i18n see: https://react.i18next.com/misc/testing#testing-without-stubbing
  */
 
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -15,7 +16,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import { I18nextProvider } from 'react-i18next';
+import { ThemeProvider } from 'styled-components';
+
 import i18n from './i18n-test';
+import theme, { Theme } from './theme';
 
 // re-export everything
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -23,7 +27,9 @@ export * from '@testing-library/react';
 
 const Providers = ({ children }) => (
   // eslint-disable-next-line react/jsx-filename-extension
-  <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+  <ThemeProvider theme={{ ...theme[Theme.light] }}>
+    <I18nextProvider i18n={i18n}>{children}</I18nextProvider>
+  </ThemeProvider>
 );
 
 Providers.propTypes = {


### PR DESCRIPTION
Fixes #1807

Using `styled-components` and function like `prop` from `theme.js`, was failing tests as we haven't wrapped the `render` function from `@testing-library` in `test-utils.js`.

I added `ThemeProvider` and provided the default theme `light` to it for testing. Similar to `I18nextProvider` is already wrapping it to provide default translation.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
