### PR TITLE
Fixed #2647, fixed overlay button blue border-box!

### DIFF
--- a/client/modules/IDE/components/AddToCollectionList.jsx
+++ b/client/modules/IDE/components/AddToCollectionList.jsx
@@ -39,7 +39,7 @@ class CollectionList extends React.Component {
       props.getProject(props.projectId);
     }
 
-    this.props.getCollections(this.props.username);
+    this.props.getCollections(this.props.user.username);
 
     this.state = {
       hasLoadedData: false

--- a/client/modules/IDE/components/AddToCollectionList.jsx
+++ b/client/modules/IDE/components/AddToCollectionList.jsx
@@ -39,7 +39,7 @@ class CollectionList extends React.Component {
       props.getProject(props.projectId);
     }
 
-    this.props.getCollections(this.props.user.username);
+    this.props.getCollections(this.props.username);
 
     this.state = {
       hasLoadedData: false

--- a/client/styles/components/_overlay.scss
+++ b/client/styles/components/_overlay.scss
@@ -50,10 +50,17 @@
 }
 
 .overlay__close-button {
-  @include icon();
-  padding: #{3 / $base-font-size}rem 0 #{3 / $base-font-size}rem #{10 / $base-font-size}rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem; 
+  cursor: pointer;
 }
 
+.overlay__close-button svg {
+  width: 16px;    
+  height: 16px;
+}
 /* Fixed height overlay */
 .overlay--is-fixed-height .overlay__body {
   height: 100vh;


### PR DESCRIPTION
Fixes #2647, Position of cross in about modal is now aligned center in blue border box.

Before: 
![Screenshot (174)](https://github.com/processing/p5.js-web-editor/assets/122638553/0dff8795-47df-4600-a17b-87039c35fd0a)

Changes:
![Screenshot (175)](https://github.com/processing/p5.js-web-editor/assets/122638553/ac3ff581-dcd1-413c-80cd-96539e9812e3)


I have verified that this pull request:

- [x] has no linting errors (`npm run lint`)
- [x] has no test errors (`npm run test`)
- [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
- [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
