### PR TITLE
Remove unused editor options code

### DIFF
--- a/client/modules/IDE/actions/ide.js
+++ b/client/modules/IDE/actions/ide.js
@@ -171,18 +171,6 @@ export function closeShareModal() {
   };
 }
 
-export function showEditorOptions() {
-  return {
-    type: ActionTypes.SHOW_EDITOR_OPTIONS
-  };
-}
-
-export function closeEditorOptions() {
-  return {
-    type: ActionTypes.CLOSE_EDITOR_OPTIONS
-  };
-}
-
 export function showKeyboardShortcutModal() {
   return {
     type: ActionTypes.SHOW_KEYBOARD_SHORTCUT_MODAL

--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -362,20 +362,10 @@ class Editor extends React.Component {
     });
   }
 
-  toggleEditorOptions() {
-    if (this.props.editorOptionsVisible) {
-      this.props.closeEditorOptions();
-    } else {
-      this.optionsButton.focus();
-      this.props.showEditorOptions();
-    }
-  }
-
   render() {
     const editorSectionClass = classNames({
       editor: true,
-      'sidebar--contracted': !this.props.isExpanded,
-      'editor--options': this.props.editorOptionsVisible
+      'sidebar--contracted': !this.props.isExpanded
     });
 
     const editorHolderClass = classNames({
@@ -462,9 +452,6 @@ Editor.propTypes = {
     fileType: PropTypes.string.isRequired,
     url: PropTypes.string
   }).isRequired,
-  editorOptionsVisible: PropTypes.bool.isRequired,
-  showEditorOptions: PropTypes.func.isRequired,
-  closeEditorOptions: PropTypes.func.isRequired,
   setUnsavedChanges: PropTypes.func.isRequired,
   startRefreshSketch: PropTypes.func.isRequired,
   autorefresh: PropTypes.bool.isRequired,

--- a/client/modules/IDE/reducers/ide.js
+++ b/client/modules/IDE/reducers/ide.js
@@ -14,7 +14,6 @@ const initialState = {
   shareModalProjectId: 'abcd',
   shareModalProjectName: 'My Cute Sketch',
   shareModalProjectUsername: 'p5_user',
-  editorOptionsVisible: false,
   keyboardShortcutVisible: false,
   unsavedChanges: false,
   infiniteLoop: false,
@@ -82,10 +81,6 @@ const ide = (state = initialState, action) => {
       });
     case ActionTypes.CLOSE_SHARE_MODAL:
       return Object.assign({}, state, { shareModalVisible: false });
-    case ActionTypes.SHOW_EDITOR_OPTIONS:
-      return Object.assign({}, state, { editorOptionsVisible: true });
-    case ActionTypes.CLOSE_EDITOR_OPTIONS:
-      return Object.assign({}, state, { editorOptionsVisible: false });
     case ActionTypes.SHOW_KEYBOARD_SHORTCUT_MODAL:
       return Object.assign({}, state, { keyboardShortcutVisible: true });
     case ActionTypes.CLOSE_KEYBOARD_SHORTCUT_MODAL:

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -372,41 +372,6 @@ pre.CodeMirror-line {
   height: #{29 / $base-font-size}rem;
 }
 
-.editor__options-button {
-  @include icon();
-  position: absolute;
-  top: #{10 / $base-font-size}rem;
-  right: #{2 / $base-font-size}rem;
-  z-index: 1;
-}
-
-
-.editor__options {
-  display: none;
-  @extend %modal;
-  position: absolute;
-  right: #{0 / $base-font-size}rem;
-  padding: #{8 / $base-font-size}rem #{20 / $base-font-size}rem;
-  font-size: #{12 / $base-font-size}rem;
-  @include themify() {
-    background-color: getThemifyVariable('modal-background-color');
-    box-shadow: 0 0 18px getThemifyVariable('shadow-color');
-  }
-  .editor--options & {
-    display: block;
-  }
-}
-
-.editor__options li {
-  padding: #{4 / $base-font-size}rem 0;
-}
-
-.editor__options a {
-  @include themify() {
-    color: getThemifyVariable('secondary-text-color');
-  }
-}
-
 .editor__file-name {
   @include themify() {
     color: getThemifyVariable('primary-text-color');

--- a/client/testData/testReduxStore.js
+++ b/client/testData/testReduxStore.js
@@ -32,7 +32,6 @@ const initialTestState = {
     shareModalProjectId: 'abcd',
     shareModalProjectName: 'My Cute Sketch',
     shareModalProjectUsername: 'p5_user',
-    editorOptionsVisible: false,
     keyboardShortcutVisible: false,
     unsavedChanges: false,
     infiniteLoop: false,


### PR DESCRIPTION
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`

I found some random unused code an `editor__options` component so this removes that code.
