### PR TITLE
fix auto refresh hover color

### DIFF
--- a/client/styles/components/_toolbar.scss
+++ b/client/styles/components/_toolbar.scss
@@ -125,8 +125,12 @@
 }
 
 .toolbar__autorefresh-label {
+	cursor: pointer;
 	@include themify() {
 		color: getThemifyVariable('secondary-text-color');
+		&:hover {
+			color: getThemifyVariable('logo-color');
+		}
 	}
 	margin-left: #{5 / $base-font-size}rem;
 	font-size: #{12 / $base-font-size}rem;


### PR DESCRIPTION
Fixes #2545 

Changes: Added cursor to pointer and hover color to logo color ie. `ED225D`

<img width="112" alt="auto-refresh-updated" src="https://github.com/processing/p5.js-web-editor/assets/47579287/c7d2e057-8a86-42f3-b8d8-26943e5a62d5">


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
