### PR TITLE
Fixes #1922

### DIFF
--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -25,7 +25,7 @@ function PreviewFrame({ fullView }) {
   const sandboxAttributes = `allow-forms allow-modals allow-pointer-lock allow-popups 
     allow-same-origin allow-scripts allow-top-navigation-by-user-activation allow-downloads`;
   const allow =
-    'accelerometer; autoplay; camera; encrypted-media; geolocation; gyroscope; microphone; magnetometer; midi; vr;';
+    'accelerometer; autoplay; camera; encrypted-media; geolocation; gyroscope; microphone; magnetometer; midi; vr; serial;';
   return (
     <Frame
       title="sketch preview"


### PR DESCRIPTION
Add WebSerial to the allow allow attributes for the preview iframe

Fixes #1922

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
