### PR TITLE
Conveniently switch back to the p5js.org website from the web editor page #2742

### DIFF
--- a/client/modules/IDE/components/Header/Nav.jsx
+++ b/client/modules/IDE/components/Header/Nav.jsx
@@ -111,12 +111,14 @@ const DashboardMenu = () => {
   return (
     <ul className="nav__items-left">
       <li className="nav__item-logo">
+        <a href ="https://p5js.org" >
         <LogoIcon
           role="img"
           aria-label={t('Common.p5logoARIA')}
           focusable="false"
           className="svg__logo"
         />
+          </a>
       </li>
       <li className="nav__item nav__item--no-icon">
         <Link to={editorLink} className="nav__back-link">

--- a/client/styles/components/_about.scss
+++ b/client/styles/components/_about.scss
@@ -43,7 +43,7 @@
 
 .about__content-column-title {
   font-size: #{21 / $base-font-size}rem;
-  // padding-left: #{17 / $base-font-size}rem;
+  padding-left: #{0 / $base-font-size}rem;
 }
 
 .about__content-column-asterisk {

--- a/client/styles/components/_about.scss
+++ b/client/styles/components/_about.scss
@@ -43,7 +43,7 @@
 
 .about__content-column-title {
   font-size: #{21 / $base-font-size}rem;
-  padding-left: #{17 / $base-font-size}rem;
+  // padding-left: #{17 / $base-font-size}rem;
 }
 
 .about__content-column-asterisk {


### PR DESCRIPTION
Fixes https://github.com/processing/p5.js-web-editor/issues

Added tag to the p5js LogoIcon in Nav.jsx (client/modules/IDE/components/Header)
to make a route to p5js.org.

I have verified that this pull request:

- [x] Has no linting errors (npm run lint)
- [x] Has no test errors (npm run test)
- [x] Is from a uniquely-named feature branch and is up to date with the develop branch.
- [x] Is descriptively named and links to an issue number https://github.com/processing/p5.js-web-editor/issues