### PR TITLE
Fix keyboard shortcut modal's width for mobile devices

### DIFF
--- a/client/styles/components/_keyboard-shortcuts.scss
+++ b/client/styles/components/_keyboard-shortcuts.scss
@@ -2,7 +2,7 @@
   padding: #{20 / $base-font-size}rem;
   margin-right: #{20 / $base-font-size}rem;
   padding-bottom: #{40 / $base-font-size}rem;
-  width: #{450 / $base-font-size}rem;
+  max-width: #{450 / $base-font-size}rem;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
### Issue:
The Keyboard Shortcuts modal exhibited horizontal scrolling on mobile devices due to a fixed width.

### Solution:
Resolved by adjusting the modal's width property from a fixed value to `max-width`, enabling responsiveness based on content. This ensures optimal viewing on various screen sizes, enhancing user experience.

### Changes:

**Before**

![keyboard-shortcuts-before](https://github.com/processing/p5.js-web-editor/assets/54032677/0c5541ed-ef02-4228-a4b1-3dc62a1dcad3)

**After**

![keyboard-shortcuts-after](https://github.com/processing/p5.js-web-editor/assets/54032677/515c93a9-478d-49f2-bc36-03d8ca5647fd)


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
