### PR TITLE
Chore/ban users

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -38,6 +38,11 @@ passport.use(
         if (!user) {
           done(null, false, { msg: `Email ${email} not found.` });
           return;
+        } else if (user.banned) {
+          const msg =
+            'Account has been suspended. Please contact privacy@p5js.org if you believe this is an error.';
+          done(null, false, { msg });
+          return;
         }
         user.comparePassword(password, (innerErr, isMatch) => {
           if (isMatch) {
@@ -63,6 +68,12 @@ passport.use(
       }
       if (!user) {
         done(null, false);
+        return;
+      }
+      if (user.banned) {
+        const msg =
+          'Account has been suspended. Please contact privacy@p5js.org if you believe this is an error.';
+        done(null, false, { msg });
         return;
       }
       user.findMatchingKey(key, (innerErr, isMatch, keyDocument) => {
@@ -116,6 +127,11 @@ passport.use(
               new Error('GitHub account is already linked to another account.')
             );
             return;
+          } else if (existingUser.banned) {
+            const msg =
+              'Account has been suspended. Please contact privacy@p5js.org if you believe this is an error.';
+            done(new Error(msg));
+            return;
           }
           done(null, existingUser);
           return;
@@ -123,6 +139,7 @@ passport.use(
 
         const emails = getVerifiedEmails(profile.emails);
         const primaryEmail = getPrimaryEmail(profile.emails);
+        console.log(profile);
 
         if (req.user) {
           if (!req.user.github) {
@@ -196,11 +213,15 @@ passport.use(
                 )
               );
               return;
+            } else if (existingUser.banned) {
+              const msg =
+                'Account has been suspended. Please contact privacy@p5js.org if you believe this is an error.';
+              done(new Error(msg));
+              return;
             }
             done(null, existingUser);
             return;
           }
-
           const primaryEmail = profile._json.emails[0].value;
 
           if (req.user) {

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -10,6 +10,9 @@ import { BasicStrategy } from 'passport-http';
 
 import User from '../models/user';
 
+const accountSuspensionMessage =
+  'Account has been suspended. Please contact privacy@p5js.org if you believe this is an error.';
+
 function generateUniqueUsername(username) {
   const adj =
     friendlyWords.predicates[
@@ -39,9 +42,7 @@ passport.use(
           done(null, false, { msg: `Email ${email} not found.` });
           return;
         } else if (user.banned) {
-          const msg =
-            'Account has been suspended. Please contact privacy@p5js.org if you believe this is an error.';
-          done(null, false, { msg });
+          done(null, false, { msg: accountSuspensionMessage });
           return;
         }
         user.comparePassword(password, (innerErr, isMatch) => {
@@ -71,9 +72,7 @@ passport.use(
         return;
       }
       if (user.banned) {
-        const msg =
-          'Account has been suspended. Please contact privacy@p5js.org if you believe this is an error.';
-        done(null, false, { msg });
+        done(null, false, { msg: accountSuspensionMessage });
         return;
       }
       user.findMatchingKey(key, (innerErr, isMatch, keyDocument) => {
@@ -129,9 +128,7 @@ passport.use(
             );
             return;
           } else if (existingUser.banned) {
-            const msg =
-              'Account has been suspended. Please contact privacy@p5js.org if you believe this is an error.';
-            done(new Error(msg));
+            done(new Error(accountSuspensionMessage));
             return;
           }
           done(null, existingUser);
@@ -140,7 +137,6 @@ passport.use(
 
         const emails = getVerifiedEmails(profile.emails);
         const primaryEmail = getPrimaryEmail(profile.emails);
-        console.log(profile);
 
         if (req.user) {
           if (!req.user.github) {
@@ -161,6 +157,10 @@ passport.use(
                 );
               } else {
                 [existingEmailUser] = existingEmailUsers;
+              }
+              if (existingEmailUser.banned) {
+                done(new Error(accountSuspensionMessage));
+                return;
               }
               existingEmailUser.email = existingEmailUser.email || primaryEmail;
               existingEmailUser.github = profile.id;
@@ -225,9 +225,7 @@ passport.use(
               );
               return;
             } else if (existingUser.banned) {
-              const msg =
-                'Account has been suspended. Please contact privacy@p5js.org if you believe this is an error.';
-              done(new Error(msg));
+              done(new Error(accountSuspensionMessage));
               return;
             }
             done(null, existingUser);
@@ -257,6 +255,10 @@ passport.use(
                     // what if a username is already taken from the display name too?
                     // then, append a random friendly word?
                     if (existingEmailUser) {
+                      if (existingEmailUser.banned) {
+                        done(new Error(accountSuspensionMessage));
+                        return;
+                      }
                       existingEmailUser.email =
                         existingEmailUser.email || primaryEmail;
                       existingEmailUser.google = profile._json.emails[0].value;

--- a/server/controllers/session.controller.js
+++ b/server/controllers/session.controller.js
@@ -24,7 +24,7 @@ export function createSession(req, res, next) {
 }
 
 export function getSession(req, res) {
-  if (req.user) {
+  if (req.user && !req.user.banned) {
     return res.json(userResponse(req.user));
   }
   return res.status(404).send({ message: 'Session does not exist' });

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -81,7 +81,8 @@ const userSchema = new Schema(
       type: String,
       enum: ['none', 'essential', 'all'],
       default: 'none'
-    }
+    },
+    banned: { type: Boolean, default: false }
   },
   { timestamps: true, usePushEach: true }
 );


### PR DESCRIPTION
RE #609 

Need a way to ban users that have violated the ToS/PP. Can simply add `banned: true` to a user in the database to suspend their account, rather than delete all of their data. 

A user's sketches will still be public, so I need to add a script that hides all of their sketches if they have been banned. Will use the sketch privacy code in the future, and need a script to automate banning a user. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
