### PR TITLE
test: add ErrorModal tests and story

### DIFF
--- a/client/modules/IDE/components/ErrorModal.jsx
+++ b/client/modules/IDE/components/ErrorModal.jsx
@@ -69,9 +69,14 @@ const ErrorModal = ({ type, service, closeModal }) => {
 };
 
 ErrorModal.propTypes = {
-  type: PropTypes.string.isRequired,
+  type: PropTypes.oneOf([
+    'forceAuthentication',
+    'staleSession',
+    'staleProject',
+    'oauthError'
+  ]).isRequired,
   closeModal: PropTypes.func.isRequired,
-  service: PropTypes.string
+  service: PropTypes.oneOf(['google', 'github'])
 };
 
 ErrorModal.defaultProps = {

--- a/client/modules/IDE/components/ErrorModal.stories.jsx
+++ b/client/modules/IDE/components/ErrorModal.stories.jsx
@@ -1,47 +1,30 @@
-import React from 'react';
-
 import ErrorModal from './ErrorModal';
 
 export default {
   title: 'IDE/ErrorModal',
   component: ErrorModal,
   argTypes: {
-    type: {
-      options: [
-        'forceAuthentication',
-        'staleSession',
-        'staleProject',
-        'oauthError'
-      ],
-      control: { type: 'select' }
-    },
-    service: {
-      options: ['google', 'github'],
-      control: { type: 'select' }
-    },
     closeModal: { action: 'closed' }
   }
 };
 
-const Template = (args) => <ErrorModal {...args} />;
-
-export const ForceAuthenticationErrorModal = Template.bind({});
-ForceAuthenticationErrorModal.args = {
-  type: 'forceAuthentication'
+export const ForceAuthenticationErrorModal = {
+  args: {
+    type: 'forceAuthentication'
+  }
 };
-
-export const StaleSessionErrorModal = Template.bind({});
-StaleSessionErrorModal.args = {
-  type: 'staleSession'
+export const StaleSessionErrorModal = {
+  args: {
+    type: 'staleSession'
+  }
 };
-
-export const StaleProjectErrorModal = Template.bind({});
-StaleProjectErrorModal.args = {
-  type: 'staleProject'
+export const StaleProjectErrorModal = {
+  args: {
+    type: 'staleProject'
+  }
 };
-
-export const OauthErrorModal = Template.bind({});
-OauthErrorModal.args = {
-  type: 'oauthError',
-  service: 'google'
+export const OauthErrorModal = {
+  args: {
+    type: 'oauthError'
+  }
 };

--- a/client/modules/IDE/components/ErrorModal.stories.jsx
+++ b/client/modules/IDE/components/ErrorModal.stories.jsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import ErrorModal from './ErrorModal';
+
+export default {
+  title: 'IDE/ErrorModal',
+  component: ErrorModal,
+  argTypes: {
+    type: {
+      options: [
+        'forceAuthentication',
+        'staleSession',
+        'staleProject',
+        'oauthError'
+      ],
+      control: { type: 'select' }
+    },
+    service: {
+      options: ['google', 'github'],
+      control: { type: 'select' }
+    },
+    closeModal: { action: 'closed' }
+  }
+};
+
+const Template = (args) => <ErrorModal {...args} />;
+
+export const ForceAuthenticationErrorModal = Template.bind({});
+ForceAuthenticationErrorModal.args = {
+  type: 'forceAuthentication'
+};
+
+export const StaleSessionErrorModal = Template.bind({});
+StaleSessionErrorModal.args = {
+  type: 'staleSession'
+};
+
+export const StaleProjectErrorModal = Template.bind({});
+StaleProjectErrorModal.args = {
+  type: 'staleProject'
+};
+
+export const OauthErrorModal = Template.bind({});
+OauthErrorModal.args = {
+  type: 'oauthError',
+  service: 'google'
+};

--- a/client/modules/IDE/components/ErrorModal.unit.test.jsx
+++ b/client/modules/IDE/components/ErrorModal.unit.test.jsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { render, screen } from '../../../test-utils';
+
+import ErrorModal from './ErrorModal';
+
+jest.mock('../../../i18n');
+
+describe('<ErrorModal />', () => {
+  it('renders type forceAuthentication', () => {
+    render(<ErrorModal type="forceAuthentication" closeModal={jest.fn()} />);
+
+    expect(screen.getByText('Login')).toBeVisible();
+    expect(screen.getByText('Sign Up')).toBeVisible();
+  });
+
+  it('renders type staleSession', () => {
+    render(<ErrorModal type="staleSession" closeModal={jest.fn()} />);
+
+    expect(screen.getByText('log in')).toBeVisible();
+  });
+
+  it('renders type staleProject', () => {
+    render(<ErrorModal type="staleProject" closeModal={jest.fn()} />);
+
+    expect(
+      screen.getByText(
+        'The project you have attempted to save has been saved from another window',
+        { exact: false }
+      )
+    ).toBeVisible();
+  });
+
+  it('renders type oauthError with service google', () => {
+    render(
+      <ErrorModal type="oauthError" service="google" closeModal={jest.fn()} />
+    );
+
+    expect(
+      screen.getByText('There was a problem linking your Google account', {
+        exact: false
+      })
+    ).toBeVisible();
+  });
+
+  it('renders type oauthError with service github', () => {
+    render(
+      <ErrorModal type="oauthError" service="github" closeModal={jest.fn()} />
+    );
+
+    expect(
+      screen.getByText('There was a problem linking your GitHub account', {
+        exact: false
+      })
+    ).toBeVisible();
+  });
+});


### PR DESCRIPTION
No issue number

Changes:

Adds tests and Storybook story around the ErrorModal component

<img width="462" alt="Screenshot 2023-07-25 at 2 41 03 pm" src="https://github.com/processing/p5.js-web-editor/assets/1826459/4e2c5af2-d997-4c0e-97f5-c0ae6815d974">

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
