### PR TITLE
Add gap b/w "Unconfirmed" and "Resend confirmation email" in account settings page

### DIFF
--- a/client/styles/components/_console.scss
+++ b/client/styles/components/_console.scss
@@ -87,7 +87,7 @@
 		@extend %link;
 		color: getThemifyVariable('secondary-text-color');
 		&:hover {
-			color: getThemifyVariable('heavy-text-color');
+			color: getThemifyVariable('logo-color');
 		}
 	}
 	background: transparent;

--- a/client/styles/components/_forms.scss
+++ b/client/styles/components/_forms.scss
@@ -79,6 +79,9 @@
 .form__context {
   text-align: left;
   margin-top: #{15 / $base-font-size}rem;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .form__status {


### PR DESCRIPTION
Fixes #2605

Changes: I have added  gap b/w Unconfirmed and Resend confirmation email in account settings page 

![un](https://github.com/processing/p5.js-web-editor/assets/123776031/5b2e131c-a941-4cb3-8781-82e8488eef6e)


I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] has no test errors (`npm run test`)
* [X] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`
