### PR TITLE
fix for text overflow #2280

### DIFF
--- a/client/styles/components/_overlay.scss
+++ b/client/styles/components/_overlay.scss
@@ -26,6 +26,7 @@
   max-width: 65%;
   position: relative;
   padding-bottom: #{25 / $base-font-size}rem;
+  overflow: scroll;
 }
 
 .overlay__header {


### PR DESCRIPTION
Fixes #2280

Changes:

Added "overflow: scroll;" in p5.js-web-editor\client\styles\components\_overlay.scss.

I have verified that this pull request:

* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
