### PR TITLE
Updated passport handles expected errors as exceptions

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -13,6 +13,9 @@ import User from '../models/user';
 const accountSuspensionMessage =
   'Account has been suspended. Please contact privacy@p5js.org if you believe this is an error.';
 
+const accountLinkingErrorMessage =
+  'Account is already linked to another account.';
+
 function generateUniqueUsername(username) {
   const adj =
     friendlyWords.predicates[
@@ -121,18 +124,17 @@ passport.use(
     },
     (req, accessToken, refreshToken, profile, done) => {
       User.findOne({ github: profile.id }, (findByGithubErr, existingUser) => {
-       if (existingUser) {
+        if (existingUser) {
           if (req.user && req.user.email !== existingUser.email) {
-            done(null, false, { msg: 'GitHub account is already linked to another account.' });
+            done(null, false, { msg: accountLinkingErrorMessage });
             return;
           } else if (existingUser.banned) {
             done(null, false, { msg: accountSuspensionMessage });
             return;
           }
           done(null, existingUser);
-          return;          
+          return;
         }
-
         const emails = getVerifiedEmails(profile.emails);
         const primaryEmail = getPrimaryEmail(profile.emails);
 
@@ -157,7 +159,7 @@ passport.use(
                 [existingEmailUser] = existingEmailUsers;
               }
               if (existingEmailUser.banned) {
-                done(null,false, {msg:accountSuspensionMessage});
+                done(null, false, { msg: accountSuspensionMessage });
                 return;
               }
               existingEmailUser.email = existingEmailUser.email || primaryEmail;
@@ -216,10 +218,10 @@ passport.use(
         (findByGoogleErr, existingUser) => {
           if (existingUser) {
             if (req.user && req.user.email !== existingUser.email) {
-              done(null,false,{msg:'Google account is already linked to another account.'});
+              done(null, false, { msg: accountLinkingErrorMessage });
               return;
             } else if (existingUser.banned) {
-              done(null,false,{msg:accountSuspensionMessage});
+              done(null, false, { msg: accountSuspensionMessage });
               return;
             }
             done(null, existingUser);
@@ -250,7 +252,7 @@ passport.use(
                     // then, append a random friendly word?
                     if (existingEmailUser) {
                       if (existingEmailUser.banned) {
-                        done(null,false,{msg:accountSuspensionMessage});
+                        done(null, false, { msg: accountSuspensionMessage });
                         return;
                       }
                       existingEmailUser.email =

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -121,18 +121,16 @@ passport.use(
     },
     (req, accessToken, refreshToken, profile, done) => {
       User.findOne({ github: profile.id }, (findByGithubErr, existingUser) => {
-        if (existingUser) {
+       if (existingUser) {
           if (req.user && req.user.email !== existingUser.email) {
-            done(
-              new Error('GitHub account is already linked to another account.')
-            );
+            done(null, false, { msg: 'GitHub account is already linked to another account.' });
             return;
           } else if (existingUser.banned) {
-            done(new Error(accountSuspensionMessage));
+            done(null, false, { msg: accountSuspensionMessage });
             return;
           }
           done(null, existingUser);
-          return;
+          return;          
         }
 
         const emails = getVerifiedEmails(profile.emails);
@@ -159,7 +157,7 @@ passport.use(
                 [existingEmailUser] = existingEmailUsers;
               }
               if (existingEmailUser.banned) {
-                done(new Error(accountSuspensionMessage));
+                done(null,false, {msg:accountSuspensionMessage});
                 return;
               }
               existingEmailUser.email = existingEmailUser.email || primaryEmail;
@@ -218,14 +216,10 @@ passport.use(
         (findByGoogleErr, existingUser) => {
           if (existingUser) {
             if (req.user && req.user.email !== existingUser.email) {
-              done(
-                new Error(
-                  'Google account is already linked to another account.'
-                )
-              );
+              done(null,false,{msg:'Google account is already linked to another account.'});
               return;
             } else if (existingUser.banned) {
-              done(new Error(accountSuspensionMessage));
+              done(null,false,{msg:accountSuspensionMessage});
               return;
             }
             done(null, existingUser);
@@ -256,7 +250,7 @@ passport.use(
                     // then, append a random friendly word?
                     if (existingEmailUser) {
                       if (existingEmailUser.banned) {
-                        done(new Error(accountSuspensionMessage));
+                        done(null,false,{msg:accountSuspensionMessage});
                         return;
                       }
                       existingEmailUser.email =


### PR DESCRIPTION
Added error messages in the third argument of the done callback instead of the first argument in Google and Github sign in features

Fixes #issue-number

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
