### PR TITLE
Fix typo in zh-TW

### DIFF
--- a/translations/locales/zh-TW/translations.json
+++ b/translations/locales/zh-TW/translations.json
@@ -103,7 +103,7 @@
     "SketchSaved": "草稿已儲存",
     "SketchFailedSave": "草稿儲存失敗",
     "AutosaveEnabled": "已啟用自動儲存",
-    "LangChange": "已辨更語系",
+    "LangChange": "已變更語系",
     "SettingsSaved": "已儲存設定"
   },
   "Toolbar": {


### PR DESCRIPTION
Just for fixing a little typo in zh-TW file.