### PR TITLE
fixes of the issue window.p5._report is not defined

### DIFF
--- a/client/modules/Preview/EmbedFrame.jsx
+++ b/client/modules/Preview/EmbedFrame.jsx
@@ -252,7 +252,7 @@ function injectLocalFiles(files, htmlFile, options) {
     'PREVIEW_SCRIPTS_URL'
   )}`;
   previewScripts.setAttribute('crossorigin', '');
-  sketchDoc.head.appendChild(previewScripts);
+  sketchDoc.body.appendChild(previewScripts);
 
   const sketchDocString = `<!DOCTYPE HTML>\n${sketchDoc.documentElement.outerHTML}`;
   scriptOffs = getAllScriptOffsets(sketchDocString);


### PR DESCRIPTION
Fixes #2327

Changes:
`sketchDoc.head.appendChild(previewScripts);` -> `sketchDoc.body.appendChild(previewScripts);`

I have verified that this pull request:

* [✅ ] has no linting errors (`npm run lint`)
* [✅ ] has no test errors (`npm run test`)
* [✅ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [✅ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
