### PR TITLE
Revert "fixes of the issue window.p5._report is not defined"

### DIFF
--- a/client/modules/Preview/EmbedFrame.jsx
+++ b/client/modules/Preview/EmbedFrame.jsx
@@ -252,7 +252,7 @@ function injectLocalFiles(files, htmlFile, options) {
     'PREVIEW_SCRIPTS_URL'
   )}`;
   previewScripts.setAttribute('crossorigin', '');
-  sketchDoc.body.appendChild(previewScripts);
+  sketchDoc.head.appendChild(previewScripts);
 
   const sketchDocString = `<!DOCTYPE HTML>\n${sketchDoc.documentElement.outerHTML}`;
   scriptOffs = getAllScriptOffsets(sketchDocString);


### PR DESCRIPTION
Reverts processing/p5.js-web-editor#2426 as fix for https://github.com/processing/p5.js-web-editor/issues/2518, where console.log() printing to browser console instead of p5 console. 

Suggested by @lindapaiste in [the issue thread](https://github.com/processing/p5.js-web-editor/issues/2518#issuecomment-1773542934).