### PR TITLE
Saving unsaved Sketch before signing in with Oauth.

### DIFF
--- a/client/modules/User/components/SocialAuthButton.jsx
+++ b/client/modules/User/components/SocialAuthButton.jsx
@@ -8,6 +8,7 @@ import { remSize } from '../../../theme';
 import { GithubIcon, GoogleIcon } from '../../../common/icons';
 import Button from '../../../common/Button';
 import { unlinkService } from '../actions';
+import { persistState } from '../../IDE/actions/project';
 
 const authUrls = {
   github: '/auth/github',
@@ -64,6 +65,7 @@ function SocialAuthButton({ service, linkStyle, isConnected }) {
       <StyledButton
         iconBefore={<ServiceIcon aria-label={ariaLabel} />}
         href={authUrls[service]}
+        onClick={() => dispatch(persistState())}
       >
         {connectLabel}
       </StyledButton>
@@ -73,6 +75,7 @@ function SocialAuthButton({ service, linkStyle, isConnected }) {
     <StyledButton
       iconBefore={<ServiceIcon aria-label={ariaLabel} />}
       href={authUrls[service]}
+      onClick={() => dispatch(persistState())}
     >
       {loginLabel}
     </StyledButton>


### PR DESCRIPTION
Fixes #2334 

Changes:
Props to @lindapaiste , he/she figured out how to sort this out while I just stuck two pieces together :)
https://github.com/processing/p5.js-web-editor/pull/2424#issuecomment-1732392638

https://github.com/processing/p5.js-web-editor/assets/122638553/36d3226a-3afd-4c3a-99b1-bc06a51f4ada


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
