### PR TITLE
Fix #2240 - Hide progress bar when upload is complete

### DIFF
--- a/client/modules/IDE/components/FileUploader.jsx
+++ b/client/modules/IDE/components/FileUploader.jsx
@@ -38,13 +38,9 @@ class FileUploader extends React.Component {
       acceptedFiles: fileExtensionsAndMimeTypes,
       dictDefaultMessage: this.props.t('FileUploader.DictDefaultMessage'),
       accept: this.props.dropzoneAcceptCallback.bind(this, userId),
-      sending: this.props.dropzoneSendingCallback,
-      complete: this.props.dropzoneCompleteCallback
-      // error: (file, errorMessage) => {
-      //   console.log(file);
-      //   console.log(errorMessage);
-      // }
+      sending: this.props.dropzoneSendingCallback
     });
+    this.uploader.on('complete', this.props.dropzoneCompleteCallback);
   }
 
   render() {


### PR DESCRIPTION
Fixes #2240 

Changes:
Following the advice in the [Dropzone docs](https://docs.dropzone.dev/configuration/events), I am implementing our `dropzoneCompleteCallback` as an event listener on the `'complete'` event rather than replacing the default handing of that event.  This way the [default behavior](https://github.com/dropzone/dropzone/blob/f50d1828ab5df79a76be00d1306cc320e39a27f4/src/options.js#L769-L776) still gets called and the correct CSS class gets added by the Dropzone package.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
