### PR TITLE
Solved the hovering cursor over Auto-refresh issue #2245

### DIFF
--- a/client/styles/components/_toolbar.scss
+++ b/client/styles/components/_toolbar.scss
@@ -125,8 +125,12 @@
 }
 
 .toolbar__autorefresh-label {
+	cursor: pointer;
 	@include themify() {
 		color: getThemifyVariable('secondary-text-color');
+		&:hover{
+			color:getThemifyVariable('logo-color');
+		}
 	}
 	margin-left: #{5 / $base-font-size}rem;
 	font-size: #{12 / $base-font-size}rem;


### PR DESCRIPTION
Fixes #2545
Issue: Hovering the cursor over Auto-refresh does not change the background text color to ED225D
Changes: On hover the background color of the Auto-refresh changes to ED225D

I have verified that this pull request:
* It has no linting errors.
* It has no test errors
