### PR TITLE
Fixes #2647, Position of cross in about modal is not aligned cen…

### DIFF
--- a/client/styles/components/_overlay.scss
+++ b/client/styles/components/_overlay.scss
@@ -51,7 +51,7 @@
 
 .overlay__close-button {
   @include icon();
-  padding: #{3 / $base-font-size}rem 0 #{3 / $base-font-size}rem #{10 / $base-font-size}rem;
+  padding: #{3 / $base-font-size}rem #{10 / $base-font-size}rem #{3 / $base-font-size}rem #{10 / $base-font-size}rem;
 }
 
 /* Fixed height overlay */


### PR DESCRIPTION
…ter in blue border box

Fixes #2647 

Changes:
Fixed the padding of the cross icon 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
