### PR TITLE
Enhance mobile collection share dropdown

### DIFF
--- a/client/styles/components/_collection.scss
+++ b/client/styles/components/_collection.scss
@@ -106,6 +106,11 @@
   @extend %dropdown-open-right;
   padding: #{math.div(20, $base-font-size)}rem;
   width: #{math.div(350, $base-font-size)}rem;
+
+  @media (max-width: 450px) {
+    right: 45%;
+    transform: translateX(50%);
+  }
 }
 
 .collection-content {


### PR DESCRIPTION
Fixes https://github.com/processing/p5.js-web-editor/issues/2624
![WhatsApp Image 2024-02-08 at 00 32 15](https://github.com/processing/p5.js-web-editor/assets/97019230/521c13ad-04fc-42bf-9050-7b62ae99ddec)

Fixes:
Enhanced the responsiveness of the Collection Share Dropdown


Changes:
- Added `@media`

After the Changes:
<img width="143" alt="image" src="https://github.com/processing/p5.js-web-editor/assets/97019230/224b3578-1233-4559-9d4f-0a3a76dd6077">


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number
