### PR TITLE
Fix mjml syntax for v4.

### DIFF
--- a/server/utils/renderMjml.js
+++ b/server/utils/renderMjml.js
@@ -1,10 +1,11 @@
-import { mjml2html } from 'mjml';
+import mjml2html from 'mjml';
 
 export default (template) => {
   try {
     const output = mjml2html(template);
     return output.html;
   } catch (e) {
+    console.error(e);
     // fall through to null
   }
 

--- a/server/views/consolidationMailLayout.js
+++ b/server/views/consolidationMailLayout.js
@@ -21,10 +21,9 @@ export default ({
     </mj-raw>
   </mj-head>
   <mj-body>
-    <mj-container>
       <mj-section>
         <mj-column>
-          <mj-image width="192" src="${domain}/images/p5js-square-logo.png" alt="p5.js" />
+          <mj-image width="192px" src="${domain}/images/p5js-square-logo.png" alt="p5.js" />
           <mj-divider border-color="#ed225d"></mj-divider>
         </mj-column>
       </mj-section>
@@ -71,7 +70,6 @@ export default ({
           </mj-text>
         </mj-column>
       </mj-section>
-    </mj-container>
   </mj-body>
 </mjml>
 `;

--- a/server/views/mailLayout.js
+++ b/server/views/mailLayout.js
@@ -18,10 +18,9 @@ export default ({
     </mj-raw>
   </mj-head>
   <mj-body>
-    <mj-container>
       <mj-section>
         <mj-column>
-          <mj-image width="192" src="${domain}/images/p5js-square-logo.png" alt="p5.js" />
+          <mj-image width="192px" src="${domain}/images/p5js-square-logo.png" alt="p5.js" />
           <mj-divider border-color="#ed225d"></mj-divider>
         </mj-column>
       </mj-section>
@@ -59,7 +58,6 @@ export default ({
           </mj-text>
         </mj-column>
       </mj-section>
-    </mj-container>
   </mj-body>
 </mjml>
 `;


### PR DESCRIPTION
Fixes #2303 
(Probably, but I haven't checked it with a valid Mailgun config to make sure that it works all the way through to sending the email.)

We merged a dependabot PR #2267 which included a major version bump of `mjml` and that caused emails to break.

Changes:

- Import `mjml2html` as the default from `mjml` instead of a named import.
- Remove deprecated component `<mj-container>` from templates.
- Convert unitless value `width="192"` to px `width="192px"`.
- Log errors when calling `mjml2html` (useful in development, probably does nothing in production but idk).

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`