### PR TITLE
[WIP] Add aria attributes to menus

### DIFF
--- a/client/components/Dropdown/DropdownMenu.jsx
+++ b/client/components/Dropdown/DropdownMenu.jsx
@@ -38,7 +38,7 @@ const DropdownMenu = forwardRef(
     };
 
     return (
-      <div ref={anchorRef} className={className}>
+      <div ref={anchorRef} className={className} aria-haspopup="menu">
         <button
           className={classes.button}
           aria-label={ariaLabel}
@@ -51,6 +51,7 @@ const DropdownMenu = forwardRef(
         </button>
         {isOpen && (
           <DropdownWrapper
+            role="menu"
             className={classes.list}
             align={align}
             onMouseUp={() => {

--- a/client/components/Dropdown/MenuItem.jsx
+++ b/client/components/Dropdown/MenuItem.jsx
@@ -10,7 +10,7 @@ function MenuItem({ hideIf, ...rest }) {
   }
 
   return (
-    <li>
+    <li role="menuitem">
       <ButtonOrLink {...rest} />
     </li>
   );

--- a/client/components/Nav/NavBar.jsx
+++ b/client/components/Nav/NavBar.jsx
@@ -69,7 +69,7 @@ function NavBar({ children, className }) {
   return (
     <NavBarContext.Provider value={contextValue}>
       <header>
-        <nav className={className} ref={nodeRef}>
+        <nav className={className} ref={nodeRef} role="menubar">
           <MenuOpenContext.Provider value={dropdownOpen}>
             {children}
           </MenuOpenContext.Provider>

--- a/client/components/Nav/NavDropdownMenu.jsx
+++ b/client/components/Nav/NavDropdownMenu.jsx
@@ -23,7 +23,11 @@ function NavDropdownMenu({ id, title, children }) {
   const { isOpen, handlers } = useMenuProps(id);
 
   return (
-    <li className={classNames('nav__item', isOpen && 'nav__item--open')}>
+    <li
+      role="menuitem"
+      className={classNames('nav__item', isOpen && 'nav__item--open')}
+      aria-haspopup="menu"
+    >
       <button {...handlers}>
         <span className="nav__item-header">{title}</span>
         <TriangleIcon
@@ -32,7 +36,7 @@ function NavDropdownMenu({ id, title, children }) {
           aria-hidden="true"
         />
       </button>
-      <ul className="nav__dropdown">
+      <ul className="nav__dropdown" role="menu">
         <ParentMenuContext.Provider value={id}>
           {children}
         </ParentMenuContext.Provider>

--- a/client/components/Nav/NavMenuItem.jsx
+++ b/client/components/Nav/NavMenuItem.jsx
@@ -18,7 +18,7 @@ function NavMenuItem({ hideIf, className, ...rest }) {
   }
 
   return (
-    <li className={className}>
+    <li className={className} role="menuitem">
       <ButtonOrLink {...rest} {...handlers} />
     </li>
   );


### PR DESCRIPTION
Ref https://github.com/processing/p5.js-web-editor/issues/2933#issuecomment-1904848578

Changes:
- Add `role="menu"` and `role="menuitem"` to dropdown menus
- Add `role="menubar"` and `role="menuitem"` to header nav bar
- Add `aria-haspopup="menu"` to dropdown anchors

Pending:
- Validate that the markup is correct
- Investigate using `role="group"` for the left and right portions of the nav bar
- Add `role="menuitem"` to nav bar items which do not have dropdowns (login and sign up)
- Figure out the proper way to keep the `"navigation"` role on the nav while also having a `"menubar"` role
- Use `aria-expanded` to indicate if the dropdown is open or closed

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
