### PR TITLE
fix #2338 sidebar dropdown stays open after sidebar is closed

### DIFF
--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -500,7 +500,10 @@ class Editor extends React.Component {
           <button
             aria-label={this.props.t('Editor.OpenSketchARIA')}
             className="sidebar__contract"
-            onClick={this.props.collapseSidebar}
+            onClick={() => {
+              this.props.collapseSidebar();
+              this.props.closeProjectOptions();
+            }}
           >
             <LeftArrowIcon focusable="false" aria-hidden="true" />
           </button>
@@ -588,6 +591,7 @@ Editor.propTypes = {
   ).isRequired,
   isExpanded: PropTypes.bool.isRequired,
   collapseSidebar: PropTypes.func.isRequired,
+  closeProjectOptions: PropTypes.func.isRequired,
   expandSidebar: PropTypes.func.isRequired,
   clearConsole: PropTypes.func.isRequired,
   hideRuntimeErrorWarning: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixes #2338 sidebar dropdown stays open after sidebar is closed

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
