### PR TITLE
Fix: Logout Glitch

### DIFF
--- a/server/controllers/session.controller.js
+++ b/server/controllers/session.controller.js
@@ -36,14 +36,12 @@ export function destroySession(req, res, next) {
       next(err);
       return;
     }
-    req.logout((err) => {
-      if (err) {
-        next(err);
+    req.logout((error) => {
+      if (error) {
+        next(error);
         return;
       }
-
       res.json({ success: true });
-      res.redirect('/login');
     });
   });
 }

--- a/server/controllers/session.controller.js
+++ b/server/controllers/session.controller.js
@@ -31,11 +31,19 @@ export function getSession(req, res) {
 }
 
 export function destroySession(req, res, next) {
-  req.logout((err) => {
+  req.session.destroy((err) => {
     if (err) {
       next(err);
       return;
     }
-    res.json({ success: true });
+    req.logout((err) => {
+      if (err) {
+        next(err);
+        return;
+      }
+
+      res.json({ success: true });
+      res.redirect('/login');
+    });
   });
 }


### PR DESCRIPTION
Fixes: #2449

@lindapaiste I noticed your comments on the issue. You mentioned that you're not an expert on cookies, and I'm in the same boat 😄. However, after some investigation, here's what I've discovered:

**1. Why doesn't the error occur on localhost?**
Ans: Seemingly, browsers have different policies regarding cookies for different domains. Therefore, cookies and session management may behave differently compared to an external server ( This is actually evident if you open the networks tab on both localhost and the prod site and check the `status code` of the session.) This could lead to differences in how sessions are managed and why the issue doesn't occur locally.

**2. How do we fix it?**
Ans: Deleting the session. What's happening now is that, on logout, the session Id is changing. However, we want it gone!
Apparently Passport provides another function for this. It is called: `session.destroy`.

Please check it out, and let me know if any changes is required.

Here is a brief video/gif:

with `req.session.destroy`
[screen-capture (1).webm](https://github.com/processing/p5.js-web-editor/assets/77490034/65425538-cf13-4639-a76f-4b52aa060aae)

with `req.logout`:
[screen-capture (3).webm](https://github.com/processing/p5.js-web-editor/assets/77490034/9e0df71f-54a5-4d5e-892c-760f5368e046)

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
