### PR TITLE
Allow using LDAP for user login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,8 @@ SESSION_SECRET=whatever_you_want_this_to_be_it_only_matters_for_production
 TRANSLATIONS_ENABLED=true
 UI_ACCESS_TOKEN_ENABLED=false
 UPLOAD_LIMIT=250000000
+USE_LDAP=false
+LDAP_URL=ldap://localhost:3890
+LDAP_BIND_DN=uid=test,ou=people,dc=example,dc=com
+LDAP_BIND_CREDENTIALS=testpassword
+LDAP_USER_SEARCH_BASE=ou=people,dc=example,dc=com

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
         "passport-github2": "^0.1.12",
         "passport-google-oauth20": "^1.0.0",
         "passport-http": "^0.3.0",
+        "passport-ldapauth": "^3.0.1",
         "passport-local": "^1.0.0",
         "prettier": "2.2.1",
         "pretty-bytes": "^3.0.1",
@@ -17608,6 +17609,14 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
+    "node_modules/@types/ldapjs": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@types/ldapjs/-/ldapjs-2.2.5.tgz",
+      "integrity": "sha512-Lv/nD6QDCmcT+V1vaTRnEKE8UgOilVv5pHcQuzkU1LcRe4mbHHuUo/KHi0LKrpdHhQY8FJzryF38fcVdeUIrzg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/lodash": {
       "version": "4.14.199",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
@@ -18260,6 +18269,11 @@
       "engines": {
         "node": ">=6.5"
       }
+    },
+    "node_modules/abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "node_modules/accepts": {
       "version": "1.3.8",
@@ -19753,6 +19767,17 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
+      "dependencies": {
+        "precond": "0.2"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/bail": {
@@ -34120,6 +34145,57 @@
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
+    "node_modules/ldap-filter": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.3.3.tgz",
+      "integrity": "sha512-/tFkx5WIn4HuO+6w9lsfxq4FN3O+fDZeO9Mek8dCD8rTUpqzRa766BOBO7BcGkn3X86m5+cBm1/2S/Shzz7gMg==",
+      "dependencies": {
+        "assert-plus": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/ldapauth-fork": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/ldapauth-fork/-/ldapauth-fork-5.0.5.tgz",
+      "integrity": "sha512-LWUk76+V4AOZbny/3HIPQtGPWZyA3SW2tRhsWIBi9imP22WJktKLHV1ofd8Jo/wY7Ve6vAT7FCI5mEn3blZTjw==",
+      "dependencies": {
+        "@types/ldapjs": "^2.2.2",
+        "bcryptjs": "^2.4.0",
+        "ldapjs": "^2.2.1",
+        "lru-cache": "^7.10.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/ldapauth-fork/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ldapjs": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-2.3.3.tgz",
+      "integrity": "sha512-75QiiLJV/PQqtpH+HGls44dXweviFwQ6SiIK27EqzKQ5jU/7UFrl2E5nLdQ3IYRBzJ/AVFJI66u0MZ0uofKYwg==",
+      "dependencies": {
+        "abstract-logging": "^2.0.0",
+        "asn1": "^0.2.4",
+        "assert-plus": "^1.0.0",
+        "backoff": "^2.5.0",
+        "ldap-filter": "^0.3.3",
+        "once": "^1.4.0",
+        "vasync": "^2.2.0",
+        "verror": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -37886,6 +37962,18 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/passport-ldapauth": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/passport-ldapauth/-/passport-ldapauth-3.0.1.tgz",
+      "integrity": "sha512-TRRx3BHi8GC8MfCT9wmghjde/EGeKjll7zqHRRfGRxXbLcaDce2OftbQrFG7/AWaeFhR6zpZHtBQ/IkINdLVjQ==",
+      "dependencies": {
+        "ldapauth-fork": "^5.0.1",
+        "passport-strategy": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
@@ -39500,6 +39588,14 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "node_modules/precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
@@ -58098,6 +58194,14 @@
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
       "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ=="
     },
+    "@types/ldapjs": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/@types/ldapjs/-/ldapjs-2.2.5.tgz",
+      "integrity": "sha512-Lv/nD6QDCmcT+V1vaTRnEKE8UgOilVv5pHcQuzkU1LcRe4mbHHuUo/KHi0LKrpdHhQY8FJzryF38fcVdeUIrzg==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/lodash": {
       "version": "4.14.199",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.199.tgz",
@@ -58682,6 +58786,11 @@
       "requires": {
         "event-target-shim": "^5.0.0"
       }
+    },
+    "abstract-logging": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
+      "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA=="
     },
     "accepts": {
       "version": "1.3.8",
@@ -59834,6 +59943,14 @@
       "requires": {
         "babel-plugin-jest-hoist": "^27.2.0",
         "babel-preset-current-node-syntax": "^1.0.0"
+      }
+    },
+    "backoff": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha512-wC5ihrnUXmR2douXmXLCe5O3zg3GKIyvRi/hi58a/XyRxVI+3/yM0PYueQOZXPXQ9pxBislYkw+sF9b7C/RuMA==",
+      "requires": {
+        "precond": "0.2"
       }
     },
     "bail": {
@@ -70655,6 +70772,47 @@
         }
       }
     },
+    "ldap-filter": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.3.3.tgz",
+      "integrity": "sha512-/tFkx5WIn4HuO+6w9lsfxq4FN3O+fDZeO9Mek8dCD8rTUpqzRa766BOBO7BcGkn3X86m5+cBm1/2S/Shzz7gMg==",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
+    },
+    "ldapauth-fork": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/ldapauth-fork/-/ldapauth-fork-5.0.5.tgz",
+      "integrity": "sha512-LWUk76+V4AOZbny/3HIPQtGPWZyA3SW2tRhsWIBi9imP22WJktKLHV1ofd8Jo/wY7Ve6vAT7FCI5mEn3blZTjw==",
+      "requires": {
+        "@types/ldapjs": "^2.2.2",
+        "bcryptjs": "^2.4.0",
+        "ldapjs": "^2.2.1",
+        "lru-cache": "^7.10.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "7.18.3",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+          "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA=="
+        }
+      }
+    },
+    "ldapjs": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-2.3.3.tgz",
+      "integrity": "sha512-75QiiLJV/PQqtpH+HGls44dXweviFwQ6SiIK27EqzKQ5jU/7UFrl2E5nLdQ3IYRBzJ/AVFJI66u0MZ0uofKYwg==",
+      "requires": {
+        "abstract-logging": "^2.0.0",
+        "asn1": "^0.2.4",
+        "assert-plus": "^1.0.0",
+        "backoff": "^2.5.0",
+        "ldap-filter": "^0.3.3",
+        "once": "^1.4.0",
+        "vasync": "^2.2.0",
+        "verror": "^1.8.1"
+      }
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -73630,6 +73788,15 @@
         "passport-strategy": "1.x.x"
       }
     },
+    "passport-ldapauth": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/passport-ldapauth/-/passport-ldapauth-3.0.1.tgz",
+      "integrity": "sha512-TRRx3BHi8GC8MfCT9wmghjde/EGeKjll7zqHRRfGRxXbLcaDce2OftbQrFG7/AWaeFhR6zpZHtBQ/IkINdLVjQ==",
+      "requires": {
+        "ldapauth-fork": "^5.0.1",
+        "passport-strategy": "^1.0.0"
+      }
+    },
     "passport-local": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/passport-local/-/passport-local-1.0.0.tgz",
@@ -74833,6 +75000,11 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
+    },
+    "precond": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha512-QCYG84SgGyGzqJ/vlMsxeXd/pgL/I94ixdNFyh1PusWmTCyVfPJjZ1K1jvHtsbfnXQs2TSkEP2fR7QiMZAnKFQ=="
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -78390,6 +78562,14 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "vasync": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/vasync/-/vasync-2.2.1.tgz",
+      "integrity": "sha512-Hq72JaTpcTFdWiNA4Y22Amej2GH3BFmBaKPPlDZ4/oC8HNn2ISHLkFrJU4Ds8R3jcUi7oo5Y9jcMHKjES+N9wQ==",
+      "requires": {
+        "verror": "1.10.0"
+      }
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
     "passport-google-oauth20": "^1.0.0",
     "passport-http": "^0.3.0",
     "passport-local": "^1.0.0",
+    "passport-ldapauth": "^3.0.1",
     "prettier": "2.2.1",
     "pretty-bytes": "^3.0.1",
     "primer-tooltips": "^1.5.11",

--- a/server/controllers/session.controller.js
+++ b/server/controllers/session.controller.js
@@ -2,8 +2,10 @@ import passport from 'passport';
 
 import { userResponse } from './user.controller';
 
+const useLdap = process.env.USE_LDAP === 'true';
+
 export function createSession(req, res, next) {
-  passport.authenticate('local', (err, user) => {
+  passport.authenticate(useLdap ? 'ldapauth' : 'local', (err, user) => {
     if (err) {
       next(err);
       return;


### PR DESCRIPTION
Changes: This PR adds a `USE_LDAP` environment variable which would replace the email-and-password authentication strategy with an LDAP server (using `passport-ldapauth`).

I have tested the PR with `lldap` by modifying the `docker-compose-development.yml` file to look like:
```yaml
# ...
services:
  # ...
  lldap:
    image: lldap/lldap:stable
    ports:
    - "17170:17170"
    - "3890:3890"
    environment:
    - LLDAP_LDAP_USER_PASS=test1234
  app:
    # ...
    environment:
      - MONGO_URL=mongodb://mongo:27017/p5js-web-editor
      - LDAP_URL=ldap://lldap:3890
      - USE_LDAP=true
```
(and subsequently logging into lldap at http://localhost:17170/ as `admin/test1234` and creating a new `test/testpassword` user for the editor (as configured in .env.example) and adding it to the `lldap_strict_readonly` group, and a `user/user@example.com/somepass` user for testing the login flow itself)

Currently, this PR does not disable changing one's password once logged in, either in the backend or frontend -- however, since passwords are handled by LDAP, such changes are completely ineffective. Likewise, this PR does not currently disable username+password signups, even though they no longer function when LDAP is enabled. Hence, I have marked it as a "draft" for the moment. Please let me know if you are interested in merging this feature, and I'll try to polish the leftover rough edges (:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [X] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123` -- does not have an issue, let me know if I should do this.
