### PR TITLE
improve password confirmation message

### DIFF
--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -279,7 +279,7 @@
     "errorPasswordMismatch": "Passwords must match",
     "errorEmptyPassword": "Please enter a password",
     "errorShortPassword": "Password must be at least 6 characters",
-    "errorConfirmPassword": "Please enter a password confirmation",
+    "errorConfirmPassword": "Please confirm your password",
     "errorNewPassword": "Please enter a new password or leave the current password empty.",
     "errorEmptyUsername": "Please enter a username.",
     "errorLongUsername": "Username must be less than 20 characters.",
@@ -290,7 +290,7 @@
     "Description": "Set a New Password",
     "TokenInvalidOrExpired": "The password reset token is invalid or has expired.",
     "EmptyPassword": "Please enter a password",
-    "PasswordConfirmation": "Please enter a password confirmation",
+    "PasswordConfirmation": "Please confirm your password",
     "PasswordMismatch": "Passwords must match"
   },
   "AccountForm": {

--- a/translations/locales/ko/translations.json
+++ b/translations/locales/ko/translations.json
@@ -258,7 +258,7 @@
     "errorPasswordMismatch": "Passwords must match",
     "errorEmptyPassword": "Please enter a password",
     "errorShortPassword": "Password must be at least 6 characters",
-    "errorConfirmPassword": "Please enter a password confirmation",
+    "errorConfirmPassword": "Please confirm your password",
     "errorNewPassword": "Please enter a new password or leave the current password empty.",
     "errorEmptyUsername": "Please enter a username.",
     "errorLongUsername": "Username must be less than 20 characters.",
@@ -269,7 +269,7 @@
     "Description": "Set a New Password",
     "TokenInvalidOrExpired": "The password reset token is invalid or has expired.",
     "EmptyPassword": "Please enter a password",
-    "PasswordConfirmation": "Please enter a password confirmation",
+    "PasswordConfirmation": "Please confirm your password",
     "PasswordMismatch": "Passwords must match"
   },
   "AccountForm": {


### PR DESCRIPTION
Fixes #2560

Changes:

This PR enhances Password Confirmation message by changing it from "Please enter a password confirmation" to "Please confirm your password"

![pr1](https://github.com/processing/p5.js-web-editor/assets/109718740/20d0a726-f40d-4ab6-8926-d558980501f6)


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
