### PR TITLE
Add margin between the the Nav bar and Sign Up form

### DIFF
--- a/client/styles/components/_form-container.scss
+++ b/client/styles/components/_form-container.scss
@@ -35,6 +35,7 @@
 	justify-content: center;
 	align-items: center;
 	margin-bottom: 20px;
+	margin-top: 20px;
 }
 
 .form-container--align-left .form-container__content {


### PR DESCRIPTION
Fixes #2635 

Changes: Fix the margin between the Nav bar and Sign Up form component.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
