### PR TITLE
Used styled components in Sidebar

### DIFF
--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -2,6 +2,7 @@ import React, { useRef, useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
+import styled, { css } from 'styled-components';
 import {
   closeProjectOptions,
   newFile,
@@ -11,11 +12,63 @@ import {
 } from '../actions/ide';
 import { selectRootFile } from '../selectors/files';
 import { getAuthenticated, selectCanEditSketch } from '../selectors/users';
-
+import { remSize } from '../../../theme';
 import ConnectedFileNode from './FileNode';
 
 import DownArrowIcon from '../../../images/down-filled-triangle.svg';
 
+const SidebarHeader = styled.header`
+  padding-right: ${remSize(6)};
+  padding-left: ${remSize(19)};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  height: ${remSize(29)};
+  min-height: ${remSize(29)};
+  position: relative;
+`;
+
+const SidebarTitle = styled.h3`
+  font-size: ${remSize(12)};
+  display: ${(props) => (props.isExpanded ? 'inline-block' : 'none')};
+  white-space: nowrap;
+  overflow: hidden;
+`;
+
+const SidebarIcons = styled.div`
+  display: flex;
+  align-items: center;
+  height: 100%;
+  ${(props) =>
+    props.cantEdit &&
+    css`
+      display: none;
+    `}
+`;
+
+const SidebarAddButton = styled.button`
+  width: ${remSize(20)};
+  height: ${remSize(20)};
+  & svg {
+    width: ${remSize(10)};
+  }
+  ${(props) =>
+    !props.isExpanded &&
+    css`
+      display: none;
+    `}
+`;
+
+const SidebarProjectOptions = styled.ul`
+  display: none;
+  width: 100%;
+  max-width: ${remSize(180)};
+  ${(props) =>
+    props.open &&
+    css`
+      display: flex;
+    `}
+`;
 // TODO: use a generic Dropdown UI component
 
 export default function SideBar() {
@@ -66,23 +119,23 @@ export default function SideBar() {
 
   return (
     <section className={sidebarClass}>
-      <header className="sidebar__header" onContextMenu={toggleProjectOptions}>
-        <h3 className="sidebar__title">
+      <SidebarHeader onContextMenu={toggleProjectOptions}>
+        <SidebarTitle isExpanded={isExpanded}>
           <span>{t('Sidebar.Title')}</span>
-        </h3>
-        <div className="sidebar__icons">
-          <button
+        </SidebarTitle>
+        <SidebarIcons cantEdit={!canEditProject}>
+          <SidebarAddButton
             aria-label={t('Sidebar.ToggleARIA')}
-            className="sidebar__add"
             tabIndex="0"
             ref={sidebarOptionsRef}
             onClick={toggleProjectOptions}
             onBlur={onBlurComponent}
             onFocus={onFocusComponent}
+            isExpanded={isExpanded}
           >
             <DownArrowIcon focusable="false" aria-hidden="true" />
-          </button>
-          <ul className="sidebar__project-options">
+          </SidebarAddButton>
+          <SidebarProjectOptions open={projectOptionsVisible}>
             <li>
               <button
                 aria-label={t('Sidebar.AddFolderARIA')}
@@ -124,9 +177,9 @@ export default function SideBar() {
                 </button>
               </li>
             )}
-          </ul>
-        </div>
-      </header>
+          </SidebarProjectOptions>
+        </SidebarIcons>
+      </SidebarHeader>
       <ConnectedFileNode id={rootFile.id} canEdit={canEditProject} />
     </section>
   );

--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -2,7 +2,7 @@ import React, { useRef, useState } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { useDispatch, useSelector } from 'react-redux';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import {
   closeProjectOptions,
   newFile,
@@ -30,7 +30,7 @@ const SidebarHeader = styled.header`
 
 const SidebarTitle = styled.h3`
   font-size: ${remSize(12)};
-  display: ${(props) => (props.isExpanded ? 'inline-block' : 'none')};
+  display: inline-block;
   white-space: nowrap;
   overflow: hidden;
 `;
@@ -39,11 +39,6 @@ const SidebarIcons = styled.div`
   display: flex;
   align-items: center;
   height: 100%;
-  ${(props) =>
-    props.cantEdit &&
-    css`
-      display: none;
-    `}
 `;
 
 const SidebarAddButton = styled.button`
@@ -52,22 +47,12 @@ const SidebarAddButton = styled.button`
   & svg {
     width: ${remSize(10)};
   }
-  ${(props) =>
-    !props.isExpanded &&
-    css`
-      display: none;
-    `}
 `;
 
 const SidebarProjectOptions = styled.ul`
-  display: none;
+  display: flex;
   width: 100%;
   max-width: ${remSize(180)};
-  ${(props) =>
-    props.open &&
-    css`
-      display: flex;
-    `}
 `;
 // TODO: use a generic Dropdown UI component
 
@@ -120,65 +105,72 @@ export default function SideBar() {
   return (
     <section className={sidebarClass}>
       <SidebarHeader onContextMenu={toggleProjectOptions}>
-        <SidebarTitle isExpanded={isExpanded}>
-          <span>{t('Sidebar.Title')}</span>
-        </SidebarTitle>
-        <SidebarIcons cantEdit={!canEditProject}>
-          <SidebarAddButton
-            aria-label={t('Sidebar.ToggleARIA')}
-            tabIndex="0"
-            ref={sidebarOptionsRef}
-            onClick={toggleProjectOptions}
-            onBlur={onBlurComponent}
-            onFocus={onFocusComponent}
-            isExpanded={isExpanded}
-          >
-            <DownArrowIcon focusable="false" aria-hidden="true" />
-          </SidebarAddButton>
-          <SidebarProjectOptions open={projectOptionsVisible}>
-            <li>
-              <button
-                aria-label={t('Sidebar.AddFolderARIA')}
-                onClick={() => {
-                  dispatch(newFolder(rootFile.id));
-                  setTimeout(() => dispatch(closeProjectOptions()), 0);
-                }}
+        {isExpanded && (
+          <SidebarTitle>
+            <span>{t('Sidebar.Title')}</span>
+          </SidebarTitle>
+        )}
+        {canEditProject && (
+          <SidebarIcons>
+            {isExpanded && (
+              <SidebarAddButton
+                aria-label={t('Sidebar.ToggleARIA')}
+                tabIndex="0"
+                ref={sidebarOptionsRef}
+                onClick={toggleProjectOptions}
                 onBlur={onBlurComponent}
                 onFocus={onFocusComponent}
               >
-                {t('Sidebar.AddFolder')}
-              </button>
-            </li>
-            <li>
-              <button
-                aria-label={t('Sidebar.AddFileARIA')}
-                onClick={() => {
-                  dispatch(newFile(rootFile.id));
-                  setTimeout(() => dispatch(closeProjectOptions()), 0);
-                }}
-                onBlur={onBlurComponent}
-                onFocus={onFocusComponent}
-              >
-                {t('Sidebar.AddFile')}
-              </button>
-            </li>
-            {isAuthenticated && (
-              <li>
-                <button
-                  aria-label={t('Sidebar.UploadFileARIA')}
-                  onClick={() => {
-                    dispatch(openUploadFileModal(rootFile.id));
-                    setTimeout(() => dispatch(closeProjectOptions()), 0);
-                  }}
-                  onBlur={onBlurComponent}
-                  onFocus={onFocusComponent}
-                >
-                  {t('Sidebar.UploadFile')}
-                </button>
-              </li>
+                <DownArrowIcon focusable="false" aria-hidden="true" />
+              </SidebarAddButton>
             )}
-          </SidebarProjectOptions>
-        </SidebarIcons>
+            {projectOptionsVisible && (
+              <SidebarProjectOptions className="sidebar__project-options">
+                <li>
+                  <button
+                    aria-label={t('Sidebar.AddFolderARIA')}
+                    onClick={() => {
+                      dispatch(newFolder(rootFile.id));
+                      setTimeout(() => dispatch(closeProjectOptions()), 0);
+                    }}
+                    onBlur={onBlurComponent}
+                    onFocus={onFocusComponent}
+                  >
+                    {t('Sidebar.AddFolder')}
+                  </button>
+                </li>
+                <li>
+                  <button
+                    aria-label={t('Sidebar.AddFileARIA')}
+                    onClick={() => {
+                      dispatch(newFile(rootFile.id));
+                      setTimeout(() => dispatch(closeProjectOptions()), 0);
+                    }}
+                    onBlur={onBlurComponent}
+                    onFocus={onFocusComponent}
+                  >
+                    {t('Sidebar.AddFile')}
+                  </button>
+                </li>
+                {isAuthenticated && (
+                  <li>
+                    <button
+                      aria-label={t('Sidebar.UploadFileARIA')}
+                      onClick={() => {
+                        dispatch(openUploadFileModal(rootFile.id));
+                        setTimeout(() => dispatch(closeProjectOptions()), 0);
+                      }}
+                      onBlur={onBlurComponent}
+                      onFocus={onFocusComponent}
+                    >
+                      {t('Sidebar.UploadFile')}
+                    </button>
+                  </li>
+                )}
+              </SidebarProjectOptions>
+            )}
+          </SidebarIcons>
+        )}
       </SidebarHeader>
       <ConnectedFileNode id={rootFile.id} canEdit={canEditProject} />
     </section>

--- a/client/styles/components/_sidebar.scss
+++ b/client/styles/components/_sidebar.scss
@@ -303,10 +303,4 @@
 
 .sidebar__project-options {
   @extend %dropdown-open-right;
-  display: none;
-  width: 100%;
-  max-width: #{180 / $base-font-size}rem;
-  .sidebar--project-options & {
-    display: flex;
-  }
 }


### PR DESCRIPTION
Hey @lindapaiste, I've been working on adding styled component to the Sidebar. I've come across a situation where the class .sidebar_project-options needs to extend from .dropdown-open-right. However, since I can't directly use extends in styled components, I'm considering moving the dropdown-open-right code to the mixins.scss file as mixins. Would it be a good idea, or do you have any other suggestions?

It's coming up like this without the dropdown-open-right
![1](https://github.com/processing/p5.js-web-editor/assets/104292766/1b81c4a8-208c-44eb-8ed3-8a2c802e8401)


```
.sidebar__project-options {
  @extend %dropdown-open-right;
  display: none;
  width: 100%;
  max-width: #{180 / $base-font-size}rem;
  .sidebar--project-options & {
    display: flex;
  }
}
```

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
