### PR TITLE
Solved the issue with replace Behaviour. 

### DIFF
--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -98,7 +98,7 @@ pre.CodeMirror-line {
     margin-left: 0;
   }
 
-  // z-index: 20;
+  z-index: 1;
 
   width: 580px;
   font-family: Montserrat, sans-serif;

--- a/client/utils/codemirror-search.js
+++ b/client/utils/codemirror-search.js
@@ -98,16 +98,24 @@ function persistentDialog(cm, text, deflt, onEnter, replaceOpened, onKeyDown) {
 
     var upArrow = dialog.getElementsByClassName("up-arrow")[0];
     CodeMirror.on(upArrow, "click", function () {
-      cm.focus();
-      CodeMirror.commands.findPrev(cm);
-      searchField.blur();
+      if (searchField.value.trim() === "") {
+        searchField.focus();
+      } else {
+        cm.focus();
+        CodeMirror.commands.findPrev(cm);
+        searchField.blur();
+      }
     });
 
     var downArrow = dialog.getElementsByClassName("down-arrow")[0];
     CodeMirror.on(downArrow, "click", function () {
+      if (searchField.value.trim() === "") {
+        searchField.focus();
+      }else{
       cm.focus();
       CodeMirror.commands.findNext(cm);
       searchField.blur();
+      }
     });
 
     var regexpButton = dialog.getElementsByClassName("CodeMirror-regexp-button")[0];
@@ -371,7 +379,7 @@ function doSearch(cm, rev, persistent, immediate, ignoreQuery) {
       startSearch(cm, state, q);
       findNext(cm, rev);
     }
-  } else {
+  } else { 
     dialog(cm, queryDialog, 'Search for:', q, function (query) {
       if (query && !state.query)
         cm.operation(function () {


### PR DESCRIPTION
Fixes #2523 

Changes: DONE THE REQUIRED CHANGES, here are the result


https://github.com/processing/p5.js-web-editor/assets/127239756/a038dfbb-bc92-405e-967f-ca9c5587866c

When the input field is empty, the up and down arrow keys will focus on the searchField.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
