### PR TITLE
issues#3043| Adding Shortcut key for Creating new File, Creating new …

### DIFF
--- a/client/common/useKeyDownHandlers.js
+++ b/client/common/useKeyDownHandlers.js
@@ -32,8 +32,13 @@ export default function useKeyDownHandlers(keyHandlers) {
     if (!e.key) return;
     const isMac = navigator.userAgent.toLowerCase().indexOf('mac') !== -1;
     const isCtrl = isMac ? e.metaKey : e.ctrlKey;
+
     if (e.shiftKey && isCtrl) {
       handlers.current[`ctrl-shift-${e.key.toLowerCase()}`]?.(e);
+    } else if (e.altKey && e.shiftKey) {
+      handlers.current[`alt-shift-${e.key.toLowerCase()}`]?.(e);
+    } else if (e.altKey) {
+      handlers.current[`alt-${e.key.toLowerCase()}`]?.(e);
     } else if (isCtrl) {
       handlers.current[`ctrl-${e.key.toLowerCase()}`]?.(e);
     }

--- a/client/modules/IDE/components/IDEKeyHandlers.jsx
+++ b/client/modules/IDE/components/IDEKeyHandlers.jsx
@@ -2,10 +2,13 @@ import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { updateFileContent } from '../actions/files';
 import {
+  closeProjectOptions,
   collapseConsole,
   collapseSidebar,
   expandConsole,
   expandSidebar,
+  newFile,
+  newFolder,
   showErrorModal,
   startSketch,
   stopSketch
@@ -18,12 +21,14 @@ import {
   getIsUserOwner,
   getSketchOwner
 } from '../selectors/users';
+import { selectRootFile } from '../selectors/files';
 
 export const useIDEKeyHandlers = ({ getContent }) => {
   const dispatch = useDispatch();
 
   const sidebarIsExpanded = useSelector((state) => state.ide.sidebarIsExpanded);
   const consoleIsExpanded = useSelector((state) => state.ide.consoleIsExpanded);
+  const rootFile = useSelector(selectRootFile);
 
   const isUserOwner = useSelector(getIsUserOwner);
   const isAuthenticated = useSelector(getAuthenticated);
@@ -75,6 +80,18 @@ export const useIDEKeyHandlers = ({ getContent }) => {
     'ctrl-`': (e) => {
       e.preventDefault();
       dispatch(consoleIsExpanded ? collapseConsole() : expandConsole());
+    },
+    'alt-n': (e) => {
+      e.preventDefault();
+      // For Creating new Files
+      dispatch(newFile(rootFile.id));
+      setTimeout(() => dispatch(closeProjectOptions()), 0);
+    },
+    'alt-shift-n': (e) => {
+      e.preventDefault();
+      // For Creating new Folder
+      dispatch(newFolder(rootFile.id));
+      setTimeout(() => dispatch(closeProjectOptions()), 0);
     }
   });
 };


### PR DESCRIPTION
…Folder

Fixes #3043 

Currently, I've added shortcuts for:

- Adding a file: `Alt + N`
- Adding a folder: `Shift + Alt + N`

To implement the other two, I require further clarification on:

- Opening a new file
- Opening my sketches

https://github.com/processing/p5.js-web-editor/assets/68202064/5bcf1ce0-754b-4d5d-a4e4-d0e60cf7dd8e

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
