### PR TITLE
set autocompleteHinter in User model to false

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -74,7 +74,7 @@ const userSchema = new Schema(
       autorefresh: { type: Boolean, default: false },
       language: { type: String, default: 'en-US' },
       autocloseBracketsQuotes: { type: Boolean, default: true },
-      autocompleteHinter: { type: Boolean, default: true }
+      autocompleteHinter: { type: Boolean, default: false }
     },
     totalSize: { type: Number, default: 0 },
     cookieConsent: {


### PR DESCRIPTION
Fixes #2520 

Changes:
- On line 77 of `server/models/user.js`, the `default` for `autoCompleteHinter` is set to `false` instead of `true`

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
