### PR TITLE
Refactor createRedirectWithUsername

### DIFF
--- a/client/components/createRedirectWithUsername.jsx
+++ b/client/components/createRedirectWithUsername.jsx
@@ -1,29 +1,23 @@
-import React from 'react';
-import { connect } from 'react-redux';
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
 import browserHistory from '../browserHistory';
 
-const RedirectToUser = ({ username, url = '/:username/sketches' }) => {
-  React.useEffect(() => {
+const RedirectToUser = ({ url = '/:username/sketches' }) => {
+  const username = useSelector((state) =>
+    state.user ? state.user.username : null
+  );
+  useEffect(() => {
     if (username == null) {
       return;
     }
-
     browserHistory.replace(url.replace(':username', username));
-  }, [username]);
-
+  }, [username, url]);
   return null;
 };
 
-function mapStateToProps(state) {
-  return {
-    username: state.user ? state.user.username : null
-  };
-}
+RedirectToUser.propTypes = {
+  url: PropTypes.string.isRequired
+};
 
-const ConnectedRedirectToUser = connect(mapStateToProps)(RedirectToUser);
-
-const createRedirectWithUsername = (url) => (props) => (
-  <ConnectedRedirectToUser {...props} url={url} />
-);
-
-export default createRedirectWithUsername;
+export default RedirectToUser;

--- a/client/routes.jsx
+++ b/client/routes.jsx
@@ -17,7 +17,7 @@ import NewPasswordView from './modules/User/pages/NewPasswordView';
 import AccountView from './modules/User/pages/AccountView';
 import CollectionView from './modules/User/pages/CollectionView';
 import DashboardView from './modules/User/pages/DashboardView';
-import createRedirectWithUsername from './components/createRedirectWithUsername';
+import RedirectToUser from './components/createRedirectWithUsername';
 import { getUser } from './modules/User/actions';
 import {
   userIsAuthenticated,
@@ -84,11 +84,11 @@ const routes = (
 
     <Route
       path="/sketches"
-      component={createRedirectWithUsername('/:username/sketches')}
+      component={() => <RedirectToUser url="/:username/sketches" />}
     />
     <Route
       path="/assets"
-      component={createRedirectWithUsername('/:username/assets')}
+      component={() => <RedirectToUser url="/:username/assets" />}
     />
     <Route path="/account" component={userIsAuthenticated(AccountView)} />
     <Route path="/about" component={IDEView} />


### PR DESCRIPTION
Progress on #2042 

Changes:
- Used `useSelector` instead of `connect` to handle the state access.
- Removed the `mapStateToProps` function as no longer needed.
- The `createRedirectWithUsername` function is removed as the URL is directly passed as a prop to `RedirectToUser` .
- Replace `createRedirectWithUsername` with `RedirectToUser` in routing.
- Added Proptypes.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
