### PR TITLE
downloadzip-solved

### DIFF
--- a/server/controllers/project.controller.js
+++ b/server/controllers/project.controller.js
@@ -222,7 +222,10 @@ function addFileToZip(file, files, zip, path = '') {
       const numChildFiles = file.children.filter((f) => f.fileType !== 'folder')
         .length;
       let childrenAdded = 0;
-
+      if (numChildFiles === 0) {
+        zip.folder(file.name);
+        resolve();
+      }
       file.children.forEach(async (fileId) => {
         const childFile = files.find((f) => f.id === fileId);
 


### PR DESCRIPTION
fixes issue #2071 

hey @raclim @catarak please review this PR , your suggestions are admired

Problem:
When there is empty folder in projects , it don't enter this line https://github.com/processing/p5.js-web-editor/blob/develop/server/controllers/project.controller.js#L226 hence it doesnot encounters `resolve()` statement

Solution:
As empty folder don't have childrens we can directly resolve that 