### PR TITLE
My Staff List can now be read with dark mode on mobile devices.

### DIFF
--- a/client/styles/abstracts/_variables.scss
+++ b/client/styles/abstracts/_variables.scss
@@ -170,7 +170,7 @@ $themes: (
     input-selection-text-color: $darkest,
     input-selection-background-color: $lightest,
     input-border-color: $middle-dark,
-    search-background-color: $lightest,
+    search-background-color: $darker,
     search-clear-background-color: $medium-dark,
     search-hover-text-color: $lightest,
     search-hover-background-color: $p5js-pink,

--- a/client/styles/abstracts/_variables.scss
+++ b/client/styles/abstracts/_variables.scss
@@ -264,7 +264,7 @@ $themes: (
     input-selection-text-color: $darkest,
     input-selection-background-color: $lightest,
     input-border-color: $middle-dark,
-    search-background-color: $white,
+    search-background-color: $darker,
     search-clear-background-color: $medium-dark,
     search-hover-text-color: $dark,
     search-hover-background-color: $yellow,


### PR DESCRIPTION
Fixes #2625

Changes:
The background color of each line of the staff list with dark mode on mobile devices has been set to a darker.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`