### PR TITLE
Feat #2334 github and google auth open in new tab

### DIFF
--- a/client/common/Button.jsx
+++ b/client/common/Button.jsx
@@ -165,6 +165,7 @@ const Button = ({
   children,
   display,
   href,
+  target,
   kind,
   iconBefore,
   iconAfter,
@@ -200,6 +201,7 @@ const Button = ({
         as="a"
         aria-label={ariaLabel}
         href={href}
+        target={target}
         {...props}
       >
         {content}
@@ -244,6 +246,7 @@ Button.defaultProps = {
   iconOnly: false,
   kind: kinds.primary,
   href: null,
+  target: null,
   'aria-label': null,
   to: null,
   type: 'button'
@@ -286,6 +289,10 @@ Button.propTypes = {
    * Specifying an href will use an <a> to link to the URL
    */
   href: PropTypes.string,
+  /**
+   * Specifying target open href URL in the new tab
+   */
+  target: PropTypes.string,
   /*
    * An ARIA Label used for accessibility
    */

--- a/client/modules/User/components/SocialAuthButton.jsx
+++ b/client/modules/User/components/SocialAuthButton.jsx
@@ -73,6 +73,7 @@ function SocialAuthButton({ service, linkStyle, isConnected }) {
     <StyledButton
       iconBefore={<ServiceIcon aria-label={ariaLabel} />}
       href={authUrls[service]}
+      target="_blank"
     >
       {loginLabel}
     </StyledButton>


### PR DESCRIPTION
Fixes #2334 

Changes: Added a new target prop in the button component. If we want to use the same in the future we can use target prop.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
