### PR TITLE
Dashboard back btn fix

### DIFF
--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -246,7 +246,6 @@ class Nav extends React.PureComponent {
           />
         </li>
         <li className="nav__item nav__item--no-icon">
-          {/* <Link to="/" className="nav__back-link"> */}
           <button
             className="nav__back-link"
             onClick={(e) => {
@@ -263,7 +262,6 @@ class Nav extends React.PureComponent {
               {this.props.t('Nav.BackEditor')}
             </span>
           </button>
-          {/* </Link> */}
         </li>
       </ul>
     );

--- a/client/components/Nav.jsx
+++ b/client/components/Nav.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router';
-import { Link } from 'react-router';
+import { Link, browserHistory } from 'react-router';
 import classNames from 'classnames';
 import { withTranslation } from 'react-i18next';
 import { languageKeyToLabel } from '../i18n';
@@ -75,6 +75,7 @@ class Nav extends React.PureComponent {
     document.removeEventListener('mousedown', this.handleClick, false);
     document.removeEventListener('keydown', this.closeDropDown, false);
   }
+
   setDropdown(dropdown) {
     this.setState({
       dropdownOpen: dropdown
@@ -245,7 +246,14 @@ class Nav extends React.PureComponent {
           />
         </li>
         <li className="nav__item nav__item--no-icon">
-          <Link to="/" className="nav__back-link">
+          {/* <Link to="/" className="nav__back-link"> */}
+          <button
+            className="nav__back-link"
+            onClick={(e) => {
+              e.preventDefault();
+              browserHistory.goBack();
+            }}
+          >
             <CaretLeftIcon
               className="nav__back-icon"
               focusable="false"
@@ -254,7 +262,8 @@ class Nav extends React.PureComponent {
             <span className="nav__item-header">
               {this.props.t('Nav.BackEditor')}
             </span>
-          </Link>
+          </button>
+          {/* </Link> */}
         </li>
       </ul>
     );


### PR DESCRIPTION
Fixes #2175 

Changes:
removed hardcoded link `'/'` in `<Link>` in `nav__back-link` and added use of `browserHIstory` which fixes the issue.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
