### PR TITLE
Fixed UI Inconcistencies in About Modal

### DIFF
--- a/client/modules/IDE/components/About.jsx
+++ b/client/modules/IDE/components/About.jsx
@@ -17,7 +17,7 @@ function About(props) {
   return (
     <div className="about__content">
       <Helmet>
-        <title> {t('About.TitleHelmet')} </title>
+        <title>{t('About.TitleHelmet')}</title>
       </Helmet>
       <div className="about__content-column">
         <SquareLogoIcon
@@ -26,7 +26,7 @@ function About(props) {
           aria-label={t('Common.p5logoARIA')}
           focusable="false"
         />
-        <div className="about__content-column">
+        <div className="about__content-inside">
           <p className="about__version-info">
             Web Editor: <span>v{packageData?.version}</span>
           </p>

--- a/client/styles/components/_about.scss
+++ b/client/styles/components/_about.scss
@@ -25,25 +25,27 @@
   margin-right: 15px;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 780px) {
   .about__content {
     flex-direction: column;
     overflow-y: auto;
     overflow-x: hidden;
-    width: 100%;
     margin-right: 15rem;
+    width: 100% !important;
+    gap: 15px;
   }
 
   .about__footer {
     flex-direction: column;
     padding-left: #{20 / $base-font-size}rem;
     padding-right: #{20 / $base-font-size}rem;
+    margin-left: unset !important;
   }
 }
 
 .about__content-column-title {
   font-size: #{21 / $base-font-size}rem;
-  padding-left: #{17 / $base-font-size}rem;
+  // padding-left: #{17 / $base-font-size}rem;
 }
 
 .about__content-column-asterisk {
@@ -83,11 +85,12 @@
 
 .about__footer {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   padding-top: #{18 / $base-font-size}rem;
   padding-right: #{20 / $base-font-size}rem;
-  padding-bottom: #{21 / $base-font-size}rem;
-  padding-left: #{20 / $base-font-size}rem;
+  // padding-bottom: #{21 / $base-font-size}rem;
+  // padding-left: #{20 / $base-font-size}rem;
+  margin-left: 15px;
   width: 100%;
 }
 

--- a/client/styles/components/_overlay.scss
+++ b/client/styles/components/_overlay.scss
@@ -23,7 +23,7 @@
   flex-wrap: wrap;
   flex-flow: column;
   max-height: 80%;
-  max-width: 80%;
+  max-width: 87%;
   position: relative;
   padding-bottom: #{25 / $base-font-size}rem;
 


### PR DESCRIPTION
Fixes #2531 

Changes:

* Fixed inconsistency in the About Modal Footer [ Please refer to the image given below ]

   ![image](https://github.com/processing/p5.js-web-editor/assets/63809278/9c7419f2-8702-444f-93b2-ed38177c7479)

* Fixed some misalignments [ Please refer to the image given below ]
      
    ![image](https://github.com/processing/p5.js-web-editor/assets/63809278/14a821bc-6e3d-4b21-a6a3-2975659d2ab6)

* Fixed "Text overflowing issue" when the screen size is 769px. Made more responsive [ Please refer to the image given below ]

    ![image](https://github.com/processing/p5.js-web-editor/assets/63809278/51bcaf5b-91a7-4be9-84cd-5860d92f7664)



I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
