### PR TITLE
fix project owner username hover color

### DIFF
--- a/client/modules/IDE/components/Header/Toolbar.jsx
+++ b/client/modules/IDE/components/Header/Toolbar.jsx
@@ -103,7 +103,10 @@ const Toolbar = (props) => {
             return (
               <p className="toolbar__project-project.owner">
                 {t('Toolbar.By')}{' '}
-                <Link to={`/${project.owner.username}/sketches`}>
+                <Link
+                  className="toolbar__username"
+                  to={`/${project.owner.username}/sketches`}
+                >
                   {project.owner.username}
                 </Link>
               </p>

--- a/client/styles/components/_toolbar.scss
+++ b/client/styles/components/_toolbar.scss
@@ -121,6 +121,18 @@
 	margin-left: #{5 / $base-font-size}rem;
 	@include themify() {
 		color: getThemifyVariable('secondary-text-color');
+		&:hover {
+			color: getThemifyVariable('logo-color');
+		}
+	}
+}
+.toolbar__username {
+	cursor: pointer;
+	@include themify() {
+		color: getThemifyVariable('secondary-text-color');
+		&:hover {
+			color: getThemifyVariable('logo-color');
+		}
 	}
 }
 


### PR DESCRIPTION
Fixes #2676 

Changes:
* Currently we do not have any styles associated with project owner `username` 
* Added `className` to that link
* Added hover effect 
<img width="290" alt="username-hover" src="https://github.com/processing/p5.js-web-editor/assets/47579287/20ebdac4-acc6-4562-8d4e-70736d6d0309">


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
