### PR TITLE
[#1899] Add allow-downloads to iframe sandbox attributes

### DIFF
--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -23,7 +23,7 @@ function PreviewFrame({ fullView }) {
 
   const frameUrl = previewUrl;
   const sandboxAttributes = `allow-forms allow-modals allow-pointer-lock allow-popups 
-    allow-same-origin allow-scripts allow-top-navigation-by-user-activation`;
+    allow-same-origin allow-scripts allow-top-navigation-by-user-activation allow-downloads`;
   const allow =
     'accelerometer; autoplay; camera; encrypted-media; geolocation; gyroscope; microphone; magnetometer; midi; vr;';
   return (


### PR DESCRIPTION
Fixes #1899
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
