### PR TITLE
Download all sketches of a user as a single zip

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -262,6 +262,11 @@ export function exportProjectAsZip(projectId) {
   win.focus();
 }
 
+export function exportAllProjectsAsZip(username) {
+  const win = window.open(`${ROOT_URL}/${username}/downloadall`, '_blank');
+  win.focus();
+}
+
 export function resetProject() {
   return {
     type: ActionTypes.RESET_PROJECT

--- a/client/modules/IDE/hooks/useSketchActions.js
+++ b/client/modules/IDE/hooks/useSketchActions.js
@@ -4,6 +4,7 @@ import { useParams } from 'react-router';
 import {
   autosaveProject,
   exportProjectAsZip,
+  exportAllProjectsAsZip,
   newProject,
   saveProject,
   setProjectName
@@ -44,6 +45,10 @@ const useSketchActions = () => {
     exportProjectAsZip(project.id);
   }
 
+  function downloadAllSketches() {
+    exportAllProjectsAsZip(params.username);
+  }
+
   function shareSketch() {
     const { username } = params;
     dispatch(showShareModal(project.id, project.name, username));
@@ -61,6 +66,7 @@ const useSketchActions = () => {
     newSketch,
     saveSketch,
     downloadSketch,
+    downloadAllSketches,
     shareSketch,
     changeSketchName,
     canEditProjectName

--- a/client/modules/User/pages/DashboardView.jsx
+++ b/client/modules/User/pages/DashboardView.jsx
@@ -13,6 +13,7 @@ import CollectionList from '../../IDE/components/CollectionList';
 import SketchList from '../../IDE/components/SketchList';
 import RootPage from '../../../components/RootPage';
 import { newProject } from '../../IDE/actions/project';
+import { useSketchActions } from '../../IDE/hooks';
 import {
   CollectionSearchbar,
   SketchSearchbar
@@ -35,8 +36,14 @@ const DashboardView = () => {
 
   const [collectionCreateVisible, setCollectionCreateVisible] = useState(false);
 
+  const { downloadAllSketches } = useSketchActions();
+
   const createNewSketch = () => {
     dispatch(newProject());
+  };
+
+  const downloadAll = () => {
+    downloadAllSketches(params.username);
   };
 
   const selectedTabKey = useCallback(() => {
@@ -89,6 +96,9 @@ const DashboardView = () => {
                 {t('DashboardView.NewSketch')}
               </Button>
             )}
+            <Button onClick={downloadAll}>
+              {t('DashboardView.DownloadAll')}
+            </Button>
             <SketchSearchbar />
           </>
         );

--- a/server/controllers/project.controller/getProjectsForUser.js
+++ b/server/controllers/project.controller/getProjectsForUser.js
@@ -5,7 +5,7 @@ import createApplicationErrorClass from '../../utils/createApplicationErrorClass
 
 const UserNotFoundError = createApplicationErrorClass('UserNotFoundError');
 
-function getProjectsForUserName(username) {
+export function getProjectsForUserName(username) {
   return new Promise((resolve, reject) => {
     User.findByUsername(username, (err, user) => {
       if (err) {

--- a/server/routes/project.routes.js
+++ b/server/routes/project.routes.js
@@ -26,4 +26,9 @@ router.get('/:username/projects', ProjectController.getProjectsForUser);
 
 router.get('/projects/:project_id/zip', ProjectController.downloadProjectAsZip);
 
+router.get(
+  '/:username/downloadall',
+  ProjectController.downloadAllProjectsAsZip
+);
+
 export default router;

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -465,7 +465,8 @@
   "DashboardView": {
     "CreateCollection": "Create collection",
     "NewSketch": "New sketch",
-    "CreateCollectionOverlay": "Create collection"
+    "CreateCollectionOverlay": "Create collection",
+    "DownloadAll": "Download all Sketches"
   },
   "DashboardTabSwitcher": {
     "Sketches": "Sketches",


### PR DESCRIPTION
Fixes #1939 

Changes:
- Added a `Download all sketches` button 
- Added `Download all sketches` in English translation file
- Added new controller `downloadAllProjectsAsZip`
- Added a new library bundling function to handle library bundling in the case of multiple projects

Logic: I created a function called `compileProjects` that can merge multiple projects into one big project that treats all the projects as subfolders. This compilation follows the JSON format needed for the `addFileToZip` function to work and thus reuses the same method used for singular project. I also created a new function `bundleExternalLibsForCompiledProject` that handles bundling library files for the compilation. It adds specific library files to each project folder for that particular project.

![image](https://github.com/processing/p5.js-web-editor/assets/135870090/06e72102-6ab3-4798-a1ce-6bfe92d169b3)

![image](https://github.com/processing/p5.js-web-editor/assets/135870090/e6fbc4bf-cd80-4f5a-80ed-da11d3d1f1d4)

![image](https://github.com/processing/p5.js-web-editor/assets/135870090/b4f8cb99-92ca-4338-85d0-00a6d5d2378b)


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
