### PR TITLE
Fix editor crashing by downgrading console-feed

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "codemirror": "^5.62.0",
     "codemirror-colorpicker": "^1.9.72",
     "connect-mongo": "^1.3.2",
-    "console-feed": "^3.5.0",
+    "console-feed": "3.2.0",
     "cookie-parser": "^1.4.5",
     "copy-webpack-plugin": "^10.2.4",
     "cors": "^2.8.5",


### PR DESCRIPTION
Hopefully a temporary fix until workarounds / updates are made.

Fixes #2298 

Changes: downgrades `console-feed` package from ^3.5.0 to 3.2.0.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
