### PR TITLE
Add link to testing guide in the development docs

### DIFF
--- a/developer_docs/README.md
+++ b/developer_docs/README.md
@@ -4,6 +4,7 @@ This folder contains documents intended for developers of the p5.js Web Editor.
 * [Contribution Guide](https://github.com/processing/p5.js-web-editor/blob/develop/.github/CONTRIBUTING.md) - A place to get started!
 * [Installation](installation.md) - A guide for setting up your development environment
 * [Development](development.md) - A guide for adding code to the web editor
+* [Testing](./testing.md) - A guide for writing and running tests in the codebase
 * [Preparing a pull-request](preparing_a_pull_request.md) - Instructions for how to make a pull-request
 * [Accessibility Guidelines](accessibility.md) - Guidelines for writing code to create an accessible application
 * [Translations Guidelines](translations.md) - Guidelines for translating the application


### PR DESCRIPTION
Doesn't fix an issue but adds a line to the README :)

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
