### PR TITLE
Fixes #2247 - Update package `friendly-words`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "express-basic-auth": "^1.2.0",
         "express-session": "^1.17.2",
         "final-form": "^4.20.2",
-        "friendly-words": "^1.2.0",
+        "friendly-words": "^1.2.1",
         "fuse.js": "^6.6.2",
         "htmlhint": "^0.15.1",
         "i18next": "^19.9.2",
@@ -22834,9 +22834,9 @@
       }
     },
     "node_modules/friendly-words": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/friendly-words/-/friendly-words-1.2.0.tgz",
-      "integrity": "sha512-KO9vxmqnaaHJy5O83V9vJV3e3gmoeHVJoqndqbiGcFQgYVdj1gvCy8NlGkqATAxY7PyTenFdyJ6GoYxxFu52TQ=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/friendly-words/-/friendly-words-1.2.1.tgz",
+      "integrity": "sha512-4tO5Z9qaQtRNsFSlDfvCgHZ8fDvE6c6qyMurdXBnOST4WNnQHl7PjeLAICtJ39SVGsbV7t7quoRLHFL/P5IsSg=="
     },
     "node_modules/from2": {
       "version": "2.3.0",
@@ -68913,9 +68913,9 @@
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "friendly-words": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/friendly-words/-/friendly-words-1.2.0.tgz",
-      "integrity": "sha512-KO9vxmqnaaHJy5O83V9vJV3e3gmoeHVJoqndqbiGcFQgYVdj1gvCy8NlGkqATAxY7PyTenFdyJ6GoYxxFu52TQ=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/friendly-words/-/friendly-words-1.2.1.tgz",
+      "integrity": "sha512-4tO5Z9qaQtRNsFSlDfvCgHZ8fDvE6c6qyMurdXBnOST4WNnQHl7PjeLAICtJ39SVGsbV7t7quoRLHFL/P5IsSg=="
     },
     "from2": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -179,7 +179,7 @@
     "express-basic-auth": "^1.2.0",
     "express-session": "^1.17.2",
     "final-form": "^4.20.2",
-    "friendly-words": "^1.2.0",
+    "friendly-words": "^1.2.1",
     "fuse.js": "^6.6.2",
     "htmlhint": "^0.15.1",
     "i18next": "^19.9.2",


### PR DESCRIPTION
Fixes #2247 

Changes:
- Bump `friendly-words` from version `1.2.0` to `1.2.1`

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
