### PR TITLE
Fixes #1813

### DIFF
--- a/client/modules/User/pages/DashboardView.jsx
+++ b/client/modules/User/pages/DashboardView.jsx
@@ -11,6 +11,7 @@ import AssetList from '../../IDE/components/AssetList';
 import AssetSize from '../../IDE/components/AssetSize';
 import CollectionList from '../../IDE/components/CollectionList';
 import SketchList from '../../IDE/components/SketchList';
+import * as ProjectActions from '../../IDE/actions/project';
 import {
   CollectionSearchbar,
   SketchSearchbar
@@ -29,6 +30,7 @@ class DashboardView extends React.Component {
   constructor(props) {
     super(props);
     this.closeAccountPage = this.closeAccountPage.bind(this);
+    this.createNewSketch = this.createNewSketch.bind(this);
     this.gotoHomePage = this.gotoHomePage.bind(this);
     this.toggleCollectionCreate = this.toggleCollectionCreate.bind(this);
     this.state = {
@@ -42,6 +44,10 @@ class DashboardView extends React.Component {
 
   closeAccountPage() {
     browserHistory.push(this.props.previousPath);
+  }
+
+  createNewSketch() {
+    this.props.newProject();
   }
 
   gotoHomePage() {
@@ -98,7 +104,9 @@ class DashboardView extends React.Component {
         return (
           <React.Fragment>
             {this.isOwner() && (
-              <Button to="/">{t('DashboardView.NewSketch')}</Button>
+              <Button onClick={this.createNewSketch}>
+                {t('DashboardView.NewSketch')}
+              </Button>
             )}
             <SketchSearchbar />
           </React.Fragment>
@@ -170,7 +178,12 @@ function mapStateToProps(state) {
   };
 }
 
+const mapDispatchToProps = {
+  ...ProjectActions
+};
+
 DashboardView.propTypes = {
+  newProject: PropTypes.func.isRequired,
   location: PropTypes.shape({
     pathname: PropTypes.string.isRequired
   }).isRequired,
@@ -185,4 +198,6 @@ DashboardView.propTypes = {
   t: PropTypes.func.isRequired
 };
 
-export default withTranslation()(connect(mapStateToProps)(DashboardView));
+export default withTranslation()(
+  connect(mapStateToProps, mapDispatchToProps)(DashboardView)
+);


### PR DESCRIPTION
Fixes #1813 

As per comment https://github.com/processing/p5.js-web-editor/issues/1813#issuecomment-802714176 I went with option 2. I.e., when you click "New sketch" on the Dashboard, it was previous just a navigation that preserved the current project. Now the button has a handler that calls newProject().

I did not choose option 1, because I think that's less consistent. Namely: when you have a sketch that is saved and go to the Dashobard, the current project is preserved. If you hit "back to sketch" or explicitly navigate to the base URL, the sketch will still be there. By choosing option 1, the same behavior remains with unsaved sketches.

I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`
