### PR TITLE
fixed ErrorModal

### DIFF
--- a/client/modules/IDE/components/ErrorModal.jsx
+++ b/client/modules/IDE/components/ErrorModal.jsx
@@ -7,22 +7,32 @@ const ErrorModal = ({ type, service, closeModal }) => {
   const { t } = useTranslation();
 
   function forceAuthentication() {
+    const linkStyle = {
+      backgroundColor: '#ED225D',
+      padding: '5px',
+      color: 'white',
+      fontWeight: 'bold'
+    };
+    const margin = {
+      marginTop: '5px'
+    };
     return (
       <p>
-        {t('ErrorModal.MessageLogin')}
-        <Link to="/login" onClick={closeModal}>
-          {' '}
-          {t('ErrorModal.Login')}
-        </Link>
-        {t('ErrorModal.LoginOr')}
-        <Link to="/signup" onClick={closeModal}>
-          {t('ErrorModal.SignUp')}
-        </Link>
+        <span>{t('ErrorModal.MessageLogin')}</span>
+        <p style={margin}>
+          <Link to="/login" onClick={closeModal} style={linkStyle}>
+            {' '}
+            {t('ErrorModal.Login')}
+          </Link>
+          {t('ErrorModal.LoginOr')}
+          <Link to="/signup" onClick={closeModal} style={linkStyle}>
+            {t('ErrorModal.SignUp')}
+          </Link>
+        </p>
         .
       </p>
     );
   }
-
   function oauthError() {
     const serviceLabels = {
       github: 'GitHub',


### PR DESCRIPTION
Fixes #2734

Changes:
fix ErrorModal. cahnge background  in login and signup link.
befor:-
![Screenshot 2023-12-18 091600](https://github.com/processing/p5.js-web-editor/assets/105407521/d1d13275-75a5-4e63-80f3-6c4d3bd6493b)
after:-
![p5 errormodal](https://github.com/processing/p5.js-web-editor/assets/105407521/433df189-f3ca-40b7-ae8f-5d5d5554c0e8)


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
