### PR TITLE
Fix: upload modal closes when clicking inside

### DIFF
--- a/client/modules/IDE/components/FileUploader.jsx
+++ b/client/modules/IDE/components/FileUploader.jsx
@@ -29,6 +29,7 @@ class FileUploader extends React.Component {
       method: 'post',
       autoProcessQueue: true,
       clickable: true,
+      hiddenInputContainer: '#hidden-input-container',
       maxFiles: 6,
       parallelUploads: 2,
       maxFilesize: 5, // in mb
@@ -48,7 +49,12 @@ class FileUploader extends React.Component {
   }
 
   render() {
-    return <div id="uploader" className="uploader dropzone"></div>;
+    return (
+      <div>
+        <div id="uploader" className="uploader dropzone" />
+        <div id="hidden-input-container" />
+      </div>
+    );
   }
 }
 

--- a/client/modules/IDE/components/UploadFileModal.jsx
+++ b/client/modules/IDE/components/UploadFileModal.jsx
@@ -34,9 +34,7 @@ const UploadFileModal = () => {
           .
         </p>
       ) : (
-        <div>
-          <FileUploader />
-        </div>
+        <FileUploader />
       )}
     </Modal>
   );


### PR DESCRIPTION
Fixes https://github.com/processing/p5.js-web-editor/pull/2049#issuecomment-1587580863

Changes:
- Add a `div` inside the upload modal with id `"hidden-input-container"`.
- Set this div as the `hiddenInputContainer` that Dropzone uses when appending hidden inputs to the document.

 => Clicks on the hidden input are considered "inside" the modal and will not trigger the close on outside click behavior.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
