### PR TITLE
fix about modal resized

### DIFF
--- a/client/styles/components/_about.scss
+++ b/client/styles/components/_about.scss
@@ -82,13 +82,17 @@
 }
 
 .about__footer {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  text-decoration: underline;
+  justify-content: end;
   padding-top: #{18 / $base-font-size}rem;
-  padding-right: #{20 / $base-font-size}rem;
+  padding-right: #{71 / $base-font-size}rem;
   padding-bottom: #{21 / $base-font-size}rem;
   padding-left: #{20 / $base-font-size}rem;
   width: 100%;
+  @media (max-width: 768px) {
+    justify-content: start;
+  }
 }
 
 .about__footer-list {

--- a/client/styles/components/_overlay.scss
+++ b/client/styles/components/_overlay.scss
@@ -23,7 +23,7 @@
   flex-wrap: wrap;
   flex-flow: column;
   max-height: 80%;
-  max-width: 80%;
+  max-width: 100%;
   position: relative;
   padding-bottom: #{25 / $base-font-size}rem;
 


### PR DESCRIPTION
Fixes #2565
Ref #2531 

Changes:

I have addressed and resolved issue #2565, which involved ensuring that the "Report a bug" and "Code of Conduct" sections no longer exceed the boundaries of the "About" modal when the window size is resized. Additionally, this pull request also addresses issue #2531.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
