### PR TITLE
Fixed #2784, Navbar on Mobile fixed!

### DIFF
--- a/client/modules/IDE/components/AddToCollectionList.jsx
+++ b/client/modules/IDE/components/AddToCollectionList.jsx
@@ -39,7 +39,7 @@ class CollectionList extends React.Component {
       props.getProject(props.projectId);
     }
 
-    this.props.getCollections(this.props.username);
+    this.props.getCollections(this.props.user.username);
 
     this.state = {
       hasLoadedData: false

--- a/client/modules/IDE/components/AddToCollectionList.jsx
+++ b/client/modules/IDE/components/AddToCollectionList.jsx
@@ -39,7 +39,7 @@ class CollectionList extends React.Component {
       props.getProject(props.projectId);
     }
 
-    this.props.getCollections(this.props.user.username);
+    this.props.getCollections(this.props.username);
 
     this.state = {
       hasLoadedData: false

--- a/client/modules/IDE/components/Header/MobileNav.jsx
+++ b/client/modules/IDE/components/Header/MobileNav.jsx
@@ -51,7 +51,7 @@ const Nav = styled(NavBar)`
 
 const LogoContainer = styled.div`
   width: ${remSize(28)};
-  aspect-ratio: 1;
+  height: ${remSize(28)};
   margin-left: ${remSize(14)};
   display: flex;
   justify-content: center;
@@ -233,9 +233,11 @@ const MobileNav = () => {
   const Logo = AsteriskIcon;
   return (
     <Nav>
-      <LogoContainer>
-        <Logo />
-      </LogoContainer>
+      <Link to="/">
+        <LogoContainer>
+          <Logo />
+        </LogoContainer>
+      </Link>
       <Title>
         <h1>{title === project.name ? <ProjectName /> : title}</h1>
         {project?.owner && title === project.name && (

--- a/client/styles/components/_overlay.scss
+++ b/client/styles/components/_overlay.scss
@@ -50,10 +50,17 @@
 }
 
 .overlay__close-button {
-  @include icon();
-  padding: #{3 / $base-font-size}rem 0 #{3 / $base-font-size}rem #{10 / $base-font-size}rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem; 
+  cursor: pointer;
 }
 
+.overlay__close-button svg {
+  width: 16px;    
+  height: 16px;
+}
 /* Fixed height overlay */
 .overlay--is-fixed-height .overlay__body {
   height: 100vh;


### PR DESCRIPTION
Fixes #2784

Changes:
Made the P5 Asterisk Icon clickable--to navback to Home Page.

PS: also aligned the blue border-box that appears when you click the icon.

I have verified that this pull request:

- [x] has no linting errors (`npm run lint`)
- [x] has no test errors (`npm run test`)
- [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
- [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
