### PR TITLE
refactored lodash imports

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -1,6 +1,6 @@
 import objectID from 'bson-objectid';
 import each from 'async/each';
-import isEqual from 'lodash/isEqual';
+import { isEqual } from 'lodash';
 import browserHistory from '../../../browserHistory';
 import apiClient from '../../../utils/apiClient';
 import getConfig from '../../../utils/getConfig';

--- a/client/modules/IDE/components/AddToCollectionSketchList.jsx
+++ b/client/modules/IDE/components/AddToCollectionSketchList.jsx
@@ -4,7 +4,7 @@ import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { withTranslation } from 'react-i18next';
-// import find from 'lodash/find';
+// import { find } from 'lodash';
 import * as ProjectsActions from '../actions/projects';
 import * as CollectionsActions from '../actions/collections';
 import * as ToastActions from '../actions/toast';

--- a/client/modules/IDE/components/CollectionList/CollectionList.jsx
+++ b/client/modules/IDE/components/CollectionList/CollectionList.jsx
@@ -5,7 +5,7 @@ import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import classNames from 'classnames';
-import find from 'lodash/find';
+import { find } from 'lodash';
 import * as ProjectActions from '../../actions/project';
 import * as ProjectsActions from '../../actions/projects';
 import * as CollectionsActions from '../../actions/collections';

--- a/client/modules/IDE/hooks/useKeyDownHandlers.js
+++ b/client/modules/IDE/hooks/useKeyDownHandlers.js
@@ -1,4 +1,4 @@
-import mapKeys from 'lodash/mapKeys';
+import { mapKeys } from 'lodash';
 import PropTypes from 'prop-types';
 import { useCallback, useEffect, useRef } from 'react';
 

--- a/client/modules/IDE/selectors/collections.js
+++ b/client/modules/IDE/selectors/collections.js
@@ -1,7 +1,6 @@
 import { createSelector } from 'reselect';
 import differenceInMilliseconds from 'date-fns/differenceInMilliseconds';
-import find from 'lodash/find';
-import orderBy from 'lodash/orderBy';
+import { find, orderBy } from 'lodash';
 import { DIRECTION } from '../actions/sorting';
 
 const getCollections = (state) => state.collections;

--- a/client/modules/IDE/selectors/projects.js
+++ b/client/modules/IDE/selectors/projects.js
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import differenceInMilliseconds from 'date-fns/differenceInMilliseconds';
-import orderBy from 'lodash/orderBy';
+import { orderBy } from 'lodash';
 import { DIRECTION } from '../actions/sorting';
 
 const getSketches = (state) => state.sketches;

--- a/client/modules/User/components/APIKeyList.jsx
+++ b/client/modules/User/components/APIKeyList.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import orderBy from 'lodash/orderBy';
+import { orderBy } from 'lodash';
 import { useTranslation } from 'react-i18next';
 
 import { APIKeyPropType } from './APIKeyForm';

--- a/server/controllers/collection.controller/updateCollection.js
+++ b/server/controllers/collection.controller/updateCollection.js
@@ -1,5 +1,4 @@
-import omitBy from 'lodash/omitBy';
-import isUndefined from 'lodash/isUndefined';
+import { omitBy, isUndefined } from 'lodash';
 import Collection from '../../models/collection';
 
 function removeUndefined(obj) {

--- a/server/controllers/user.controller/__tests__/apiKey.test.js
+++ b/server/controllers/user.controller/__tests__/apiKey.test.js
@@ -1,6 +1,6 @@
 /* @jest-environment node */
 
-import last from 'lodash/last';
+import { last } from 'lodash';
 import { Request, Response } from 'jest-express';
 
 import User, { createMock, createInstanceMock } from '../../../models/user';

--- a/server/domain-objects/Project.js
+++ b/server/domain-objects/Project.js
@@ -1,5 +1,4 @@
-import isPlainObject from 'lodash/isPlainObject';
-import pick from 'lodash/pick';
+import { isPlainObject, pick } from 'lodash';
 import Project from '../models/project';
 import createId from '../utils/createId';
 import createApplicationErrorClass from '../utils/createApplicationErrorClass';

--- a/server/domain-objects/__test__/Project.test.js
+++ b/server/domain-objects/__test__/Project.test.js
@@ -1,4 +1,4 @@
-import find from 'lodash/find';
+import { find } from 'lodash';
 
 import {
   containsRootHtmlFile,


### PR DESCRIPTION
Fixes #2566

Changes:
* Replaced lodash imports,
`import find from 'lodash/find'`

with this,

`import { find } from 'lodash'`

* Just to be consistent throughout the app, this is the way to go i think.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
