### PR TITLE
Delete unnecessary `return new Promise` in Redux actions.

### DIFF
--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -89,25 +89,22 @@ export function handleCreateFile(formProps, setSelected = true) {
     const { files } = state;
     const { parentId } = state.ide;
     const projectId = state.project.id;
-    return new Promise((resolve) => {
-      submitFile(formProps, files, parentId, projectId)
-        .then((response) => {
-          const { file, updatedAt } = response;
-          dispatch(createFile(file, parentId));
-          if (updatedAt) dispatch(setProjectSavedTime(updatedAt));
-          dispatch(closeNewFileModal());
-          dispatch(setUnsavedChanges(true));
-          if (setSelected) {
-            dispatch(setSelectedFile(file.id));
-          }
-          resolve();
-        })
-        .catch((error) => {
-          const { response } = error;
-          dispatch(createError(response.data));
-          resolve({ error });
-        });
-    });
+    submitFile(formProps, files, parentId, projectId)
+      .then((response) => {
+        const { file, updatedAt } = response;
+        dispatch(createFile(file, parentId));
+        if (updatedAt) dispatch(setProjectSavedTime(updatedAt));
+        dispatch(closeNewFileModal());
+        dispatch(setUnsavedChanges(true));
+        if (setSelected) {
+          dispatch(setSelectedFile(file.id));
+        }
+      })
+      .catch((error) => {
+        const { response } = error;
+        dispatch(createError(response.data));
+        return { error };
+      });
   };
 }
 
@@ -149,22 +146,19 @@ export function handleCreateFolder(formProps) {
     const { files } = state;
     const { parentId } = state.ide;
     const projectId = state.project.id;
-    return new Promise((resolve) => {
-      submitFolder(formProps, files, parentId, projectId)
-        .then((response) => {
-          const { file, updatedAt } = response;
-          dispatch(createFile(file, parentId));
-          if (updatedAt) dispatch(setProjectSavedTime(updatedAt));
-          dispatch(closeNewFolderModal());
-          dispatch(setUnsavedChanges(true));
-          resolve();
-        })
-        .catch((error) => {
-          const { response } = error;
-          dispatch(createError(response.data));
-          resolve({ error });
-        });
-    });
+    return submitFolder(formProps, files, parentId, projectId)
+      .then((response) => {
+        const { file, updatedAt } = response;
+        dispatch(createFile(file, parentId));
+        if (updatedAt) dispatch(setProjectSavedTime(updatedAt));
+        dispatch(closeNewFolderModal());
+        dispatch(setUnsavedChanges(true));
+      })
+      .catch((error) => {
+        const { response } = error;
+        dispatch(createError(response.data));
+        return { error };
+      });
   };
 }
 

--- a/client/modules/User/actions.js
+++ b/client/modules/User/actions.js
@@ -46,26 +46,21 @@ export function validateAndLoginUser(formProps) {
   return (dispatch, getState) => {
     const state = getState();
     const { previousPath } = state.ide;
-    return new Promise((resolve) => {
-      loginUser(formProps)
-        .then((response) => {
-          dispatch(authenticateUser(response.data));
-          dispatch(setPreferences(response.data.preferences));
-          dispatch(
-            setLanguage(response.data.preferences.language, {
-              persistPreference: false
-            })
-          );
-          dispatch(justOpenedProject());
-          browserHistory.push(previousPath);
-          resolve();
-        })
-        .catch((error) =>
-          resolve({
-            [FORM_ERROR]: error.response.data.message
+    return loginUser(formProps)
+      .then((response) => {
+        dispatch(authenticateUser(response.data));
+        dispatch(setPreferences(response.data.preferences));
+        dispatch(
+          setLanguage(response.data.preferences.language, {
+            persistPreference: false
           })
         );
-    });
+        dispatch(justOpenedProject());
+        browserHistory.push(previousPath);
+      })
+      .catch((error) => ({
+        [FORM_ERROR]: error.response.data.message
+      }));
   };
 }
 
@@ -73,20 +68,17 @@ export function validateAndSignUpUser(formValues) {
   return (dispatch, getState) => {
     const state = getState();
     const { previousPath } = state.ide;
-    return new Promise((resolve) => {
-      signUpUser(formValues)
-        .then((response) => {
-          dispatch(authenticateUser(response.data));
-          dispatch(justOpenedProject());
-          browserHistory.push(previousPath);
-          resolve();
-        })
-        .catch((error) => {
-          const { response } = error;
-          dispatch(authError(response.data.error));
-          resolve({ error });
-        });
-    });
+    return signUpUser(formValues)
+      .then((response) => {
+        dispatch(authenticateUser(response.data));
+        dispatch(justOpenedProject());
+        browserHistory.push(previousPath);
+      })
+      .catch((error) => {
+        const { response } = error;
+        dispatch(authError(response.data.error));
+        return { error };
+      });
   };
 }
 
@@ -159,23 +151,19 @@ export function logoutUser() {
 }
 
 export function initiateResetPassword(formValues) {
-  return (dispatch) =>
-    new Promise((resolve) => {
-      dispatch({
-        type: ActionTypes.RESET_PASSWORD_INITIATE
-      });
-      return apiClient
-        .post('/reset-password', formValues)
-        .then(() => resolve())
-        .catch((error) => {
-          const { response } = error;
-          dispatch({
-            type: ActionTypes.ERROR,
-            message: response.data
-          });
-          resolve({ error });
-        });
+  return (dispatch) => {
+    dispatch({
+      type: ActionTypes.RESET_PASSWORD_INITIATE
     });
+    return apiClient.post('/reset-password', formValues).catch((error) => {
+      const { response } = error;
+      dispatch({
+        type: ActionTypes.ERROR,
+        message: response.data
+      });
+      return { error };
+    });
+  };
 }
 
 export function initiateVerification() {
@@ -183,7 +171,7 @@ export function initiateVerification() {
     dispatch({
       type: ActionTypes.EMAIL_VERIFICATION_INITIATE
     });
-    apiClient
+    return apiClient
       .post('/verify/send', {})
       .then(() => {
         // do nothing
@@ -245,21 +233,18 @@ export function validateResetPasswordToken(token) {
 
 export function updatePassword(formValues, token) {
   return (dispatch) =>
-    new Promise((resolve) =>
-      apiClient
-        .post(`/reset-password/${token}`, formValues)
-        .then((response) => {
-          dispatch(authenticateUser(response.data));
-          browserHistory.push('/');
-          resolve();
-        })
-        .catch((error) => {
-          dispatch({
-            type: ActionTypes.INVALID_RESET_PASSWORD_TOKEN
-          });
-          resolve({ error });
-        })
-    );
+    apiClient
+      .post(`/reset-password/${token}`, formValues)
+      .then((response) => {
+        dispatch(authenticateUser(response.data));
+        browserHistory.push('/');
+      })
+      .catch((error) => {
+        dispatch({
+          type: ActionTypes.INVALID_RESET_PASSWORD_TOKEN
+        });
+        return { error };
+      });
 }
 
 export function updateSettingsSuccess(user) {
@@ -275,16 +260,13 @@ export function submitSettings(formValues) {
 
 export function updateSettings(formValues) {
   return (dispatch) =>
-    new Promise((resolve) =>
-      submitSettings(formValues)
-        .then((response) => {
-          dispatch(updateSettingsSuccess(response.data));
-          dispatch(showToast(5500));
-          dispatch(setToastText('Toast.SettingsSaved'));
-          resolve();
-        })
-        .catch((error) => resolve({ error }))
-    );
+    submitSettings(formValues)
+      .then((response) => {
+        dispatch(updateSettingsSuccess(response.data));
+        dispatch(showToast(5500));
+        dispatch(setToastText('Toast.SettingsSaved'));
+      })
+      .catch((error) => ({ error }));
 }
 
 export function createApiKeySuccess(user) {
@@ -303,7 +285,7 @@ export function createApiKey(label) {
       })
       .catch((error) => {
         const { response } = error;
-        Promise.reject(new Error(response.data.error));
+        return new Error(response.data.error);
       });
 }
 
@@ -319,7 +301,7 @@ export function removeApiKey(keyId) {
       })
       .catch((error) => {
         const { response } = error;
-        Promise.reject(new Error(response.data.error));
+        return new Error(response.data.error);
       });
 }
 


### PR DESCRIPTION
Changes:
- Remove all unnecessary `new Promise` constructors from Redux actions.

We have a lot of instances where we a wrapping an API call in `return new Promise((resolve, reject) => {`.  This is unnecessary because the API call is already a `Promise`. 

This code:
```
return new Promise((resolve) => {
  someFunction(args)
    .then((response) => {
      /** ... **/
      resolve();
    })
    .catch((error) => {
      /** ... **/
      resolve({ error });
    });
});
```
Is the same as this:
```
return someFunction(args)
  .then((response) => {
    /** ... **/
  })
  .catch((error) => {
    /** ... **/
    return { error };
  });
```
Both return a `Promise` which either resolves to `void` (on success) or resolves to an object with an `error` property (on failure).

There's a lot more cleanup that can be done here in the future, but right now I'm just changing this one thing.  Notes for the future.

- We often resolve to `{ error }` but we don't use this value anywhere.
-I've encountered uncaught errors which are thrown in the `catch` clauses.  We are assuming that the `error` variable always has a property `error.response.data` and this is not always the case, as the `catch` clause catches ALL errors. (This won't crash the app but it logs to the console).
- Some async action creator functions return the Promise and others don't.

This returns a `Promise`:
```
return (dispatch) =>
  apiClient
    .get('path')
```
This returns `void`:
```
return (dispatch) => {
  apiClient
    .get('path')
};
```

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
