### PR TITLE
fix: Moda content overflow and Preferences height

### DIFF
--- a/client/styles/components/_modal.scss
+++ b/client/styles/components/_modal.scss
@@ -10,8 +10,13 @@
 .modal-content {
   @extend %modal;
   min-height: #{150 / $base-font-size}rem;
-  width: #{500 / $base-font-size}rem;
   padding: #{20 / $base-font-size}rem;
+  
+  @media (min-width: 770px) {
+    width: #{500 / $base-font-size}rem;
+    
+  }
+
   .modal--reduced & {
     //min-height: #{150 / $base-font-size}rem;
   }

--- a/client/styles/components/_preferences.scss
+++ b/client/styles/components/_preferences.scss
@@ -10,7 +10,6 @@
   flex-direction: column;
   outline: none;
   height: calc(80vh - #{65 / $base-font-size}rem);
-  max-height: #{460 / $base-font-size}rem;
   & .react-tabs {
     max-height: 100%;
     display: flex;
@@ -18,6 +17,11 @@
   }
   & .react-tabs__tab-panel {
     overflow-y: auto;
+  }
+  
+  @media (min-width: 770px) {
+    max-height: #{460 / $base-font-size}rem;
+    
   }
 }
 


### PR DESCRIPTION
Changes:
Fixes the Modal overflow, and preferences height in mobile devices.

this needs to be merged before
#2400 Account UI fix

### Before
![image](https://github.com/processing/p5.js-web-editor/assets/71703033/79574429-ac3e-40cb-ba21-2ef468c6e255)

### after
![image](https://github.com/processing/p5.js-web-editor/assets/71703033/baa8b015-3b7a-422a-b72f-4716bb958d55)
![image](https://github.com/processing/p5.js-web-editor/assets/71703033/066564c8-967d-457c-a3a1-6b9d51733a34)



I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
