### PR TITLE
Fixed the horizotal page  scroll issue for smaller usernames

### DIFF
--- a/client/styles/components/_nav.scss
+++ b/client/styles/components/_nav.scss
@@ -119,6 +119,7 @@
   display: none;
   .nav__item--open & {
     display: flex;
+    max-width: fit-content;
   }
 }
 


### PR DESCRIPTION
Fixes #2678 

Changes:
For resolving this issue there were many design ideas i thought:
1. providing padding or margin so that we will be able to stop the overflow of the dropdown. But crating blank space in the right side of that element would look bad.
2. alignning the dropdown menu right would be another option but as mentioned in the following comment I dropped this idea https://github.com/processing/p5.js-web-editor/issues/2678#issuecomment-1839258617
3. So, the better option was to use different style of dropdown menu
![Screenshot from 2024-01-02 02-22-19](https://github.com/processing/p5.js-web-editor/assets/137636943/c40f6d1c-88d7-4444-a930-47503f209f1c)
![Screenshot from 2024-01-02 02-21-46](https://github.com/processing/p5.js-web-editor/assets/137636943/04a2a86e-4828-4a40-a835-303b9c926052)
So for the longer usernames it stays as before, but for short usernames it shrinks itself below the username.

4.Another proposed idea is to interchange the postion of the language dropdown and username dropdown. @lindapaiste I would like to have your review of my currently created and 4th proposed idea.

I have verified that this pull request:

- [X] has no linting errors (`npm run lint`)
- [X] has no test errors (`npm run test`)
- [X] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
- [X] is descriptively named and links to an issue number, i.e. `Fixes #123`
