### PR TITLE
fixes hindi translation of About object

### DIFF
--- a/translations/locales/hi/translations.json
+++ b/translations/locales/hi/translations.json
@@ -96,7 +96,10 @@
       "Resources": "साधन",
       "Libraries": "लाइब्रेरीज़",
       "Forum": "समूह",
-      "Examples": "उदाहरण"
+      "Examples": "उदाहरण",
+      "PrivacyPolicy": "प्राइवेसी पॉलिसी",
+      "TermsOfUse": "उपयोग की शर्तें",
+      "CodeOfConduct": "कोड ऑफ कंडक्ट"
     },
     "Toast": {
       "OpenedNewSketch": "नया स्केच खोला",


### PR DESCRIPTION
ref #2609

Changes:

This PR adds and translates `About.PrivacyPolicy` `About.TermsOfUse` `About.CodeOfConduct` phrases in Hindi.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
