### PR TITLE
Fixes Clicking on cross icon on create folder/create file modal throws unnessary error.

### DIFF
--- a/client/modules/IDE/components/NewFileForm.jsx
+++ b/client/modules/IDE/components/NewFileForm.jsx
@@ -20,7 +20,7 @@ function NewFileForm() {
     const errors = {};
 
     if (!formProps.name) {
-      errors.name = t('NewFileModal.EnterName');
+      errors.name = '';
     } else if (!formProps.name.match(CREATE_FILE_REGEX)) {
       errors.name = t('NewFileModal.InvalidType');
     }

--- a/client/modules/IDE/components/NewFolderForm.jsx
+++ b/client/modules/IDE/components/NewFolderForm.jsx
@@ -16,7 +16,7 @@ function NewFolderForm() {
   function validate(formProps) {
     const errors = {};
     if (!formProps.name) {
-      errors.name = t('NewFolderModal.EnterName');
+      errors.name = '';
     } else if (formProps.name.trim().length === 0) {
       errors.name = t('NewFolderModal.EmptyName');
     } else if (formProps.name.match(/\.+/i)) {

--- a/translations/locales/be/translations.json
+++ b/translations/locales/be/translations.json
@@ -243,7 +243,6 @@
   "NewFileModal": {
     "Title": "ফাইল তৈরি করুন",
     "CloseButtonARIA": "নতুন ফাইল মোডাল বন্ধ করুন",
-    "EnterName": "নাম লিখুন",
     "InvalidType": "অবৈধ ফাইল ধরন। বৈধ এক্সটেনশনগুলি হলো .js, .css, .json, .xml, .stl, .txt, .csv, .tsv, .frag এবং .vert."
   },
   "NewFileForm": {
@@ -253,7 +252,6 @@
   "NewFolderModal": {
     "Title": "ফোল্ডার তৈরি করুন",
     "CloseButtonARIA": "নতুন ফোল্ডার মোডাল বন্ধ করুন",
-    "EnterName": "নাম লিখুন দয়া করে",
     "EmptyName": "ফোল্ডার নাম কেবলমাত্র স্থান নিতে পারবে না",
     "InvalidExtension": "ফোল্ডার নামে একটি এক্সটেনশন থাকতে পারবে না"
   },

--- a/translations/locales/de/translations.json
+++ b/translations/locales/de/translations.json
@@ -234,7 +234,6 @@
   "NewFileModal": {
     "Title": "Neue Datei",
     "CloseButtonARIA": "Neue Datei Fenster schließen",
-    "EnterName": "Bitte gib einen Namen ein",
     "InvalidType": "Ungültiger Dateityp. Gültige Endungen sind .js, .css, .json, .xml, .txt, .csv, .tsv, .frag, und .vert."
   },
   "NewFileForm": {
@@ -244,7 +243,6 @@
   "NewFolderModal": {
     "Title": "Neuer Ordner",
     "CloseButtonARIA": "Neuer Ordner Fenster schließen",
-    "EnterName": "Bitte gib einen Namen ein",
     "EmptyName": "Der Ordnername kann keine Leerzeichen enthalten",
     "InvalidExtension": "Der Ordnername kann keine Datei-Endung enthalten"
   },

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -243,7 +243,6 @@
   "NewFileModal": {
     "Title": "Create File",
     "CloseButtonARIA": "Close New File Modal",
-    "EnterName": "Please enter a name",
     "InvalidType": "Invalid file type. Valid extensions are .js, .css, .json, .xml, .stl, .txt, .csv, .tsv, .frag, and .vert."
   },
   "NewFileForm": {
@@ -253,7 +252,6 @@
   "NewFolderModal": {
     "Title": "Create Folder",
     "CloseButtonARIA": "Close New Folder Modal",
-    "EnterName": "Please enter a name",
     "EmptyName": "Folder name cannot contain only spaces",
     "InvalidExtension": "Folder name cannot contain an extension"
   },

--- a/translations/locales/es-419/translations.json
+++ b/translations/locales/es-419/translations.json
@@ -234,7 +234,6 @@
   "NewFileModal": {
     "Title": "Crear Archivo",
     "CloseButtonARIA": "Cerrar diálogo de crear archivo",
-    "EnterName": "Por favor introduce un nombre",
     "InvalidType": "Tipo de archivo inválido. Las extensiones válidas son .js, .css, .json, .xml, .stl, .txt, .csv, .tsv, .frag y .vert."
   },
   "NewFileForm": {
@@ -244,7 +243,6 @@
   "NewFolderModal": {
     "Title": "Crear Directorio",
     "CloseButtonARIA": "Cerrar Diálogo de Nuevo Directorio",
-    "EnterName": "Por favor introduce un nombre",
     "EmptyName": " El nombre del directorio no debe contener solo espacios vacíos",
     "InvalidExtension": "El nombre del directorio no debe contener una extensión"
   },

--- a/translations/locales/fr-CA/translations.json
+++ b/translations/locales/fr-CA/translations.json
@@ -237,7 +237,6 @@
     "NewFileModal": {
       "Title": "Créer un fichier",
       "CloseButtonARIA": "Fermer la boîte de dialogue de création de fichier",
-      "EnterName": "Veuillez saisir un nom",
       "InvalidType": "Type de fichier invalide. Les extensions valides sont .js, .css, .json, .txt, .csv, .tsv, .frag, and .vert."
     },
     "NewFileForm": {
@@ -247,7 +246,6 @@
     "NewFolderModal": {
       "Title": "Créer un dossier",
       "CloseButtonARIA": "Fermer la boîte de dialogue de création de dossier",
-      "EnterName": "Veuillez saisir un nom",
       "EmptyName": "Le nom du dossier ne peut contenir uniquement des espaces",
       "InvalidExtension": "Le nom du dossier ne peut contenir une extension"
     },

--- a/translations/locales/hi/translations.json
+++ b/translations/locales/hi/translations.json
@@ -237,7 +237,6 @@
     "NewFileModal": {
       "Title": "फ़ाइल बनाएँ",
       "CloseButtonARIA": "नई फ़ाइल मोडल बंद करें",
-      "EnterName": "कृपया एक नाम दर्ज करें",
       "InvalidType": "अमान्य फ़ाइल प्रकार। मान्य एक्सटेंशन हैं .js, .css, .json, .xml, .stl, .txt, .csv, .tsv, .frag, और .vert."
     },
     "NewFileForm": {
@@ -247,7 +246,6 @@
     "NewFolderModal": {
       "Title": "फोल्डर बनाएं",
       "CloseButtonARIA": "नया फ़ोल्डर मोडल बंद करें",
-      "EnterName": "कृपया नाम दर्ज करें",
       "EmptyName": "फ़ोल्डर नाम में केवल रिक्त स्थान नहीं हो सकते",
       "InvalidExtension": "फ़ोल्डर नाम में एक्सटेंशन नहीं हो सकता"
     },

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -240,7 +240,6 @@
   "NewFileModal": {
     "Title": "Crea File",
     "CloseButtonARIA": "Chiudi finestra Nuovo File",
-    "EnterName": "Prego inserire il nome",
     "InvalidType": "Tipo di file non valido. Estensioni valide sono: .js, .css, .json, .xml, .txt, .csv, .tsv, .frag, and .vert."
   },
   "NewFileForm": {
@@ -250,7 +249,6 @@
   "NewFolderModal": {
     "Title": "Crea cartella",
     "CloseButtonARIA": "Chiudi finestra nuova cartella",
-    "EnterName": "Prego inserire il nome",
     "EmptyName": "Il nome cartella non può contenere solo spazi",
     "InvalidExtension": "Il nome cartella non può contenere un'estensione"
   },

--- a/translations/locales/ja/translations.json
+++ b/translations/locales/ja/translations.json
@@ -234,7 +234,6 @@
     "NewFileModal": {
       "Title": "ファイル作成",
       "CloseButtonARIA": "新規ファイルモーダルを閉じる",
-      "EnterName": "ファイル名を入力してください",
       "InvalidType": "ファイルタイプが無効です。有効な拡張子は、.js、.css、.json、.xml、.stl、.txt、.csv、.tsv、.frag、.vertです。"
     },
     "NewFileForm": {
@@ -244,7 +243,6 @@
     "NewFolderModal": {
       "Title": "フォルダ作成",
       "CloseButtonARIA": "新しいフォルダモーダルを閉じる",
-      "EnterName": "フォルダ名を入力してください",
       "EmptyName": "スペースのみのフォルダ名は無効です",
       "InvalidExtension": "フォルダ名に拡張子を含めることはできません"
     },

--- a/translations/locales/ko/translations.json
+++ b/translations/locales/ko/translations.json
@@ -222,7 +222,6 @@
   "NewFileModal": {
     "Title": "파일 생성",
     "CloseButtonARIA": "Close New File Modal",
-    "EnterName": "Please enter a name",
     "InvalidType": "Invalid file type. Valid extensions are .js, .css, .json, .txt, .csv, .tsv, .frag, and .vert."
   },
   "NewFileForm": {
@@ -232,7 +231,6 @@
   "NewFolderModal": {
     "Title": "폴더 생성",
     "CloseButtonARIA": "Close New Folder Modal",
-    "EnterName": "Please enter a name",
     "EmptyName": "Folder name cannot contain only spaces",
     "InvalidExtension": "Folder name cannot contain an extension"
   },

--- a/translations/locales/pt-BR/translations.json
+++ b/translations/locales/pt-BR/translations.json
@@ -234,7 +234,6 @@
   "NewFileModal": {
     "Title": "Criar Arquivos",
     "CloseButtonARIA": "Fechar Módulo de Criação de Arquivos",
-    "EnterName": "Por favor coloque um nome",
     "InvalidType": "Tipo de arquivo invalido. Extensões válidas são .js, .css, .json, .xml, .txt, .csv, .tsv, .frag, and .vert."
   },
   "NewFileForm": {
@@ -244,7 +243,6 @@
   "NewFolderModal": {
     "Title": "Criar",
     "CloseButtonARIA": "Fechar Módulo de Criação de Pasta",
-    "EnterName": "Por favor coloque um nome",
     "EmptyName": "Nomes de pastas não podem conter apenas espaços",
     "InvalidExtension": "Nomes de pastas não podem conter extensões"
   },

--- a/translations/locales/sv/translations.json
+++ b/translations/locales/sv/translations.json
@@ -237,7 +237,6 @@
   "NewFileModal": {
     "Title": "Skapa fil",
     "CloseButtonARIA": "Stäng ny fil Modal",
-    "EnterName": "Skriv in ett namn",
     "InvalidType": "Felaktig filtyp. Giltiga filändelser är .js, .css, .json, .xml, .txt, .csv, .tsv, .frag, och .vert."
   },
   "NewFileForm": {
@@ -247,7 +246,6 @@
   "NewFolderModal": {
     "Title": "Skapa mapp",
     "CloseButtonARIA": "Stäng ny mapp Modal",
-    "EnterName": "Skriv in ett namn",
     "EmptyName": "Mappnamnet kan inte vara tomt",
     "InvalidExtension": "Mappnamnet kan inte innehålla en filändelse"
   },

--- a/translations/locales/tr/translations.json
+++ b/translations/locales/tr/translations.json
@@ -240,7 +240,6 @@
   "NewFileModal": {
     "Title": "Dosya Oluştur",
     "CloseButtonARIA": "Yeni Dosya Modalını Kapat",
-    "EnterName": "Lütfen bir isim girin",
     "InvalidType": "Geçersiz dosya türü. Geçerli uzantılar .js, .css, .json, .xml, .txt, .csv, .tsv, .frag ve .vert'tir."
   },
   "NewFileForm": {
@@ -250,7 +249,6 @@
   "NewFolderModal": {
     "Title": "Klasör Oluştur",
     "CloseButtonARIA": "Yeni Klasör Modalını Kapat",
-    "EnterName": "Lütfen bir isim girin",
     "EmptyName": "Klasör adı sadece boşluk içeremez",
     "InvalidExtension": "Klasör adı bir uzantı içeremez"
   },

--- a/translations/locales/uk-UA/translations.json
+++ b/translations/locales/uk-UA/translations.json
@@ -236,7 +236,6 @@
   "NewFileModal": {
     "Title": "Додати файл",
     "CloseButtonARIA": "Закрити",
-    "EnterName": "Введіть ім'я файла",
     "InvalidType": "Некоректний тип файлу. Підтримувані формати: .js, .css, .json, .xml, .txt, .csv, .tsv, .frag та .vert."
   },
   "NewFileForm": {
@@ -246,7 +245,6 @@
   "NewFolderModal": {
     "Title": "Додати папку",
     "CloseButtonARIA": "Закрити",
-    "EnterName": "Введіть ім'я папки",
     "EmptyName": "Ім'я папки не може містити лише пробіли",
     "InvalidExtension": "Ім'я папки не може містити розширення"
   },

--- a/translations/locales/ur/translations.json
+++ b/translations/locales/ur/translations.json
@@ -243,7 +243,6 @@
     "NewFileModal": {
       "Title": "فائل بنائیں",
       "CloseButtonARIA": "نیا فائل موڈل بند کریں۔",
-      "EnterName": "براہ کرم ایک نام درج کریں۔",
       "InvalidType": "غلط فائل کی قسم۔ "
     },
     "NewFileForm": {
@@ -253,7 +252,6 @@
     "NewFolderModal": {
       "Title": "فولڈر بنائیں",
       "CloseButtonARIA": "نیا فولڈر موڈل بند کریں۔",
-      "EnterName": "براہ کرم ایک نام درج کریں۔",
       "EmptyName": "فولڈر کا نام صرف خالی جگہوں پر مشتمل نہیں ہو سکتا",
       "InvalidExtension": "فولڈر کے نام میں توسیع نہیں ہو سکتی"
     },

--- a/translations/locales/zh-CN/translations.json
+++ b/translations/locales/zh-CN/translations.json
@@ -237,7 +237,6 @@
   "NewFileModal": {
     "Title": "新建文件",
     "CloseButtonARIA": "取消新建文件",
-    "EnterName": "请输入名称",
     "InvalidType": "不支持的格式。支持的格式有 .js, .css, .json, .xml, .txt, .csv, .tsv, .frag, .vert 。"
   },
   "NewFileForm": {
@@ -247,7 +246,6 @@
   "NewFolderModal": {
     "Title": "新建文件夹",
     "CloseButtonARIA": "取消新建文件夹",
-    "EnterName": "请输入名称",
     "EmptyName": "文件夹名称不能含有空格",
     "InvalidExtension": "文件夹名称不能含有空格"
   },

--- a/translations/locales/zh-TW/translations.json
+++ b/translations/locales/zh-TW/translations.json
@@ -237,7 +237,6 @@
   "NewFileModal": {
     "Title": "建立檔案",
     "CloseButtonARIA": "關閉建立檔案交談窗",
-    "EnterName": "請輸入檔名",
     "InvalidType": "檔案類型錯誤, 只能接受 .js, .css, .json, .xml, .txt, .csv, .tsv, .frag, 或是 .vert 副檔名"
   },
   "NewFileForm": {
@@ -247,7 +246,6 @@
   "NewFolderModal": {
     "Title": "建立資料夾",
     "CloseButtonARIA": "關閉建立資料夾交談窗",
-    "EnterName": "請輸入資料夾名稱",
     "EmptyName": "資料夾名稱中不能只有空白",
     "InvalidExtension": "資料夾名稱不能包含副檔名"
   },


### PR DESCRIPTION
Fixes #2895 

Changes:
Clicking on cross icon or whitespace on create folder/create file modal not dosen't throw any validation error message. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #2895 `
