### PR TITLE
file drawer filename space issue fixed

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -50,7 +50,7 @@ function FileName({ name }) {
   return (
     <span className="sidebar__file-item-name-text">
       <span>{firstLetter}</span>
-      {middleText.charAt(middleText.length - 1) === ' ' && <span>&nbsp;</span>}
+      {middleText.charAt(0) === ' ' && <span>&nbsp;</span>}
       {baseName.length > 2 && (
         <span className="sidebar__file-item-name--ellipsis">
           {middleText.trim()}

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -50,13 +50,13 @@ function FileName({ name }) {
   return (
     <span className="sidebar__file-item-name-text">
       <span>{firstLetter}</span>
-      {middleText.charAt(0) === ' ' && <span>&nbsp;</span>}
       {baseName.length > 2 && (
         <span className="sidebar__file-item-name--ellipsis">
+          {middleText.charAt(0) === ' ' && <>&nbsp;</>}
           {middleText.trim()}
+          {middleText.charAt(middleText.length - 1) === ' ' && <>&nbsp;</>}
         </span>
       )}
-      {middleText.charAt(middleText.length - 1) === ' ' && <span>&nbsp;</span>}
       {baseName.length > 1 && <span>{lastLetter}</span>}
       {extension && <span>{extension}</span>}
     </span>

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -51,11 +51,7 @@ function FileName({ name }) {
     <span className="sidebar__file-item-name-text">
       <span>{firstLetter}</span>
       {baseName.length > 2 && (
-        <span className="sidebar__file-item-name--ellipsis">
-          {middleText.charAt(0) === ' ' && <>&nbsp;</>}
-          {middleText.trim()}
-          {middleText.charAt(middleText.length - 1) === ' ' && <>&nbsp;</>}
-        </span>
+        <span className="sidebar__file-item-name--ellipsis">{middleText}</span>
       )}
       {baseName.length > 1 && <span>{lastLetter}</span>}
       {extension && <span>{extension}</span>}

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -50,8 +50,11 @@ function FileName({ name }) {
   return (
     <span className="sidebar__file-item-name-text">
       <span>{firstLetter}</span>
+      {middleText.charAt(middleText.length - 1) === ' ' && <span>&nbsp;</span>}
       {baseName.length > 2 && (
-        <span className="sidebar__file-item-name--ellipsis">{middleText}</span>
+        <span className="sidebar__file-item-name--ellipsis">
+          {middleText.trim()}
+        </span>
       )}
       {middleText.charAt(middleText.length - 1) === ' ' && <span>&nbsp;</span>}
       {baseName.length > 1 && <span>{lastLetter}</span>}

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -53,6 +53,7 @@ function FileName({ name }) {
       {baseName.length > 2 && (
         <span className="sidebar__file-item-name--ellipsis">{middleText}</span>
       )}
+      {middleText.charAt(middleText.length - 1) === ' ' && <span>&nbsp;</span>}
       {baseName.length > 1 && <span>{lastLetter}</span>}
       {extension && <span>{extension}</span>}
     </span>

--- a/client/styles/components/_sidebar.scss
+++ b/client/styles/components/_sidebar.scss
@@ -115,6 +115,7 @@
   white-space: nowrap;
   text-overflow: ellipsis;
   min-width: #{7 / $base-font-size}rem;
+  white-space: pre;
 }
 
 .sidebar__file-item-name-text {


### PR DESCRIPTION
Fixes #2106

Changes:
I've made changes in the `client/modules/IDE/components/FileNode.jsx` file.
```javascript
{middleText.charAt(middleText.length - 1) === ' ' && <span>&nbsp;</span>}
```
I've added this in `FileName()` function, as the html syntax was not detecting the space after the middle text which was causing the issue to occur, now it is fixed
![p5fixed](https://user-images.githubusercontent.com/71703033/219490794-cb729707-8545-4c96-9d57-26c921647c2e.png)

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
