### PR TITLE
Update links to design principles and issue labels in contributor_docs/README.md

### DIFF
--- a/contributor_docs/README.md
+++ b/contributor_docs/README.md
@@ -12,6 +12,6 @@ This folder contains documents intended for developers of the p5.js Web Editor.
 * [Release](./release.md) - A guide to creating a production release.
 
 ## Documents to Create
-* Design Principles - reference [p5.js design principles](https://github.com/processing/p5.js/edit/develop/contributor_docs/design_principles.md)
-* Issue Labels - reference [p5.js issue labels](https://github.com/processing/p5.js/blob/develop/contributor_docs/issue_labels.md)
+* Design Principles - reference [p5.js design principles](https://github.com/processing/p5.js/blob/main/contributor_docs/design_principles.md)
+* Issue Labels - reference [p5.js issue labels](https://github.com/processing/p5.js/blob/main/contributor_docs/issue_labels.md)
 * File Structure - An explanation of the file structure of this application.


### PR DESCRIPTION
See title. Small link fix in contributor documentation.

Fixes #2097 

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
