### PR TITLE
changed right left arrow to file icon

### DIFF
--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -52,8 +52,6 @@ import * as hinter from '../../../../utils/p5-hinter';
 import '../../../../utils/codemirror-search';
 
 import beepUrl from '../../../../sounds/audioAlert.mp3';
-import RightArrowIcon from '../../../../images/right-arrow.svg';
-import LeftArrowIcon from '../../../../images/left-arrow.svg';
 import { getHTMLFile } from '../../reducers/files';
 import { selectActiveFile } from '../../selectors/files';
 
@@ -522,14 +520,20 @@ class Editor extends React.Component {
                     this.props.closeProjectOptions();
                   }}
                 >
-                  <LeftArrowIcon focusable="false" aria-hidden="true" />
+                  <IconButton
+                    onClick={this.props.expandSidebar}
+                    icon={FolderIcon}
+                  />
                 </button>
                 <button
                   aria-label={this.props.t('Editor.CloseSketchARIA')}
                   className="sidebar__expand"
                   onClick={this.props.expandSidebar}
                 >
-                  <RightArrowIcon focusable="false" aria-hidden="true" />
+                  <IconButton
+                    onClick={this.props.expandSidebar}
+                    icon={FolderIcon}
+                  />
                 </button>
                 <div className="editor__file-name">
                   <span>

--- a/client/styles/components/_sidebar.scss
+++ b/client/styles/components/_sidebar.scss
@@ -239,7 +239,6 @@
       fill: getThemifyVariable("toolbar-button-color");
     }
     &:hover {
-      background-color: getThemifyVariable("button-background-hover-color");
       & polygon, & path {
         fill: getThemifyVariable("button-hover-color");
       }


### PR DESCRIPTION
Fixes #2888

Changes:
made src button a file icon for a seemless experience. Made it same as on mobile devices on the desktop.
I have verified that this pull request:

 * [x] has no linting errors (`npm run lint`)
 * [x] has no test errors (`npm run test`)
 * [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
 * [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
