### PR TITLE
Modal tests

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,5 @@
+<script>
+    // https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/176#issuecomment-683150213
+    window.$RefreshReg$ = () => {};
+    window.$RefreshSig$ = () => () => {};
+</script>

--- a/client/modules/IDE/components/Modal.stories.jsx
+++ b/client/modules/IDE/components/Modal.stories.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import Modal from './Modal';
+
+export default {
+  title: 'IDE/Modal',
+  component: Modal,
+  argTypes: {
+    onClose: { action: 'onClose' }
+  }
+};
+
+export const ModalDefault = {
+  args: {
+    title: 'Example Modal Title',
+    children: <p>Example modal body</p>
+  }
+};

--- a/client/modules/IDE/components/Modal.unit.test.jsx
+++ b/client/modules/IDE/components/Modal.unit.test.jsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { fireEvent, render, screen } from '../../../test-utils';
+import Modal from './Modal';
+
+describe('Modal', () => {
+  it('can render title', () => {
+    render(
+      <Modal title="Foo" closeAriaLabel="Foo" onClose={jest.fn()}>
+        Bar
+      </Modal>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Foo' })).toBeVisible();
+  });
+
+  it('can render child content', () => {
+    render(
+      <Modal title="Foo" closeAriaLabel="Foo" onClose={jest.fn()}>
+        Bar
+      </Modal>
+    );
+
+    expect(screen.getByText('Bar')).toBeVisible();
+  });
+
+  it('can call onClose when close button clicked', () => {
+    const handleClose = jest.fn();
+    render(
+      <Modal title="Foo" closeAriaLabel="Foo" onClose={handleClose}>
+        Bar
+      </Modal>
+    );
+
+    const buttonEl = screen.getByRole('button');
+    fireEvent.click(buttonEl);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('can call onClose when click event occurs in a parent node', () => {
+    const handleClose = jest.fn();
+    render(
+      <div>
+        <h1>Parent</h1>
+        <Modal title="Foo" closeAriaLabel="Foo" onClose={handleClose}>
+          Bar
+        </Modal>
+      </div>
+    );
+
+    const headingEl = screen.getByRole('heading', { name: 'Parent' });
+    fireEvent.click(headingEl);
+
+    expect(handleClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('can ignore click event for closing when it occurs inside component', () => {
+    const handleClose = jest.fn();
+    render(
+      <Modal title="Foo" closeAriaLabel="Foo" onClose={handleClose}>
+        Bar
+      </Modal>
+    );
+
+    const headingEl = screen.getByRole('heading', { name: 'Foo' });
+    fireEvent.click(headingEl);
+
+    expect(handleClose).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #issue-number

This PR adds storybook documentation and unit tests to the modal component.

<img width="768" alt="Screenshot 2023-08-11 at 6 06 11 am" src="https://github.com/processing/p5.js-web-editor/assets/1826459/b6749a51-9ee0-4d80-8bbe-83b032fd6a56">


It also looks like a bable upgrade along the way broke storybook hot module reloading.
I didn't spend a lot of time investigating the cause but did find[ a solution](https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/176) to monkey patching the issue. HMR was still working in storybook but un-viewable without this patch.

<img width="1120" alt="Screenshot 2023-08-11 at 6 05 10 am" src="https://github.com/processing/p5.js-web-editor/assets/1826459/9ce30af4-4fa7-433c-b252-83c27bb13897">

Changes:


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
