### PR TITLE
Revert change to production deploy script to build only on tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy to production
 on:
   workflow_run:
     workflows: ["Test"]
-    tags:
-      - '*'
+    branches:
+      - release
     types:
       - completed
 env:


### PR DESCRIPTION
I made a change so that the production deployment would only happen when a tag is pushed, but it's not working. Reverting to the old way to build when pushing to release for now.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] is from a uniquely-named feature branch and has been rebased on top of the latest `develop` branch. (If I was asked to make more changes, I have made sure to rebase onto `develop` then too)
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
