### PR TITLE
Fix #2040 - Inaccurate rendering during file upload

### DIFF
--- a/client/modules/IDE/actions/uploader.js
+++ b/client/modules/IDE/actions/uploader.js
@@ -73,7 +73,6 @@ export function dropzoneAcceptCallback(userId, file, done) {
           file.custom_status = 'ready'; // eslint-disable-line
           file.postData = response.data; // eslint-disable-line
           file.s3 = response.data.key; // eslint-disable-line
-          file.previewTemplate.className += ' uploading'; // eslint-disable-line
           done();
         })
         .catch((error) => {
@@ -108,7 +107,9 @@ export function dropzoneCompleteCallback(file) {
       (!file.name.match(TEXT_FILE_REGEX) || file.size >= MAX_LOCAL_FILE_SIZE) &&
       file.status !== 'error'
     ) {
-      let inputHidden = '<input type="hidden" name="attachments[]" value="';
+      const input = document.createElement('input');
+      input.setAttribute('type', 'hidden');
+      input.setAttribute('name', 'attachments[]');
       const json = {
         url: `${s3BucketHttps}${file.postData.key}`,
         originalFilename: file.name
@@ -118,8 +119,8 @@ export function dropzoneCompleteCallback(file) {
 
       // convert the json string to binary data so that btoa can encode it
       jsonStr = toBinary(jsonStr);
-      inputHidden += `${window.btoa(jsonStr)}" />`;
-      document.getElementById('uploader').innerHTML += inputHidden;
+      input.setAttribute('value', window.btoa(jsonStr));
+      document.getElementById('uploader').appendChild(input);
 
       const formParams = {
         name: file.name,


### PR DESCRIPTION
Fixes #2040 

The bug is caused by these lines (which I actually called out in #2174):
https://github.com/processing/p5.js-web-editor/blob/1c05241e9ead4bc6f622188ba205c3329268fc72/client/modules/IDE/actions/uploader.js#L111
https://github.com/processing/p5.js-web-editor/blob/1c05241e9ead4bc6f622188ba205c3329268fc72/client/modules/IDE/actions/uploader.js#L121-L122

Our intention is to insert an additional `input` into the form.  But the way that we are implementing it is by replacing the entire content of the uploader with new elements parsed from the modified HTML string. 

The Dropzone library stores a reference to the `previewElement` associated with each file and modifies the CSS classes on this element at various points in the code.  When our bad code gets executed for the first file all of the `file.previewElement` elements get removed from the DOM.  Any subsequent changes to these elements will not change the HTML that we actually see.

As a result, only the first file will get the "success" styles applied.  The second file gets stuck on "processing" and the rest of the files never even get to the "processing" style.

Changes:
I removed the modification of `innerHTML`.  Instead I am creating the input with `document.createElement` and inserting it with `appendChild`.  This keeps the DOM intact.

I had to dig way deep into this code in order to track down the cause of the bug and now that I understand it I do have some further improvements which I can make in future PRs.  ~~I think it would be cleaner to render these hidden inputs via React in the FileUploader component, by storing the data to component state.~~ I think we might not need the hidden inputs at all?

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
