### PR TITLE
made the anchor tags bold on the signup page

### DIFF
--- a/client/styles/components/_forms.scss
+++ b/client/styles/components/_forms.scss
@@ -26,6 +26,11 @@
 .form__navigation-options {
   margin-top: #{16 / $base-font-size}rem;
   font-size: #{12 / $base-font-size}rem;
+
+  a {
+    font-weight: bold;
+  }
+
   @include themify() {
     color: getThemifyVariable("form-navigation-options-color");
   }


### PR DESCRIPTION
Fixes #2440 

Changes: Here what it looks like after adding css on the links given on the bottom of the signup page.

![Screenshot 2023-09-15 025149](https://github.com/processing/p5.js-web-editor/assets/127239756/ad68fead-eabf-435c-b7a0-5722ecc503eb)

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
