### PR TITLE
Test for EditorAccessibility

### DIFF
--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -594,7 +594,8 @@ Editor.propTypes = {
   linewrap: PropTypes.bool.isRequired,
   lintMessages: PropTypes.arrayOf(
     PropTypes.shape({
-      severity: PropTypes.string.isRequired,
+      severity: PropTypes.oneOf(['error', 'hint', 'info', 'warning'])
+        .isRequired,
       line: PropTypes.number.isRequired,
       message: PropTypes.string.isRequired,
       id: PropTypes.number.isRequired

--- a/client/modules/IDE/components/EditorAccessibility.jsx
+++ b/client/modules/IDE/components/EditorAccessibility.jsx
@@ -37,7 +37,7 @@ const EditorAccessibility = ({ lintMessages = [] }) => {
 EditorAccessibility.propTypes = {
   lintMessages: PropTypes.arrayOf(
     PropTypes.shape({
-      severity: PropTypes.string.isRequired,
+      severity: PropTypes.oneOf(['error', 'hint', 'info', 'warning']),
       line: PropTypes.number.isRequired,
       message: PropTypes.string.isRequired,
       id: PropTypes.number.isRequired

--- a/client/modules/IDE/components/EditorAccessibility.jsx
+++ b/client/modules/IDE/components/EditorAccessibility.jsx
@@ -37,7 +37,8 @@ const EditorAccessibility = ({ lintMessages = [] }) => {
 EditorAccessibility.propTypes = {
   lintMessages: PropTypes.arrayOf(
     PropTypes.shape({
-      severity: PropTypes.oneOf(['error', 'hint', 'info', 'warning']),
+      severity: PropTypes.oneOf(['error', 'hint', 'info', 'warning'])
+        .isRequired,
       line: PropTypes.number.isRequired,
       message: PropTypes.string.isRequired,
       id: PropTypes.number.isRequired

--- a/client/modules/IDE/components/EditorAccessibility.unit.test.jsx
+++ b/client/modules/IDE/components/EditorAccessibility.unit.test.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { render, screen } from '../../../test-utils';
+
+import EditorAccessibility from './EditorAccessibility';
+
+describe('<EditorAccessibility />', () => {
+  it('renders empty message with no lines', () => {
+    render(<EditorAccessibility lintMessages={[]} />);
+
+    expect(
+      screen.getByRole('listitem', {
+        description: 'There are no lint messages'
+      })
+    ).toBeInTheDocument();
+  });
+
+  it('renders lint message', () => {
+    render(
+      <EditorAccessibility
+        lintMessages={[
+          {
+            severity: 'info',
+            line: '1',
+            message: 'foo',
+            id: '1a2b3c'
+          }
+        ]}
+      />
+    );
+
+    expect(
+      screen.queryByText('There are no lint messages')
+    ).not.toBeInTheDocument();
+
+    const listItem = screen.getByRole('listitem');
+    expect(listItem).toBeInTheDocument();
+    expect(listItem.textContent).toEqual('info in line1 :foo');
+  });
+});

--- a/translations/locales/de/translations.json
+++ b/translations/locales/de/translations.json
@@ -531,7 +531,7 @@
   },
   "EditorAccessibility": {
     "NoLintMessages": "Keine Lint-Warnungen vorhanden",
-    "CurrentLine": " Aktuelle Zeile"
+    "CurrentLine": "Aktuelle Zeile"
   },
   "Timer": {
     "SavedAgo": "Gesichert: {{timeAgo}}"

--- a/translations/locales/de/translations.json
+++ b/translations/locales/de/translations.json
@@ -530,7 +530,7 @@
     "KeyUpLineNumber": "Zeile {{lineNumber}}"
   },
   "EditorAccessibility": {
-    "NoLintMessages": "Keine Lint-Warnungen vorhanden ",
+    "NoLintMessages": "Keine Lint-Warnungen vorhanden",
     "CurrentLine": " Aktuelle Zeile"
   },
   "Timer": {

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -538,7 +538,7 @@
     "KeyUpLineNumber": "line {{lineNumber}}"
   },
   "EditorAccessibility": {
-    "NoLintMessages": "There are no lint messages ",
+    "NoLintMessages": "There are no lint messages",
     "CurrentLine": " Current line"
   },
   "Timer": {

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -539,7 +539,7 @@
   },
   "EditorAccessibility": {
     "NoLintMessages": "There are no lint messages",
-    "CurrentLine": " Current line"
+    "CurrentLine": "Current line"
   },
   "Timer": {
     "SavedAgo": "Saved: {{timeAgo}}"

--- a/translations/locales/es-419/translations.json
+++ b/translations/locales/es-419/translations.json
@@ -530,7 +530,7 @@
   },
   "EditorAccessibility": {
     "NoLintMessages": "No hay mensajes de Lint",
-    "CurrentLine": " Línea actual"
+    "CurrentLine": "Línea actual"
   },
   "Timer": {
     "SavedAgo": "Guardado: {{timeAgo}}"

--- a/translations/locales/fr-CA/translations.json
+++ b/translations/locales/fr-CA/translations.json
@@ -532,7 +532,7 @@
       "KeyUpLineNumber": "ligne {{lineNumber}}"
     },
     "EditorAccessibility": {
-      "NoLintMessages": "Il n'y a pas de messages lint ",
+      "NoLintMessages": "Il n'y a pas de messages lint",
       "CurrentLine": " Ligne actuelle"
     },
     "Timer": {

--- a/translations/locales/fr-CA/translations.json
+++ b/translations/locales/fr-CA/translations.json
@@ -533,7 +533,7 @@
     },
     "EditorAccessibility": {
       "NoLintMessages": "Il n'y a pas de messages lint",
-      "CurrentLine": " Ligne actuelle"
+      "CurrentLine": "Ligne actuelle"
     },
     "Timer": {
       "SavedAgo": "Sauvegardé: {{timeAgo}}"

--- a/translations/locales/hi/translations.json
+++ b/translations/locales/hi/translations.json
@@ -530,7 +530,7 @@
     },
     "EditorAccessibility": {
       "NoLintMessages": "कोई लिंट मैसेज नहीं",
-      "CurrentLine": " वर्तमान लाइन"
+      "CurrentLine": "वर्तमान लाइन"
     },
     "Timer": {
       "SavedAgo": "सेव किया: {{timeAgo}}"

--- a/translations/locales/hi/translations.json
+++ b/translations/locales/hi/translations.json
@@ -529,7 +529,7 @@
       "KeyUpLineNumber": "लाइन {{lineNumber}}"
     },
     "EditorAccessibility": {
-      "NoLintMessages": "कोई लिंट मैसेज नहीं ",
+      "NoLintMessages": "कोई लिंट मैसेज नहीं",
       "CurrentLine": " वर्तमान लाइन"
     },
     "Timer": {

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -536,7 +536,7 @@
   },
   "EditorAccessibility": {
     "NoLintMessages": "Non ci sono messaggi",
-    "CurrentLine": " Linea attuale"
+    "CurrentLine": "Linea attuale"
   },
   "Timer": {
     "SavedAgo": "Salvato: {{timeAgo}}"

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -535,7 +535,7 @@
     "KeyUpLineNumber": "linea {{lineNumber}}"
   },
   "EditorAccessibility": {
-    "NoLintMessages": "Non ci sono messaggi ",
+    "NoLintMessages": "Non ci sono messaggi",
     "CurrentLine": " Linea attuale"
   },
   "Timer": {

--- a/translations/locales/ja/translations.json
+++ b/translations/locales/ja/translations.json
@@ -529,7 +529,7 @@
       "KeyUpLineNumber": "{{lineNumber}} 行"
     },
     "EditorAccessibility": {
-      "NoLintMessages": "リントメッセージはありません ",
+      "NoLintMessages": "リントメッセージはありません",
       "CurrentLine": " 現在の行"
     },
     "Timer": {

--- a/translations/locales/ja/translations.json
+++ b/translations/locales/ja/translations.json
@@ -530,7 +530,7 @@
     },
     "EditorAccessibility": {
       "NoLintMessages": "リントメッセージはありません",
-      "CurrentLine": " 現在の行"
+      "CurrentLine": "現在の行"
     },
     "Timer": {
       "SavedAgo": "保存されました: {{timeAgo}}"

--- a/translations/locales/ko/translations.json
+++ b/translations/locales/ko/translations.json
@@ -518,7 +518,7 @@
   },
   "EditorAccessibility": {
     "NoLintMessages": "There are no lint messages",
-    "CurrentLine": " Current line"
+    "CurrentLine": "Current line"
   },
   "Timer": {
     "SavedAgo": "Saved: {{timeAgo}}"

--- a/translations/locales/ko/translations.json
+++ b/translations/locales/ko/translations.json
@@ -517,7 +517,7 @@
     "KeyUpLineNumber": "line {{lineNumber}}"
   },
   "EditorAccessibility": {
-    "NoLintMessages": "There are no lint messages ",
+    "NoLintMessages": "There are no lint messages",
     "CurrentLine": " Current line"
   },
   "Timer": {

--- a/translations/locales/pt-BR/translations.json
+++ b/translations/locales/pt-BR/translations.json
@@ -529,7 +529,7 @@
     "KeyUpLineNumber": "linha {{lineNumber}}"
   },
   "EditorAccessibility": {
-    "NoLintMessages": "Não há mensagens de Lint ",
+    "NoLintMessages": "Não há mensagens de Lint",
     "CurrentLine": "Linha atual"
   },
   "Timer": {

--- a/translations/locales/sv/translations.json
+++ b/translations/locales/sv/translations.json
@@ -533,7 +533,7 @@
   },
   "EditorAccessibility": {
     "NoLintMessages": "Det finns inga Lint-meddelanden",
-    "CurrentLine": " Aktuell rad"
+    "CurrentLine": "Aktuell rad"
   },
   "Timer": {
     "SavedAgo": "Sparad: {{timeAgo}}"

--- a/translations/locales/sv/translations.json
+++ b/translations/locales/sv/translations.json
@@ -532,7 +532,7 @@
     "KeyUpLineNumber": "rad {{lineNumber}}"
   },
   "EditorAccessibility": {
-    "NoLintMessages": "Det finns inga Lint-meddelanden ",
+    "NoLintMessages": "Det finns inga Lint-meddelanden",
     "CurrentLine": " Aktuell rad"
   },
   "Timer": {

--- a/translations/locales/tr/translations.json
+++ b/translations/locales/tr/translations.json
@@ -536,7 +536,7 @@
   },
   "EditorAccessibility": {
     "NoLintMessages": "Lint mesajı yok",
-    "CurrentLine": " Şu anki satır"
+    "CurrentLine": "Şu anki satır"
   },
   "Timer": {
     "SavedAgo": "Kaydedildi: {{timeAgo}}"

--- a/translations/locales/tr/translations.json
+++ b/translations/locales/tr/translations.json
@@ -535,7 +535,7 @@
     "KeyUpLineNumber": "{{lineNumber}}. satır"
   },
   "EditorAccessibility": {
-    "NoLintMessages": "Lint mesajı yok ",
+    "NoLintMessages": "Lint mesajı yok",
     "CurrentLine": " Şu anki satır"
   },
   "Timer": {

--- a/translations/locales/uk-UA/translations.json
+++ b/translations/locales/uk-UA/translations.json
@@ -531,7 +531,7 @@
     "KeyUpLineNumber": "рядок {{lineNumber}}"
   },
   "EditorAccessibility": {
-    "NoLintMessages": "Жодних повідомлень ",
+    "NoLintMessages": "Жодних повідомлень",
     "CurrentLine": " Поточний рядок"
   },
   "Timer": {

--- a/translations/locales/uk-UA/translations.json
+++ b/translations/locales/uk-UA/translations.json
@@ -532,7 +532,7 @@
   },
   "EditorAccessibility": {
     "NoLintMessages": "Жодних повідомлень",
-    "CurrentLine": " Поточний рядок"
+    "CurrentLine": "Поточний рядок"
   },
   "Timer": {
     "SavedAgo": "Збережено: {{timeAgo}}"

--- a/translations/locales/zh-TW/translations.json
+++ b/translations/locales/zh-TW/translations.json
@@ -532,7 +532,7 @@
     "KeyUpLineNumber": "第 {{lineNumber}} 行"
   },
   "EditorAccessibility": {
-    "NoLintMessages": "沒有語法檢查的錯誤 ",
+    "NoLintMessages": "沒有語法檢查的錯誤",
     "CurrentLine": " 目前行"
   },
   "Timer": {

--- a/translations/locales/zh-TW/translations.json
+++ b/translations/locales/zh-TW/translations.json
@@ -533,7 +533,7 @@
   },
   "EditorAccessibility": {
     "NoLintMessages": "沒有語法檢查的錯誤",
-    "CurrentLine": " 目前行"
+    "CurrentLine": "目前行"
   },
   "Timer": {
     "SavedAgo": "已儲存: {{timeAgo}}"


### PR DESCRIPTION
Changes:

After creating a story for this component it became apparent that the visual story was redundant. A better way to document this components behaviour is through unit tests.

https://github.com/processing/p5.js-web-editor/pull/2398

* Updated the prop types to `oneOf` to limit down the severity options. This matches the  severity options in CodeMirror where these messages are generated from. https://codemirror.net/docs/ref/#lint.Diagnostic.severity
* Removed tailing white space from translations
* Test for empty messages
* Test for single message

---

I think this component is malformed. It looks like some work has gone into enhancing aria properties for the line number. But it contains an empty string. Perhaps it was intended to be a sub component?

```
<span
  className="editor-linenumber"
  aria-live="polite"
  aria-atomic="true"
  id="current-line"
>
    {' '}
```

It appears redundant to me. I'd be in favour of removing it for now until its known what it is used for.

---

An interesting post on inclusively hiding content. I was wondering if its worth updating `%hidden-element` to use clip, rather than positioning 10000px off screen. They both seem to remain available to assistive technology (I haven't verifyied). But clipping isn't relying on a large offset to hide.
https://www.scottohara.me/blog/2017/04/14/inclusively-hidden.html

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
