### PR TITLE
Added 'New Password confirmation' when updating account

### DIFF
--- a/client/modules/User/components/AccountForm.jsx
+++ b/client/modules/User/components/AccountForm.jsx
@@ -168,6 +168,26 @@ function AccountForm() {
               </p>
             )}
           </Field>
+          <Field name="confirmNewPassword">
+            {(field) => (
+              <p className="form__field">
+                <label htmlFor="confirm new password" className="form__label">
+                  {t('AccountForm.ConfirmNewPassword')}
+                </label>
+                <input
+                  className="form__input"
+                  aria-label={t('AccountForm.ConfirmNewPasswordARIA')}
+                  type="password"
+                  id="confirmNewPassword"
+                  autoComplete="confirm-new-password"
+                  {...field.input}
+                />
+                {field.meta.touched && field.meta.error && (
+                  <span className="form-error">{field.meta.error}</span>
+                )}
+              </p>
+            )}
+          </Field>
           <Button type="submit" disabled={submitting || invalid}>
             {t('AccountForm.SubmitSaveAllSettings')}
           </Button>

--- a/client/utils/reduxFormUtils.js
+++ b/client/utils/reduxFormUtils.js
@@ -51,6 +51,11 @@ export function validateSettings(formProps) {
   if (formProps.newPassword && formProps.newPassword.length < 6) {
     errors.newPassword = i18n.t('ReduxFormUtils.errorShortPassword');
   }
+  if (formProps.newPassword !== formProps.confirmNewPassword) {
+    errors.confirmNewPassword = i18n.t(
+      'ReduxFormUtils.errorNewPasswordConfirm'
+    );
+  }
   return errors;
 }
 

--- a/translations/locales/be/translations.json
+++ b/translations/locales/be/translations.json
@@ -306,7 +306,8 @@
     "CurrentPasswordARIA": "বর্তমান পাসওয়ার্ড",
     "NewPassword": "নতুন পাসওয়ার্ড",
     "NewPasswordARIA": "নতুন পাসওয়ার্ড",
-    "SubmitSaveAllSettings": "সমস্ত সেটিংস সংরক্ষণ করুন"
+    "SubmitSaveAllSettings": "সমস্ত সেটিংস সংরক্ষণ করুন",
+    "ConfirmNewPassword": "নিশ্চিত কর নতুন গোপননম্বর"
   },
   "AccountView": {
     "SocialLogin": "সোশ্যাল লগইন",

--- a/translations/locales/de/translations.json
+++ b/translations/locales/de/translations.json
@@ -297,7 +297,8 @@
     "CurrentPasswordARIA": "aktuelles passwort",
     "NewPassword": "Neues Passwort",
     "NewPasswordARIA": "neues passwort",
-    "SubmitSaveAllSettings": "Alle Einstellungen speichern"
+    "SubmitSaveAllSettings": "Alle Einstellungen speichern",
+    "ConfirmNewPassword": "Bevestig nieuw wachtwoord"
   },
   "AccountView": {
     "SocialLogin": "Social Login",

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -289,7 +289,8 @@
     "errorNewPassword": "Please enter a new password or leave the current password empty.",
     "errorEmptyUsername": "Please enter a username.",
     "errorLongUsername": "Username must be less than 20 characters.",
-    "errorValidUsername": "Username must only consist of numbers, letters, periods, dashes, and underscores."
+    "errorValidUsername": "Username must only consist of numbers, letters, periods, dashes, and underscores.",
+    "errorNewPasswordConfirm": "The password comfirmation does not match."
   },
   "NewPasswordView": {
     "Title": "p5.js Web Editor | New Password",
@@ -311,7 +312,8 @@
     "CurrentPasswordARIA": "Current Password",
     "NewPassword": "New Password",
     "NewPasswordARIA": "New Password",
-    "SubmitSaveAllSettings": "Save All Settings"
+    "SubmitSaveAllSettings": "Save All Settings",
+    "ConfirmNewPassword": "Confirm New Password"
   },
   "AccountView": {
     "SocialLogin": "Social Login",

--- a/translations/locales/es-419/translations.json
+++ b/translations/locales/es-419/translations.json
@@ -297,7 +297,8 @@
     "CurrentPasswordARIA": "Contraseña Actual",
     "NewPassword": "Nueva Contraseña",
     "NewPasswordARIA": "Nueva Contraseña",
-    "SubmitSaveAllSettings": "Guardar Todas Las Configuraciones"
+    "SubmitSaveAllSettings": "Guardar Todas Las Configuraciones",
+    "ConfirmNewPassword": "Confirmar nueva contraseña"
   },
   "AccountView": {
     "SocialLogin": "Identificacion usando redes sociales",

--- a/translations/locales/fr-CA/translations.json
+++ b/translations/locales/fr-CA/translations.json
@@ -300,7 +300,8 @@
       "CurrentPasswordARIA": "Mot de passe actuel",
       "NewPassword": "Nouveau mot de passe",
       "NewPasswordARIA": "Nouveau mot de passe",
-      "SubmitSaveAllSettings": "Sauvegarder tous les paramrètres"
+      "SubmitSaveAllSettings": "Sauvegarder tous les paramrètres",
+      "ConfirmNewPassword": "Confirmer le nouveau mot de passe"
     },
     "AccountView": {
       "SocialLogin": "Identification à l'aide des réseaux sociaux",

--- a/translations/locales/hi/translations.json
+++ b/translations/locales/hi/translations.json
@@ -312,7 +312,8 @@
       "CurrentPasswordARIA": "वर्तमान पासवर्ड",
       "NewPassword": "नया पासवर्ड",
       "NewPasswordARIA": "नया पासवर्ड",
-      "SubmitSaveAllSettings": "सभी सेटिंग्स सेव करें"
+      "SubmitSaveAllSettings": "सभी सेटिंग्स सेव करें",
+      "ConfirmNewPassword": "नए पासवर्ड की पुष्टि करें"
     },
     "AccountView": {
       "SocialLogin": "सामाजिक लॉग इन",

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -303,7 +303,8 @@
     "CurrentPasswordARIA": "Password attuale",
     "NewPassword": "Nuova Password",
     "NewPasswordARIA": "Nuova Password",
-    "SubmitSaveAllSettings": "Salva tutte le impostazioni"
+    "SubmitSaveAllSettings": "Salva tutte le impostazioni",
+    "ConfirmNewPassword": "Conferma la nuova password"
   },
   "AccountView": {
     "SocialLogin": "Accesso ai social",

--- a/translations/locales/ja/translations.json
+++ b/translations/locales/ja/translations.json
@@ -297,7 +297,8 @@
       "CurrentPasswordARIA": "現在のパスワード",
       "NewPassword": "新しいパスワード",
       "NewPasswordARIA": "新しいパスワード",
-      "SubmitSaveAllSettings": "すべての設定を保存"
+      "SubmitSaveAllSettings": "すべての設定を保存",
+      "ConfirmNewPassword": "新しいパスワードを確認"
     },
     "AccountView": {
       "SocialLogin": "ソーシャルログイン",


### PR DESCRIPTION
Fixes #2975 

Changes:

Added a `new password confirmation` field when the user resets his password form `/account`

https://github.com/processing/p5.js-web-editor/assets/91189139/2d8c794b-ae13-4db4-8db2-21e722770631


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #2975`
