### PR TITLE
fix: storybook i18n strings

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,6 +3,7 @@ import { Provider } from 'react-redux';
 
 import ThemeProvider from '../client/modules/App/components/ThemeProvider';
 import configureStore from '../client/store';
+import '../client/i18n-test';
 import '../client/styles/build/css/main.css'
 
 const initialState = window.__INITIAL_STATE__;


### PR DESCRIPTION
A follow up to this PR https://github.com/processing/p5.js-web-editor/pull/2310

Changes:

Includes i18n-test in storybook preview to render strings.

Without:
<img width="314" alt="Screenshot 2023-07-25 at 9 06 20 am" src="https://github.com/processing/p5.js-web-editor/assets/1826459/9d45f701-fd6d-47ec-877f-d83645d4181b">

With:
<img width="314" alt="Screenshot 2023-07-25 at 9 03 17 am" src="https://github.com/processing/p5.js-web-editor/assets/1826459/213717ea-3d1d-4635-95da-1e8664dbfb23">


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
