### PR TITLE
Fix : [#2940] Add font-weight

### DIFF
--- a/client/styles/components/_keyboard-shortcuts.scss
+++ b/client/styles/components/_keyboard-shortcuts.scss
@@ -38,6 +38,10 @@
   padding-bottom: #{10 / $base-font-size}rem;
 }
 
+.keyboard-shortcuts__description a {
+  font-weight: bold;
+}
+
 .keyboard-shortcuts__list:not(:last-of-type) {
   padding-bottom: #{10 / $base-font-size}rem;
 }


### PR DESCRIPTION
Fixes #2940

Changes: Added font-weight to the anchor tag to resolve the issue.

This will ensure that the hyperlink is formatted to align with the visual style of other hyperlinks within the web application.
Like following :- 
![image](https://github.com/processing/p5.js-web-editor/assets/80570105/e6c7d48b-d48d-4850-9ae0-c09c0bea2e63)



I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number.
