### PR TITLE
Add component for outage notification

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -36,6 +36,7 @@ import Feedback from '../components/Feedback';
 import { CollectionSearchbar } from '../components/Searchbar';
 import { getIsUserOwner } from '../selectors/users';
 import RootPage from '../../../components/RootPage';
+import Notification from '../../User/components/Notification';
 
 function getTitle(props) {
   const { id } = props.project;
@@ -252,6 +253,7 @@ class IDEView extends React.Component {
   render() {
     return (
       <RootPage>
+        <Notification />
         <Helmet>
           <title>{getTitle(this.props)}</title>
         </Helmet>

--- a/client/modules/User/components/Notification.jsx
+++ b/client/modules/User/components/Notification.jsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import Cookies from 'js-cookie';
+import { useDispatch } from 'react-redux';
+import { showToast, setToastText } from '../../IDE/actions/toast';
+
+function Notification() {
+  const dispatch = useDispatch();
+  useEffect(() => {
+    const notification = Cookies.get('p5-notification');
+    if (!notification) {
+      // show the toast
+      dispatch(showToast(30000));
+      const text = `There is a scheduled outage on Sunday, April 9 3AM - 5AM UTC.
+        The entire site will be down, so please plan accordingly.`;
+      dispatch(setToastText(text));
+      Cookies.set('p5-notification', true, { expires: 365 });
+    }
+  });
+  return null;
+}
+
+export default Notification;


### PR DESCRIPTION

Changes:
This PR adds a `Notification` component with an outage message. This is to prepare for the database maintenance scheduled for Saturday, April 8 11PM EDT. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`


