### PR TITLE
Fix validation typo in email input

### DIFF
--- a/client/modules/User/components/SignupForm.jsx
+++ b/client/modules/User/components/SignupForm.jsx
@@ -8,8 +8,13 @@ import Button from '../../../common/Button';
 import apiClient from '../../../utils/apiClient';
 
 function asyncValidate(fieldToValidate, value) {
+  if (fieldToValidate === 'email') {
+    return `Please enter an ${fieldToValidate}.`;
+  }
+
   if (!value || value.trim().length === 0)
     return `Please enter a ${fieldToValidate}.`;
+
   const queryParams = {};
   queryParams[fieldToValidate] = value;
   queryParams.check_type = fieldToValidate;

--- a/client/modules/User/components/SignupForm.jsx
+++ b/client/modules/User/components/SignupForm.jsx
@@ -8,12 +8,12 @@ import Button from '../../../common/Button';
 import apiClient from '../../../utils/apiClient';
 
 function asyncValidate(fieldToValidate, value) {
-  if (fieldToValidate === 'email') {
-    return `Please enter an ${fieldToValidate}.`;
-  }
-
-  if (!value || value.trim().length === 0)
+  if (!value || value.trim().length === 0) {
+    if (fieldToValidate === 'email') {
+      return `Please enter an ${fieldToValidate}.`;
+    }
     return `Please enter a ${fieldToValidate}.`;
+  }
 
   const queryParams = {};
   queryParams[fieldToValidate] = value;


### PR DESCRIPTION
Fixes #2499 

Changes:
Added a `if condition` to check if fieldToValidate is email, then Please enter `an`  ${fieldToValidate}

<img width="403" alt="Screenshot 2023-10-13 at 1 40 46 PM" src="https://github.com/processing/p5.js-web-editor/assets/47579287/baced91a-8b0b-443c-9623-5192d089da12">


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
