### PR TITLE
fix: #2730 The navbar menu is now responsive

### DIFF
--- a/client/modules/IDE/components/Header/MobileNav.jsx
+++ b/client/modules/IDE/components/Header/MobileNav.jsx
@@ -94,6 +94,9 @@ export const Options = styled.div`
   ul.opened {
     transform: scale(1);
     opacity: 1;
+    max-width: 90vw;
+    max-height: 90vh;
+    overflow-y: auto;
   }
 
   > div {

--- a/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
+++ b/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
@@ -175,6 +175,9 @@ exports[`Nav renders dashboard version for mobile 1`] = `
   -ms-transform: scale(1);
   transform: scale(1);
   opacity: 1;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .c3 > div {
@@ -816,6 +819,9 @@ exports[`Nav renders editor version for mobile 1`] = `
   -ms-transform: scale(1);
   transform: scale(1);
   opacity: 1;
+  max-width: 90vw;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 .c3 > div {


### PR DESCRIPTION
Fixes #2730 

Changes:
Made some style changes to the mobile nav menu container, added max widths and heights and allowed auto overflow for scrolling in case the modal overflows on smaller screens.
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

https://github.com/processing/p5.js-web-editor/assets/114330931/7210a726-3956-4875-abbb-7d1b9bfcde0f


