### PR TITLE
Fixed Passport handles expected errors as exceptions

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -123,12 +123,12 @@ passport.use(
       User.findOne({ github: profile.id }, (findByGithubErr, existingUser) => {
         if (existingUser) {
           if (req.user && req.user.email !== existingUser.email) {
-            done(
-              new Error('GitHub account is already linked to another account.')
-            );
+            done(null, false, {
+              msg: 'GitHub account is already linked to another account.'
+            });
             return;
           } else if (existingUser.banned) {
-            done(new Error(accountSuspensionMessage));
+            done(null, false, { msg: accountSuspensionMessage });
             return;
           }
           done(null, existingUser);
@@ -159,7 +159,7 @@ passport.use(
                 [existingEmailUser] = existingEmailUsers;
               }
               if (existingEmailUser.banned) {
-                done(new Error(accountSuspensionMessage));
+                done(null, false, { msg: accountSuspensionMessage });
                 return;
               }
               existingEmailUser.email = existingEmailUser.email || primaryEmail;
@@ -218,14 +218,12 @@ passport.use(
         (findByGoogleErr, existingUser) => {
           if (existingUser) {
             if (req.user && req.user.email !== existingUser.email) {
-              done(
-                new Error(
-                  'Google account is already linked to another account.'
-                )
-              );
+              done(null, false, {
+                msg: 'Google account is already linked to another account.'
+              });
               return;
             } else if (existingUser.banned) {
-              done(new Error(accountSuspensionMessage));
+              done(null, false, { msg: accountSuspensionMessage });
               return;
             }
             done(null, existingUser);
@@ -256,7 +254,7 @@ passport.use(
                     // then, append a random friendly word?
                     if (existingEmailUser) {
                       if (existingEmailUser.banned) {
-                        done(new Error(accountSuspensionMessage));
+                        done(null, false, { msg: accountSuspensionMessage });
                         return;
                       }
                       existingEmailUser.email =

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -123,12 +123,10 @@ passport.use(
       User.findOne({ github: profile.id }, (findByGithubErr, existingUser) => {
         if (existingUser) {
           if (req.user && req.user.email !== existingUser.email) {
-            done(
-              new Error('GitHub account is already linked to another account.')
-            );
+            done(null, false, { msg: 'GitHub account is already linked to another account.' });
             return;
           } else if (existingUser.banned) {
-            done(new Error(accountSuspensionMessage));
+            done(null, false, { msg: accountSuspensionMessage });
             return;
           }
           done(null, existingUser);
@@ -159,7 +157,7 @@ passport.use(
                 [existingEmailUser] = existingEmailUsers;
               }
               if (existingEmailUser.banned) {
-                done(new Error(accountSuspensionMessage));
+                done(null, false, { msg: accountSuspensionMessage });
                 return;
               }
               existingEmailUser.email = existingEmailUser.email || primaryEmail;
@@ -218,14 +216,10 @@ passport.use(
         (findByGoogleErr, existingUser) => {
           if (existingUser) {
             if (req.user && req.user.email !== existingUser.email) {
-              done(
-                new Error(
-                  'Google account is already linked to another account.'
-                )
-              );
+              done(null, false, { msg: 'Google account is already linked to another account.' });
               return;
             } else if (existingUser.banned) {
-              done(new Error(accountSuspensionMessage));
+              done(null, false, { msg: accountSuspensionMessage });
               return;
             }
             done(null, existingUser);
@@ -256,7 +250,7 @@ passport.use(
                     // then, append a random friendly word?
                     if (existingEmailUser) {
                       if (existingEmailUser.banned) {
-                        done(new Error(accountSuspensionMessage));
+                        done(null, false, { msg: accountSuspensionMessage });
                         return;
                       }
                       existingEmailUser.email =


### PR DESCRIPTION
# Fix account suspension handling in authentication strategies
Fixes #3044 

## Changes

- Addressed the issue regarding the handling of account suspension messages in the authentication strategies, specifically for GitHub and Google authentication.

## Checklist

- [x] No linting errors (`npm run lint`)
- [x] No test errors (`npm run test`)
- [x] Created from a uniquely-named feature branch (`fix-account-suspension-handling`) and is up to date with the `develop` branch.
- [x] Descriptively named and links to the corresponding issue number, i.e., `Fixes #3044`

## Additional Details

Ensured that when a user is banned, the authentication process fails gracefully with an appropriate account suspension message. This enhances the security and user experience of the authentication flow.

This pull request aims to improve the reliability and security of the application by providing clear feedback to users with suspended accounts during the authentication process.
