### PR TITLE
Fix: Screen Shake in Privacy Policy tabs

### DIFF
--- a/client/modules/Legal/components/PolicyContainer.jsx
+++ b/client/modules/Legal/components/PolicyContainer.jsx
@@ -7,6 +7,7 @@ import { remSize, prop } from '../../../theme';
 
 const PolicyContainerMain = styled.main`
   max-width: ${remSize(700)};
+  min-height: 100vh;
   margin: 0 auto;
   padding: ${remSize(10)};
   line-height: 1.5em;


### PR DESCRIPTION
Fixes #2581 

Changes:
- Add min-height of 100vh in `PolicyContainerMain`
[Screencast from 09-11-23 01:22:06 PM IST.webm](https://github.com/processing/p5.js-web-editor/assets/92508481/64ca7a9a-11a2-44db-be79-92f5dac2c05f)


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
