### PR TITLE
Fix:- Drop down menu cannot be right-clicked

### DIFF
--- a/client/components/Nav/NavBar.jsx
+++ b/client/components/Nav/NavBar.jsx
@@ -71,7 +71,10 @@ function NavBar({ children, className }) {
         onFocus: clearHideTimeout
       }),
       createMenuItemHandlers: (dropdown) => ({
-        onMouseUp: () => {
+        onMouseUp: (e) => {
+          if (e.button === 2) {
+            return;
+          }
           setDropdownOpen('none');
         },
         onBlur: handleBlur,


### PR DESCRIPTION
Fixes #2359 

the `onMouseUp` event whenever triggered causes the drop down state changed to `none` thus closing it, i have added a early return check to look for the right click.



https://github.com/processing/p5.js-web-editor/assets/72331432/02d2eb84-f746-4e5f-b704-e87d04069ce4






Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
