### PR TITLE
added german translation of UI

### DIFF
--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -651,6 +651,16 @@ class Nav extends React.PureComponent {
               <button
                 onFocus={this.handleFocusForLang}
                 onBlur={this.handleBlur}
+                value="pt-BR"
+                onClick={(e) => this.handleLangSelection(e)}
+              >
+                Deutsch
+              </button>
+            </li>
+            <li className="nav__dropdown-item">
+              <button
+                onFocus={this.handleFocusForLang}
+                onBlur={this.handleBlur}
                 value="ja"
                 onClick={(e) => this.handleLangSelection(e)}
               >

--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -651,7 +651,7 @@ class Nav extends React.PureComponent {
               <button
                 onFocus={this.handleFocusForLang}
                 onBlur={this.handleBlur}
-                value="pt-BR"
+                value="de"
                 onClick={(e) => this.handleLangSelection(e)}
               >
                 Deutsch

--- a/client/i18n.js
+++ b/client/i18n.js
@@ -1,10 +1,10 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import Backend from 'i18next-http-backend';
-import { enUS, es, ja, hi, ptBR } from 'date-fns/locale';
+import { enUS, es, ja, hi, ptBR, de } from 'date-fns/locale';
 
 const fallbackLng = ['en-US'];
-const availableLanguages = ['en-US', 'es-419', 'ja', 'hi', 'pt-BR'];
+const availableLanguages = ['en-US', 'es-419', 'ja', 'hi', 'pt-BR', 'de'];
 
 export function languageKeyToLabel(lang) {
   const languageMap = {
@@ -12,7 +12,8 @@ export function languageKeyToLabel(lang) {
     'es-419': 'Español',
     ja: '日本語',
     hi: 'हिन्दी',
-    'pt-BR': 'Português'
+    'pt-BR': 'Português',
+    de: 'Deutsch'
   };
   return languageMap[lang];
 }
@@ -23,6 +24,7 @@ export function languageKeyToDateLocale(lang) {
     'es-419': es,
     ja,
     hi,
+    de,
     'pt-BR': ptBR
   };
   return languageMap[lang];

--- a/translations/locales/de/translations.json
+++ b/translations/locales/de/translations.json
@@ -1,0 +1,607 @@
+{
+  "Nav": {
+    "File": {
+      "Title": "Datei",
+      "New": "Neu",
+      "Share": "Teilen",
+      "Duplicate": "Duplizieren",
+      "Open": "Öffnen",
+      "Download": "Herunterladen",
+      "AddToCollection": "Zur Sammlung hinzufügen",
+      "Examples": "Beispiele"
+    },
+    "Edit": {
+      "Title": "Bearbeiten",
+      "TidyCode": "Code aufräumen",
+      "Find": "Finden",
+      "Replace": "Ersetzen"
+    },
+    "Sketch": {
+      "Title": "Sketch",
+      "AddFile": "Neue Datei",
+      "AddFolder": "Neuer Ordner",
+      "Run": "Ausführen",
+      "Stop": "Stoppen"
+    },
+    "Help": {
+      "Title": "Hilfe",
+      "KeyboardShortcuts": "Tastenkürzel",
+      "Reference": "Referenz",
+      "About": "Über"
+    },
+    "Lang": "Sprache",
+    "BackEditor": "Zurück zum Editor",
+    "WarningUnsavedChanges": "Bist du sicher, dass du die Seite verlassen willst? Du hast ungesicherte Änderungen.",
+    "Login": "Anmelden",
+    "LoginOr": "oder",
+    "SignUp": "Registrieren",
+    "Auth": {
+      "Welcome": "Willkommen",
+      "Hello": "Hallo",
+      "MyAccount": "Mein Account",
+      "My": "Mein",
+      "MySketches": "Meine Sketches",
+      "MyCollections": "Meine Sammlungen",
+      "Asset": "Asset",
+      "MyAssets": "Meine Assets",
+      "LogOut": "Abmelden"
+    }
+  },
+  "CodemirrorFindAndReplace": {
+    "ToggleReplace": "Ersetzen umschalten",
+    "Find": "Finden\n",
+    "FindPlaceholder": "In Datei finden",
+    "Replace": "Ersetzen",
+    "ReplaceAll": "Alle Ersetzen",
+    "ReplacePlaceholder": "Ersetzen mit",
+    "Regex": "Regulärer Ausdruck",
+    "CaseSensitive": "Groß- Kleinschreibung beachten",
+    "WholeWords": "Ganze Worte",
+    "Previous": "Vorheriges",
+    "Next": "Nächstes",
+    "NoResults": "Keine Ergebnisse",
+    "Close": "Schließen"
+  },
+  "LoginForm": {
+    "UsernameOrEmail": "E-Mail oder Nutzername",
+    "UsernameOrEmailARIA": "E-Mail oder Nutzername",
+    "Password": "Passwort",
+    "PasswordARIA": "Passwort",
+    "Submit": "Einloggen"
+  },
+  "LoginView": {
+    "Title": "p5.js Web Editor | Anmelden",
+    "Login": "Einloggen",
+    "LoginOr": "oder",
+    "SignUp": "Registrieren",
+    "Email": "email",
+    "Username": "nutzername",
+    "DontHaveAccount": "Noch keinen Account? ",
+    "ForgotPassword": "Passwort vergessen?",
+    "ResetPassword": "Passwort zurücksetzen"
+  },
+  "SocialAuthButton": {
+    "Connect": "{{serviceauth}} Account verbinden",
+    "Unlink": "Verbindung zu {{serviceauth}} aufheben",
+    "Login": "Mit {{serviceauth}} einloggen",
+    "LogoARIA": "{{serviceauth}} logo"
+  },
+  "About": {
+    "Title": "Über",
+    "TitleHelmet": "p5.js Web Editor | Über",
+    "Contribute": "Mitwirken",
+    "NewP5": "Neu bei p5.js?",
+    "Report": "Einen Fehler melden",
+    "Learn": "Lernen",
+    "Resources": "Ressourcen",
+    "Libraries": "Bibliotheken",
+    "Forum": "Forum",
+    "Examples": "Beispiele"
+  },
+  "Toast": {
+    "OpenedNewSketch": "Neuer Sketch geöffnet.",
+    "SketchSaved": "Sketch gesichert.",
+    "SketchFailedSave": "Fehler beim sichern deines Sketches.",
+    "AutosaveEnabled": "Automatisches sichern aktiviert.",
+    "LangChange": "Sprache geändert",
+    "SettingsSaved": "Einstellungen gespeichert."
+  },
+  "Toolbar": {
+    "Preview": "Vorschau",
+    "Auto-refresh": "Automatisch neu laden",
+    "OpenPreferencesARIA": "Einstellungen öffnen",
+    "PlaySketchARIA": "Sketch starten",
+    "PlayOnlyVisualSketchARIA": "Nur visuellen Sketch starten",
+    "StopSketchARIA": "Sketch stoppen",
+    "EditSketchARIA": "Sketch Namen bearbeiten",
+    "NewSketchNameARIA": "Neuer Sketch name",
+    "By": " von "
+  },
+  "Console": {
+    "Title": "Konsole",
+    "Clear": "Leeren",
+    "ClearARIA": "Konsole leeren",
+    "Close": "Schließen",
+    "CloseARIA": "Konsole schließen",
+    "Open": "Öffnen",
+    "OpenARIA": "Konsole öffnen"
+  },
+  "Preferences": {
+    "Settings": "Einstellungen",
+    "GeneralSettings": "Allgemeine Einstellungen",
+    "Accessibility": "Bedienungshilfen",
+    "Theme": "Erscheinungsbild",
+    "LightTheme": "Hell",
+    "LightThemeARIA": "Erscheinungsbild Hell an",
+    "DarkTheme": "Dunkel",
+    "DarkThemeARIA": "Erscheinungsbild Dunkel an",
+    "HighContrastTheme": "Hoher Kontrast",
+    "HighContrastThemeARIA": "Erscheinungsbild Hoher Kontrast an",
+    "TextSize": "Text Größe",
+    "DecreaseFont": "Verringern",
+    "DecreaseFontARIA": "Text Größe verringern",
+    "IncreaseFont": "Erhöhen",
+    "IncreaseFontARIA": "Text Größe erhöhen",
+    "Autosave": "Automatisches Speichern",
+    "On": "An",
+    "AutosaveOnARIA": "Automatisches Speichern an",
+    "Off": "Aus",
+    "AutosaveOffARIA": "Automatisches Speichern aus",
+    "AutocloseBracketsQuotes": "Klammern und Anführungszeichen automatisch schließen",
+    "AutocloseBracketsQuotesOnARIA": "Klammern und Anführungszeichen automatisch schließen an",
+    "AutocloseBracketsQuotesOffARIA": "Klammern und Anführungszeichen automatisch schließen aus",
+    "WordWrap": "Wortumbruch",
+    "LineWrapOnARIA": "zeilenumbruch an",
+    "LineWrapOffARIA": "zeilenumbruch aus",
+    "LineNumbers": "Zeilennummerierung",
+    "LineNumbersOnARIA": "Zeilennummerierung an",
+    "LineNumbersOffARIA": "Zeilennummerierung aus",
+    "LintWarningSound": "Lint Warnton",
+    "LintWarningOnARIA": "lint Warnton an",
+    "LintWarningOffARIA": "lint Warnton aus",
+    "PreviewSound": "Warnton anhören",
+    "PreviewSoundARIA": "Warnton anhören",
+    "AccessibleTextBasedCanvas": "Barrierefreier, text-basierter Canvas",
+    "UsedScreenReader": "Nutzung mit Bildschirmlesegerät ",
+    "PlainText": "Nur Text",
+    "TextOutputARIA": "Text Ausgabe an",
+    "TableText": "Tabellarisch",
+    "TableOutputARIA": "Tabellarische Ausgabe an",
+    "Sound": "Sound",
+    "SoundOutputARIA": "sound Ausgabe an"
+  },
+  "KeyboardShortcuts": {
+    "Title": "Tastenkürzel",
+    "ShortcutsFollow": "Die Tastenkürzel zum editieren des Codes folgen den",
+    "SublimeText": "Sublime Tastenkürzeln",
+    "CodeEditing": {
+      "Tidy": "Code aufräumen",
+      "FindText": "Text finden",
+      "FindNextMatch": "Nächsten Treffer finden",
+      "FindPrevMatch": "Vorherigen Treffer finden",
+      "ReplaceTextMatch": "Treffer ersetzen",
+      "IndentCodeLeft": "Code links einrücken",
+      "IndentCodeRight": "Code rechts einrücken",
+      "CommentLine": "Kommentar einfügen",
+      "FindNextTextMatch": "Nächsten Text Treffer finden",
+      "FindPreviousTextMatch": "Vorherigen Text Treffer finden",
+      "CodeEditing": "Code editieren"
+    },
+    "General": {
+      "StartSketch": "Sketch starten",
+      "StopSketch": "Sketch stoppen",
+      "TurnOnAccessibleOutput": "Barrierefreie Ausgabe einschalten",
+      "TurnOffAccessibleOutput": "Barrierefreie Ausgabe ausschalten"
+    }
+  },
+  "Sidebar": {
+    "Title": "Sketch Dateien",
+    "ToggleARIA": "Schalter öffnen/schließen der Sketch Dateien",
+    "AddFolder": "Ordner erstellen",
+    "AddFolderARIA": "Ordner erstellen",
+    "AddFile": "Datei erstellen",
+    "AddFileARIA": "Datei erstellen",
+    "UploadFile": "Datei hochladen",
+    "UploadFileARIA": "Datei hochladen"
+  },
+  "FileNode": {
+    "OpenFolderARIA": "Ordner Inhalte öffnen",
+    "CloseFolderARIA": "Ordner Inhalte schließen",
+    "ToggleFileOptionsARIA": "Schalter öffnen/schließen der Sketch Dateien",
+    "AddFolder": "Ordner erstellen",
+    "AddFolderARIA": "Ordner hinzufügen",
+    "AddFile": "Datei erstellen",
+    "AddFileARIA": "Datei hinzufügen",
+    "UploadFile": "Datei hochladen",
+    "UploadFileARIA": "Datei hochladen",
+    "Rename": "Umbenennen",
+    "Delete": "Löschen"
+  },
+  "Common": {
+    "Error": "Fehler",
+    "ErrorARIA": "Fehler",
+    "Save": "Speichern",
+    "p5logoARIA": "p5.js Logo",
+    "DeleteConfirmation": "Bist du sicher, dass du {{name}} löschen möchtest?"
+  },
+  "IDEView": {
+    "SubmitFeedback": "Feedback abgeben",
+    "SubmitFeedbackARIA": "feedback-abgeben",
+    "AddCollectionTitle": "Zur Sammlung hinzufügen",
+    "AddCollectionARIA": "zur Sammlung hinzufügen",
+    "ShareTitle": "Teilen",
+    "ShareARIA": "teilen"
+  },
+  "NewFileModal": {
+    "Title": "Neue Datei",
+    "CloseButtonARIA": "Neue Datei Fenster schließen",
+    "EnterName": "Bitte gib einen Namen ein",
+    "InvalidType": "Ungültiger Dateityp. Gültige Endungen sind .js, .css, .json, .xml, .txt, .csv, .tsv, .frag, und .vert."
+  },
+  "NewFileForm": {
+    "AddFileSubmit": "Neue Datei",
+    "Placeholder": "Name"
+  },
+  "NewFolderModal": {
+    "Title": "Neuer Ordner",
+    "CloseButtonARIA": "Neuer Ordner Fenster schließen",
+    "EnterName": "Bitte gib einen Namen ein",
+    "EmptyName": "Der Ordner Name kann keine Leerzeichen enthalten",
+    "InvalidExtension": "Der Ordnername kann keine Datei-Endung enthalten"
+  },
+  "NewFolderForm": {
+    "AddFolderSubmit": "Ordner hinzufügen",
+    "Placeholder": "Name"
+  },
+  "ResetPasswordForm": {
+    "Email": "E-Mail, die zum registrieren verwendet wurde.",
+    "EmailARIA": "email",
+    "Submit": "Passwort an E-Mail senden"
+  },
+  "ResetPasswordView": {
+    "Title": "p5.js Web Editor | Passwort zurücksetzen",
+    "Reset": "Passwort zurücksetzen",
+    "Submitted": "Die E-Mail zum zurücksetzen deines Passwort, sollte in kürze eintreffen. Wenn Du sie nicht \n findest, schau in Deinem Spam Ordner nach.",
+    "Login": "Einloggen",
+    "LoginOr": "oder",
+    "SignUp": "Registrieren"
+  },
+  "ReduxFormUtils": {
+    "errorInvalidEmail": "Gib bitte eine gültige E-Mailadresse ein",
+    "errorEmptyEmail": "Gib bitte eine E-Mailadresse ein",
+    "errorPasswordMismatch": "Beide Passwörter müssen übereinstimmen",
+    "errorEmptyPassword": "Gib bitte ein Passwort ein",
+    "errorShortPassword": "Das Passwort muss mindestens aus 6 Zeichen bestehen",
+    "errorConfirmPassword": "Gib bitte das Passwort erneut ein",
+    "errorNewPassword": "Gib bitte ein neues Passwort ein oder lass dieses Feld frei.",
+    "errorEmptyUsername": "Gib bitte einen Nutzernamen ein.",
+    "errorLongUsername": "Der Nutzername muss weniger als 20 Zeichen haben.",
+    "errorValidUsername": "Der Nutzername darf nur aus Zahlen, Buchstaben, Punkten, Bindestrichen oder Unterstrichen bestehen."
+  },
+  "NewPasswordView": {
+    "Title": "p5.js Web Editor | Neues Passwort",
+    "Description": "Neues Passwort vergeben",
+    "TokenInvalidOrExpired": "Der Link zum zurücksetzten ist ungültig oder abgelaufen.",
+    "EmptyPassword": "Gib bitte ein Passwort ein",
+    "PasswordConfirmation": "Gib bitte das Passwort erneut ein",
+    "PasswordMismatch": "Beide Passwörter müssen übereinstimmen"
+  },
+  "AccountForm": {
+    "Email": "E-Mail",
+    "EmailARIA": "email",
+    "Unconfirmed": "Unbestätigt.",
+    "EmailSent": "Bestätigung gesendet, schau in deine E-Mails.",
+    "Resend": "Bestätigung erneut senden",
+    "UserName": "Nutzername",
+    "UserNameARIA": "nutzername",
+    "CurrentPassword": "Aktuelles Passwort",
+    "CurrentPasswordARIA": "aktuelles passwort",
+    "NewPassword": "Neues Passwort",
+    "NewPasswordARIA": "neues passwort",
+    "SubmitSaveAllSettings": "Alle Einstellungen speichern"
+  },
+  "AccountView": {
+    "SocialLogin": "Social Login",
+    "SocialLoginDescription": "Nutze deinen GitHub oder Google Account um dich beim p5.js Web Editor anzumelden.",
+    "Title": "p5.js Web Editor | Account Einstellungen",
+    "Settings": "Account Einstellungen",
+    "AccountTab": "Account",
+    "AccessTokensTab": "Zugangstokens"
+  },
+  "APIKeyForm": {
+    "ConfirmDelete": "Bist Du dir sicher, dass Du {{key_label}} löschen willst?",
+    "Summary": "Persönliche Zugangstoken fungieren wie Dein Passwort. \n Sie erlauben automatisierten Skripten Zugang zur Editor API. \n Erstelle einen Token für jedes Skript, das Zugang benötigt.",
+    "CreateToken": "Neuen Token erstellen",
+    "TokenLabel": "Wofür wird dieser Token genutzt?",
+    "TokenPlaceholder": "Wofür wird dieser Token genutzt? Z.B. um Skripte zu importieren.",
+    "CreateTokenSubmit": "Erstellen",
+    "NoTokens": "Du hast keine Tokens.",
+    "NewTokenTitle": "Dein neuer Zugangstoken",
+    "NewTokenInfo": "Kopiere dir jetzt Deinen neuen, persönlichen Token. \n Du kannst ihn nicht wieder anschauen.",
+    "ExistingTokensTitle": "Bestehende Tokens"
+  },
+  "APIKeyList": {
+    "Name": "Name",
+    "Created": "Erstellt am",
+    "LastUsed": "Zuletzt verwendet",
+    "Actions": "Actions",
+    "Never": "Nie",
+    "DeleteARIA": "API Schlüssel löschen"
+  },
+  "NewPasswordForm": {
+    "Title": "Passwort",
+    "TitleARIA": "Passwort",
+    "ConfirmPassword": "Passwort bestätigen",
+    "ConfirmPasswordARIA": "Passwort bestätigen",
+    "SubmitSetNewPassword": "Neues Passwort erstellen"
+  },
+  "SignupForm": {
+    "Title": "Nutzername",
+    "TitleARIA": "Nutzername",
+    "Email": "E-Mail",
+    "EmailARIA": "email",
+    "Password": "Passwort",
+    "PasswordARIA": "Passwort",
+    "ConfirmPassword": "Passwort bestätigen",
+    "ConfirmPasswordARIA": "Passwort bestätigen",
+    "SubmitSignup": "Registrieren"
+  },
+  "SignupView": {
+    "Title": "p5.js Web Editor | Registrieren",
+    "Description": "Registrieren",
+    "Or": "Oder",
+    "AlreadyHave": "Hast Du bereits einen Account?",
+    "Login": "Anmelden"
+  },
+  "EmailVerificationView": {
+    "Title": "p5.js Web Editor | E-Mail Bestätigung",
+    "Verify": "Bestätige deine E-Mail",
+    "InvalidTokenNull": "Der Link ist ungültig.",
+    "Checking": "Überprüfe Token, bitte warten...",
+    "Verified": "Geschafft, deine E-Mailadresse wurde bestätigt.",
+    "InvalidState": "Etwas ist schief gelaufen."
+  },
+  "AssetList": {
+    "Title": "p5.js Web Editor | Meine Assets",
+    "ToggleOpenCloseARIA": "Schalter Öffnen/Schließen Asset Optionen",
+    "Delete": "Löschen",
+    "OpenNewTab": "In neuem Tab öffnen",
+    "NoUploadedAssets": "Keine hochgeladenen Assets",
+    "HeaderName": "Name",
+    "HeaderSize": "Größe",
+    "HeaderSketch": "Sketch"
+  },
+  "Feedback": {
+    "Title": "p5.js Web Editor | Feedback",
+    "ViaGithubHeader": "Per Github Issues",
+    "ViaGithubDescription": "Wenn Du dich mit GitHub auskennst, ist dies die bevorzugte Methode Feedback und Bug Reports einzureichen.",
+    "GoToGithub": "Zu Github gehen",
+    "ViaGoogleHeader": "Per Google Form",
+    "ViaGoogleDescription": "Du kannst auch diesen Fragebogen ausfüllen",
+    "GoToForm": "Zum Fragebogen gehen"
+  },
+  "Searchbar": {
+    "SearchSketch": "Sketche durchsuchen...",
+    "SearchCollection": "Sammlungen durchsuchen...",
+    "ClearTerm": "löschen"
+  },
+  "UploadFileModal": {
+    "Title": "Datei hochladen",
+    "CloseButtonARIA": "Datei hochladen Fenster schließen",
+    "SizeLimitError": "Fehler: Du kannst keine weiteren Dateien mehr hochladen. \n Du hast das Limit von {{sizeLimit}} erreicht. Wenn Du mehr hochladen willst, \n lösche bitte Dateien, die Du nicht mehr nutzt.\n                in Deiner "
+  },
+  "FileUploader": {
+    "DictDefaultMessage": "Ziehe Dateien hierhin oder klicke um den Dateibrowser zu verwenden."
+  },
+
+  "ErrorModal": {
+    "MessageLogin": "Um Deinen Sketch sichern zu können musst du angemeldet sein. Bitte ",
+    "Login": "Melde Dich an",
+    "LoginOr": " oder ",
+    "SignUp": "Registriere Dich",
+    "MessageLoggedOut": "Es scheint als hättest Du Dich abgemeldet. Bitte ",
+    "LogIn": "melde Dich an",
+    "SavedDifferentWindow": "Das Projekt, dass Du speichern möchtest, wurde in einem anderen Fenster gespeichert. \n        Bitte lade die Seite neu um die aktuelle Version zu sehen.",
+    "LinkTitle": "Fehler beim verbinden deines Accounts",
+    "LinkMessage": "Es gab einen Fehler, beim verbinden deines {{serviceauth}} Accounts mit deinem p5.js Web Editor Account. Dein {{serviceauth}} wurde bereits mit einem anderen p5.js Web Editor Account verknüpft."
+  },
+  "ShareModal": {
+    "Embed": "Einbetten",
+    "Present": "Präsentieren",
+    "Fullscreen": "Vollbildmodus",
+    "Edit": "Bearbeitungsmodus"
+  },
+  "CollectionView": {
+    "TitleCreate": "Sammlung erstellen",
+    "TitleDefault": "Sammlung"
+  },
+  "Collection": {
+    "Title": "p5.js Web Editor | Meine Sammlungen",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s Sammlung",
+    "Share": "Teilen",
+    "URLLink": "Link zur Sammlung",
+    "AddSketch": "Sketch hinzufügen",
+    "DeleteFromCollection": "Bist Du sicher, dass du {{name_sketch}} aus dieser Sammlung entfernen willst?",
+    "SketchDeleted": "Sketch gelöscht",
+    "SketchRemoveARIA": "Sketch aus der Sammlung entfernen",
+    "DescriptionPlaceholder": "Beschreibung hinzufügen",
+    "Description": "Beschreibung",
+    "NumSketches": "{{count}} Sketch",
+    "NumSketches_plural": "{{count}} Sketche",
+    "By": "Sammlung von ",
+    "NoSketches": "Keine Sketche in dieser Sammlung",
+    "TableSummary": "Liste mit allen Sammlungen",
+    "HeaderName": "Name",
+    "HeaderCreatedAt": "Hinzugefügt am",
+    "HeaderUser": "Besitzer",
+    "DirectionAscendingARIA": "Aufsteigend",
+    "DirectionDescendingARIA": "Absteigend",
+    "ButtonLabelAscendingARIA": "Sortiere nach {{displayName}} aufsteigend.",
+    "ButtonLabelDescendingARIA": "Sortiere nach {{displayName}} absteigend."
+  },
+  "AddToCollectionList": {
+    "Title": "p5.js Web Editor | Meine Sammlungen",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s Sammlungen",
+    "Empty": "Keine Sammlungen"
+  },
+  "CollectionCreate": {
+    "Title": "p5.js Web Editor | Sammlung erstellen",
+    "FormError": "Konnte keine Sammlung erstellen",
+    "FormLabel": "Name der Sammlung",
+    "FormLabelARIA": "name",
+    "NameRequired": "Sammlungsname ist notwendig",
+    "Description": "Beschreibung (optional)",
+    "DescriptionARIA": "Beschreibung",
+    "DescriptionPlaceholder": "Meine Lieblingssketche",
+    "SubmitCollectionCreate": "Sammlung erstellen"
+  },
+  "DashboardView": {
+    "CreateCollection": "Sammlung erstellen",
+    "NewSketch": "Neuer Sketch",
+    "CreateCollectionOverlay": "Sammlung erstellen"
+  },
+  "DashboardTabSwitcher": {
+    "Sketches": "Sketche",
+    "Collections": "Sammlungen",
+    "Assets": "Assets"
+  },
+  "CollectionList": {
+    "Title": "p5.js Web Editor | Meine Sammlungen",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s Sammlungen",
+    "NoCollections": "Keine Sammlungen.",
+    "TableSummary": "Liste mit allen Sammlungen",
+    "HeaderName": "Name",
+    "HeaderCreatedAt": "Erstellt am",
+    "HeaderCreatedAt_mobile": "Erstellt",
+    "HeaderUpdatedAt": "Modifiziert am",
+    "HeaderUpdatedAt_mobile": "Modifiziert",
+    "HeaderNumItems": "# Sketche",
+    "HeaderNumItems_mobile": "# Sketche",
+    "DirectionAscendingARIA": "Aufsteigend",
+    "DirectionDescendingARIA": "Absteigend",
+    "ButtonLabelAscendingARIA": "Sortieren nach {{displayName}} aufsteigend.",
+    "ButtonLabelDescendingARIA": "Sortieren nach {{displayName}} absteigend.",
+    "AddSketch": "Sketch hinzufügen"
+  },
+  "CollectionListRow": {
+    "ToggleCollectionOptionsARIA": "Schalter Öffnen/Schließen der Sammlungs Optionen",
+    "AddSketch": "Sketch hinzufügen",
+    "Delete": "Löschen",
+    "Rename": "Umbenennen"
+  },
+  "Overlay": {
+    "AriaLabel": "{{title}} Fenster schließen"
+  },
+  "QuickAddList": {
+    "ButtonRemoveARIA": "Aus der Sammlung entfernen",
+    "ButtonAddToCollectionARIA": "Zur Sammlung hinzufügen",
+    "View": "Öffnen"
+  },
+  "SketchList": {
+    "View": "Öffnen",
+    "Title": "p5.js Web Editor | Meine Sketche",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s Sketche",
+    "ToggleLabelARIA": "Schalter Öffnen/Schließen der Sketch Optionen",
+    "DropdownRename": "Umbenennen",
+    "DropdownDownload": "Herunterladen",
+    "DropdownDuplicate": "Duplizieren",
+    "DropdownAddToCollection": "Zur Sammlung hinzufügen",
+    "DropdownDelete": "Löschen",
+    "DirectionAscendingARIA": "Aufsteigend",
+    "DirectionDescendingARIA": "Absteigend",
+    "ButtonLabelAscendingARIA": "Sortieren nach {{displayName}} aufsteigend.",
+    "ButtonLabelDescendingARIA": "Sortieren nach {{displayName}} absteigend.",
+    "AddToCollectionOverlayTitle": "Zur Sammlung hinzufügen",
+    "TableSummary": "Liste mit allen gesicherten Projekten",
+    "HeaderName": "Sketch",
+    "HeaderCreatedAt": "Erstellt am",
+    "HeaderCreatedAt_mobile": "Erstellt",
+    "HeaderUpdatedAt": "Modifiziert am",
+    "HeaderUpdatedAt_mobile": "Modifiziert",
+    "NoSketches": "Keine Sketche."
+  },
+  "AddToCollectionSketchList": {
+    "Title": "p5.js Web Editor | Meine Sketche",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s Sketche",
+    "NoCollections": "Keine Sammlung."
+  },
+  "Editor": {
+    "OpenSketchARIA": "Öffne Sketch Navigation",
+    "CloseSketchARIA": "Schließe Sketch Navigation",
+    "UnsavedChangesARIA": "Der Sketch hat ungesicherte Änderungen",
+    "KeyUpLineNumber": "Zeile {{lineNumber}}"
+  },
+  "EditorAccessibility": {
+    "NoLintMessages": "Keine Lint Warnungen vorhanden ",
+    "CurrentLine": " Aktuelle Zeile"
+  },
+  "Timer": {
+    "SavedAgo": "Gesichert: {{timeAgo}}"
+  },
+  "formatDate": {
+    "JustNow": "gerade eben",
+    "15Seconds": "vor 15 Sekunden",
+    "25Seconds": "vor 25 Sekunden",
+    "35Seconds": "vor 35 Sekunden",
+    "Ago": "vor {{timeAgo}}"
+  },
+  "AddRemoveButton": {
+    "AltAddARIA": "Zur Sammlung hinzufügen",
+    "AltRemoveARIA": "Aus Sammlung entfernen"
+  },
+  "CopyableInput": {
+    "CopiedARIA": "In die Zwischenablage kopiert",
+    "OpenViewTabARIA": "Öffne {{label}} in neuem Tab"
+  },
+  "EditableInput": {
+    "EditValue": "Bearbeite {{display}} Wert",
+    "EmptyPlaceholder": "Kein Wert"
+  },
+  "PreviewNav": {
+    "EditSketchARIA": "Sketch bearbeiten",
+    "ByUser": "von"
+  },
+  "MobilePreferences": {
+    "Settings": "Einstellungen",
+    "GeneralSettings": "Allgemeine Einstellungen",
+    "Accessibility": "Bedienungshilfen",
+    "AccessibleOutput": "Bedienungshilfen Ausgabe",
+    "Theme": "Erscheinungsbild",
+    "LightTheme": "Hell",
+    "DarkTheme": "Dunkel",
+    "HighContrastTheme": "Hoher Kontrast",
+    "Autosave": "Automatisches Speichern",
+    "WordWrap": "Wortumbruch",
+    "LineNumbers": "Zeilennummerierung",
+    "LintWarningSound": "Lint Warnton",
+    "UsedScreenReader": "Nutzung mit Bildschirmlesegerät ",
+    "PlainText": "Nur Text",
+    "TableText": "Tabellarisch",
+    "Sound": "Sound"
+  },
+  "PreferenceCreators": {
+    "On": "An",
+    "Off": "Aus"
+  },
+  "MobileIDEView": {
+    "Preferences": "Einstellungen",
+    "MyStuff": "Mein Zeug",
+    "Examples": "Beispiele",
+    "OriginalEditor": "Original Editor",
+    "Login": "Anmelden",
+    "Logout": "Abmelden"
+  },
+  "MobileDashboardView": {
+    "Examples":  "Beispiele",
+    "Sketches":  "Sketche",
+    "Collections": "Sammlungen",
+    "Assets": "Assets",
+    "MyStuff": "Mein Zeug",
+    "CreateSketch": "Sketch erstellen",
+    "CreateCollection": "Sammlung erstellen"
+  },
+  "Explorer": {
+    "Files": "Dateien"
+  }
+}
+

--- a/translations/locales/de/translations.json
+++ b/translations/locales/de/translations.json
@@ -12,7 +12,7 @@
     },
     "Edit": {
       "Title": "Bearbeiten",
-      "TidyCode": "Code aufräumen",
+      "TidyCode": "Code formatieren",
       "Find": "Finden",
       "Replace": "Ersetzen"
     },
@@ -31,7 +31,7 @@
     },
     "Lang": "Sprache",
     "BackEditor": "Zurück zum Editor",
-    "WarningUnsavedChanges": "Bist du sicher, dass du die Seite verlassen willst? Du hast ungesicherte Änderungen.",
+    "WarningUnsavedChanges": "Bist Du sicher, dass Du die Seite verlassen willst? Du hast ungesicherte Änderungen.",
     "Login": "Anmelden",
     "LoginOr": "oder",
     "SignUp": "Registrieren",
@@ -55,7 +55,7 @@
     "ReplaceAll": "Alle Ersetzen",
     "ReplacePlaceholder": "Ersetzen mit",
     "Regex": "Regulärer Ausdruck",
-    "CaseSensitive": "Groß- Kleinschreibung beachten",
+    "CaseSensitive": "Groß-/Kleinschreibung beachten",
     "WholeWords": "Ganze Worte",
     "Previous": "Vorheriges",
     "Next": "Nächstes",
@@ -74,8 +74,8 @@
     "Login": "Einloggen",
     "LoginOr": "oder",
     "SignUp": "Registrieren",
-    "Email": "email",
-    "Username": "nutzername",
+    "Email": "E-Mail",
+    "Username": "Nutzername",
     "DontHaveAccount": "Noch keinen Account? ",
     "ForgotPassword": "Passwort vergessen?",
     "ResetPassword": "Passwort zurücksetzen"
@@ -101,8 +101,8 @@
   "Toast": {
     "OpenedNewSketch": "Neuer Sketch geöffnet.",
     "SketchSaved": "Sketch gesichert.",
-    "SketchFailedSave": "Fehler beim sichern deines Sketches.",
-    "AutosaveEnabled": "Automatisches sichern aktiviert.",
+    "SketchFailedSave": "Fehler beim Sichern Deines Sketches.",
+    "AutosaveEnabled": "Automatisches Sichern aktiviert.",
     "LangChange": "Sprache geändert",
     "SettingsSaved": "Einstellungen gespeichert."
   },
@@ -156,7 +156,7 @@
     "LineNumbers": "Zeilennummerierung",
     "LineNumbersOnARIA": "Zeilennummerierung an",
     "LineNumbersOffARIA": "Zeilennummerierung aus",
-    "LintWarningSound": "Lint Warnton",
+    "LintWarningSound": "Lint-Warnton",
     "LintWarningOnARIA": "lint Warnton an",
     "LintWarningOffARIA": "lint Warnton aus",
     "PreviewSound": "Warnton anhören",
@@ -172,7 +172,7 @@
   },
   "KeyboardShortcuts": {
     "Title": "Tastenkürzel",
-    "ShortcutsFollow": "Die Tastenkürzel zum editieren des Codes folgen den",
+    "ShortcutsFollow": "Die Tastenkürzel zum Editieren des Codes folgen den",
     "SublimeText": "Sublime Tastenkürzeln",
     "CodeEditing": {
       "Tidy": "Code aufräumen",
@@ -183,8 +183,8 @@
       "IndentCodeLeft": "Code links einrücken",
       "IndentCodeRight": "Code rechts einrücken",
       "CommentLine": "Kommentar einfügen",
-      "FindNextTextMatch": "Nächsten Text Treffer finden",
-      "FindPreviousTextMatch": "Vorherigen Text Treffer finden",
+      "FindNextTextMatch": "Nächsten Text-Treffer finden",
+      "FindPreviousTextMatch": "Vorherigen Text-Treffer finden",
       "CodeEditing": "Code editieren"
     },
     "General": {
@@ -222,7 +222,7 @@
     "ErrorARIA": "Fehler",
     "Save": "Speichern",
     "p5logoARIA": "p5.js Logo",
-    "DeleteConfirmation": "Bist du sicher, dass du {{name}} löschen möchtest?"
+    "DeleteConfirmation": "Bist Du sicher, dass Du {{name}} löschen möchtest?"
   },
   "IDEView": {
     "SubmitFeedback": "Feedback abgeben",
@@ -246,7 +246,7 @@
     "Title": "Neuer Ordner",
     "CloseButtonARIA": "Neuer Ordner Fenster schließen",
     "EnterName": "Bitte gib einen Namen ein",
-    "EmptyName": "Der Ordner Name kann keine Leerzeichen enthalten",
+    "EmptyName": "Der Ordnername kann keine Leerzeichen enthalten",
     "InvalidExtension": "Der Ordnername kann keine Datei-Endung enthalten"
   },
   "NewFolderForm": {
@@ -254,14 +254,14 @@
     "Placeholder": "Name"
   },
   "ResetPasswordForm": {
-    "Email": "E-Mail, die zum registrieren verwendet wurde.",
+    "Email": "E-Mail, die zum Registrieren verwendet wurde.",
     "EmailARIA": "email",
     "Submit": "Passwort an E-Mail senden"
   },
   "ResetPasswordView": {
     "Title": "p5.js Web Editor | Passwort zurücksetzen",
     "Reset": "Passwort zurücksetzen",
-    "Submitted": "Die E-Mail zum zurücksetzen deines Passwort, sollte in kürze eintreffen. Wenn Du sie nicht \n findest, schau in Deinem Spam Ordner nach.",
+    "Submitted": "Die E-Mail zum Zurücksetzen Deines Passworts sollte in Kürze eintreffen. Wenn Du sie nicht \n findest, schau in Deinem Spam-Ordner nach.",
     "Login": "Einloggen",
     "LoginOr": "oder",
     "SignUp": "Registrieren"
@@ -290,7 +290,7 @@
     "Email": "E-Mail",
     "EmailARIA": "email",
     "Unconfirmed": "Unbestätigt.",
-    "EmailSent": "Bestätigung gesendet, schau in deine E-Mails.",
+    "EmailSent": "Bestätigung gesendet, schau in Deine E-Mails.",
     "Resend": "Bestätigung erneut senden",
     "UserName": "Nutzername",
     "UserNameARIA": "nutzername",
@@ -302,7 +302,7 @@
   },
   "AccountView": {
     "SocialLogin": "Social Login",
-    "SocialLoginDescription": "Nutze deinen GitHub oder Google Account um dich beim p5.js Web Editor anzumelden.",
+    "SocialLoginDescription": "Nutze Deinen GitHub oder Google Account um dich beim p5.js Web Editor anzumelden.",
     "Title": "p5.js Web Editor | Account Einstellungen",
     "Settings": "Account Einstellungen",
     "AccountTab": "Account",
@@ -310,7 +310,7 @@
   },
   "APIKeyForm": {
     "ConfirmDelete": "Bist Du dir sicher, dass Du {{key_label}} löschen willst?",
-    "Summary": "Persönliche Zugangstoken fungieren wie Dein Passwort. \n Sie erlauben automatisierten Skripten Zugang zur Editor API. \n Erstelle einen Token für jedes Skript, das Zugang benötigt.",
+    "Summary": "Persönliche Zugangstoken fungieren wie Dein Passwort. \n Sie erlauben automatisierten Skripten Zugang zur Editor-API. \n Erstelle einen Token für jedes Skript, das Zugang benötigt.",
     "CreateToken": "Neuen Token erstellen",
     "TokenLabel": "Wofür wird dieser Token genutzt?",
     "TokenPlaceholder": "Wofür wird dieser Token genutzt? Z.B. um Skripte zu importieren.",
@@ -350,15 +350,15 @@
     "Title": "p5.js Web Editor | Registrieren",
     "Description": "Registrieren",
     "Or": "Oder",
-    "AlreadyHave": "Hast Du bereits einen Account?",
+    "AlreadyHave": "Hast Du bereits einen Account? ",
     "Login": "Anmelden"
   },
   "EmailVerificationView": {
     "Title": "p5.js Web Editor | E-Mail Bestätigung",
-    "Verify": "Bestätige deine E-Mail",
+    "Verify": "Bestätige Deine E-Mail",
     "InvalidTokenNull": "Der Link ist ungültig.",
     "Checking": "Überprüfe Token, bitte warten...",
-    "Verified": "Geschafft, deine E-Mailadresse wurde bestätigt.",
+    "Verified": "Geschafft, Deine E-Mailadresse wurde bestätigt.",
     "InvalidState": "Etwas ist schief gelaufen."
   },
   "AssetList": {
@@ -395,15 +395,15 @@
   },
 
   "ErrorModal": {
-    "MessageLogin": "Um Deinen Sketch sichern zu können musst du angemeldet sein. Bitte ",
+    "MessageLogin": "Um Deinen Sketch sichern zu können musst Du angemeldet sein. Bitte ",
     "Login": "Melde Dich an",
     "LoginOr": " oder ",
     "SignUp": "Registriere Dich",
     "MessageLoggedOut": "Es scheint als hättest Du Dich abgemeldet. Bitte ",
     "LogIn": "melde Dich an",
     "SavedDifferentWindow": "Das Projekt, dass Du speichern möchtest, wurde in einem anderen Fenster gespeichert. \n        Bitte lade die Seite neu um die aktuelle Version zu sehen.",
-    "LinkTitle": "Fehler beim verbinden deines Accounts",
-    "LinkMessage": "Es gab einen Fehler, beim verbinden deines {{serviceauth}} Accounts mit deinem p5.js Web Editor Account. Dein {{serviceauth}} wurde bereits mit einem anderen p5.js Web Editor Account verknüpft."
+    "LinkTitle": "Fehler beim Verbinden Deines Accounts",
+    "LinkMessage": "Es gab einen Fehler beim Verbinden Deines {{serviceauth}} Accounts mit Deinem p5.js Web Editor Account. Dein {{serviceauth}} wurde bereits mit einem anderen p5.js Web Editor Account verknüpft."
   },
   "ShareModal": {
     "Embed": "Einbetten",
@@ -421,7 +421,7 @@
     "Share": "Teilen",
     "URLLink": "Link zur Sammlung",
     "AddSketch": "Sketch hinzufügen",
-    "DeleteFromCollection": "Bist Du sicher, dass du {{name_sketch}} aus dieser Sammlung entfernen willst?",
+    "DeleteFromCollection": "Bist Du sicher, dass Du {{name_sketch}} aus dieser Sammlung entfernen willst?",
     "SketchDeleted": "Sketch gelöscht",
     "SketchRemoveARIA": "Sketch aus der Sammlung entfernen",
     "DescriptionPlaceholder": "Beschreibung hinzufügen",
@@ -532,7 +532,7 @@
     "KeyUpLineNumber": "Zeile {{lineNumber}}"
   },
   "EditorAccessibility": {
-    "NoLintMessages": "Keine Lint Warnungen vorhanden ",
+    "NoLintMessages": "Keine Lint-Warnungen vorhanden ",
     "CurrentLine": " Aktuelle Zeile"
   },
   "Timer": {
@@ -573,7 +573,7 @@
     "Autosave": "Automatisches Speichern",
     "WordWrap": "Wortumbruch",
     "LineNumbers": "Zeilennummerierung",
-    "LintWarningSound": "Lint Warnton",
+    "LintWarningSound": "Lint-Warnton",
     "UsedScreenReader": "Nutzung mit Bildschirmlesegerät ",
     "PlainText": "Nur Text",
     "TableText": "Tabellarisch",
@@ -587,7 +587,7 @@
     "Preferences": "Einstellungen",
     "MyStuff": "Mein Zeug",
     "Examples": "Beispiele",
-    "OriginalEditor": "Original Editor",
+    "OriginalEditor": "Original-Editor",
     "Login": "Anmelden",
     "Logout": "Abmelden"
   },


### PR DESCRIPTION
Fixes #1783 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

Hi there, as mentioned in issue #1783, I've added a german translation for the web editor. (Took longer than expected)

I sorted it in the dropdown under Portuguese to have all "Latin" languages grouped together. Hope that's ok. 
![Screenshot 2021-05-18 at 12 14 52](https://user-images.githubusercontent.com/33449313/118634898-50696900-b7d3-11eb-967d-1daed57b848e.png)
