### PR TITLE
fix file preview link

### DIFF
--- a/client/modules/IDE/components/AssetList.jsx
+++ b/client/modules/IDE/components/AssetList.jsx
@@ -107,15 +107,16 @@ class AssetListRowBase extends React.Component {
                 </button>
               </li>
               <li>
-                <Link
-                  to={asset.url}
+                <a
+                  href={asset.url}
                   target="_blank"
+                  rel="noreferrer"
                   onBlur={this.onBlurComponent}
                   onFocus={this.onFocusComponent}
                   className="asset-table__action-option"
                 >
                   {t('AssetList.OpenNewTab')}
-                </Link>
+                </a>
               </li>
             </ul>
           )}


### PR DESCRIPTION
Fixes #2583 

Changes:

* Replaced `react-router-dom` Link with an HTML `<a>` tag
* Here, 
https://github.com/processing/p5.js-web-editor/blob/f99eda05a8128adc311c48530e989a6f19edc411/client/modules/IDE/components/AssetList.jsx#L110-L118

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
