### PR TITLE
[#1938] Add height: 100% to Fullscreen view

### DIFF
--- a/client/modules/IDE/pages/FullView.jsx
+++ b/client/modules/IDE/pages/FullView.jsx
@@ -46,7 +46,7 @@ function FullView(props) {
     };
   }, []);
   return (
-    <RootPage>
+    <RootPage fixedHeight="100%">
       <Helmet>
         <title>{project.name}</title>
       </Helmet>


### PR DESCRIPTION
Fixes #1938

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
