### PR TITLE
fixed about modal when window size is resized

### DIFF
--- a/client/styles/components/_about.scss
+++ b/client/styles/components/_about.scss
@@ -82,15 +82,18 @@
 }
 
 .about__footer {
-  display: flex;
-  justify-content: space-between;
+  display: grid;
+  text-decoration: underline;
+  justify-content: end;
   padding-top: #{18 / $base-font-size}rem;
-  padding-right: #{20 / $base-font-size}rem;
+  padding-right: #{71 / $base-font-size}rem;
   padding-bottom: #{21 / $base-font-size}rem;
   padding-left: #{20 / $base-font-size}rem;
   width: 100%;
+  @media (max-width: 768px) {
+    justify-content: start;
+  }
 }
-
 .about__footer-list {
   padding-top: #{12 / $base-font-size}rem;
 }

--- a/client/styles/components/_overlay.scss
+++ b/client/styles/components/_overlay.scss
@@ -23,7 +23,7 @@
   flex-wrap: wrap;
   flex-flow: column;
   max-height: 80%;
-  max-width: 80%;
+  max-width: 100%;
   position: relative;
   padding-bottom: #{25 / $base-font-size}rem;
 


### PR DESCRIPTION
Fixes #2565 
Ref #2531

Changes:
I have addressed and resolved issue #2565, which involved ensuring that the "Report a bug" and "Code of Conduct" sections no longer exceed the boundaries of the "About" modal when the window size is resized .

The behavior of the about component has been successfully resolved. Prior to the changes, it appeared as follows:

<img width="500" alt="bug" src="https://github.com/processing/p5.js-web-editor/assets/114111046/6fe29c80-3374-401e-9eba-9ba593cf7818">


Following the alterations, it now appears in an improved state:


<img width="500" alt="Screenshot 2023-11-04 at 3 43 36 PM" src="https://github.com/processing/p5.js-web-editor/assets/114111046/2520f71c-0184-4595-bbbb-ea36835a5f15">

As there haven't been any merged pull requests for issue #2531, I've redesign it to the best of my abilities. I request feedback from @raclim and @lindapaiste regarding whether it's appropriate to retain these changes exclusively for issue #2565. If it's preferable to keep the modifications isolated to this specific issue, I'll be happy to re-submit the pull request with the code affecting issue #2531 removed. 


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
