### PR TITLE
Local storage

### DIFF
--- a/client/constants.js
+++ b/client/constants.js
@@ -17,6 +17,7 @@ export const SET_LINE_NUMBERS = 'SET_LINE_NUMBERS';
 export const AUTH_USER = 'AUTH_USER';
 export const UNAUTH_USER = 'UNAUTH_USER';
 export const AUTH_ERROR = 'AUTH_ERROR';
+export const THEME_KEY = 'THEME_KEY';
 
 export const SETTINGS_UPDATED = 'SETTINGS_UPDATED';
 

--- a/client/modules/IDE/reducers/preferences.js
+++ b/client/modules/IDE/reducers/preferences.js
@@ -1,3 +1,4 @@
+import { THEME_KEY } from '../../../constants';
 import * as ActionTypes from '../../../constants';
 
 const initialState = {
@@ -8,7 +9,7 @@ const initialState = {
   lintWarning: false,
   textOutput: false,
   gridOutput: false,
-  theme: 'light',
+  theme: localStorage.getItem(THEME_KEY) || 'light',
   autorefresh: false,
   language: 'en-US',
   autocloseBracketsQuotes: true
@@ -31,6 +32,7 @@ const preferences = (state = initialState, action) => {
     case ActionTypes.SET_PREFERENCES:
       return action.preferences;
     case ActionTypes.SET_THEME:
+      localStorage.setItem(THEME_KEY, action.value);
       return Object.assign({}, state, { theme: action.value });
     case ActionTypes.SET_AUTOREFRESH:
       return Object.assign({}, state, { autorefresh: action.value });


### PR DESCRIPTION
Fixes #2144 

Changes: these changes allows the editor to store the theme locally for the next refresh 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
