### PR TITLE
Added a new feature of a copy code button from the code snippet

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -127,7 +127,21 @@ const IDEView = () => {
       }
     };
   }, [shouldAutosave, dispatch]);
-
+  const [copied, setCopied] = useState(false);
+  const handleCopy = async () => {
+    const editor = cmRef.current;
+    try {
+      const content = editor;
+      await navigator.clipboard.writeText(content.getContent().content);
+      setCopied(true);
+      const x = setTimeout(() => {
+        setCopied(false);
+        clearTimeout(x);
+      }, 500);
+    } catch (error) {
+      console.error('Failed to copy text to clipboard:', error);
+    }
+  };
   return (
     <RootPage>
       <Helmet>
@@ -142,7 +156,29 @@ const IDEView = () => {
       <MediaQuery minWidth={770}>
         {(matches) =>
           matches ? (
-            <main className="editor-preview-container">
+            <main
+              className="editor-preview-container"
+              style={{
+                position: 'relative'
+              }}
+            >
+              <button
+                style={{
+                  position: 'fixed',
+                  zIndex: 27,
+                  right: '41.8%',
+                  backgroundColor: '#ccc',
+                  textAlign: 'center',
+                  display: 'grid',
+                  placeItems: 'center',
+                  marginTop: '-4.5rem',
+                  width: '100px',
+                  height: '40px'
+                }}
+                onClick={handleCopy}
+              >
+                {copied ? 'copied' : 'copy'}
+              </button>
               <SplitPane
                 split="vertical"
                 size={ide.sidebarIsExpanded ? sidebarSize : 20}


### PR DESCRIPTION
Fixes #2446 

Changes: This pull request adds a copy button to the top of the editor. The purpose of this button is to allow users to easily copy the content of the editor to the clipboard. This enhancement improves user experience by providing a convenient way to duplicate code snippets.

https://github.com/processing/p5.js-web-editor/assets/127239756/736700cc-452f-4458-b8a4-15f478dc4742


I have verified that this pull request: I have fully verified the code.

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
