### PR TITLE
Modify the REGEX to support .mtl file

### DIFF
--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -40,7 +40,8 @@ export const fileExtensionsArray = [
   'frag',
   'bin',
   'xml',
-  'stl'
+  'stl',
+  'mtl'
 ];
 
 export const mimeTypes = `image/*,audio/*,text/javascript,text/html,text/css,
@@ -68,8 +69,8 @@ export const STRING_REGEX = /(['"])((\\\1|.)*?)\1/gm;
 // these are files that have to be linked to with a blob url
 export const PLAINTEXT_FILE_REGEX = /.+\.(json|txt|csv|vert|frag|tsv|xml|stl)$/i;
 // these are files that users would want to edit as text (maybe svg should be here?)
-export const TEXT_FILE_REGEX = /.+\.(json|txt|csv|tsv|vert|frag|js|css|html|htm|jsx|xml|stl)$/i;
+export const TEXT_FILE_REGEX = /.+\.(json|txt|csv|tsv|vert|frag|js|css|html|htm|jsx|xml|stl|mtl)$/i;
 export const NOT_EXTERNAL_LINK_REGEX = /^(?!(http:\/\/|https:\/\/))/;
 export const EXTERNAL_LINK_REGEX = /^(http:\/\/|https:\/\/)/;
 
-export const CREATE_FILE_REGEX = /.+\.(json|txt|csv|tsv|js|css|frag|vert|xml|html|htm|stl)$/i;
+export const CREATE_FILE_REGEX = /.+\.(json|txt|csv|tsv|js|css|frag|vert|xml|html|htm|stl|mtl)$/i;


### PR DESCRIPTION
Fixes #3067
Review is requested.

Allowing .mtl file uploads in the p5.js Web Editor would ensure feature consistency between the editor and p5.js itself, reducing potential confusion for users.

I have verified that this pull request:

npm run lint passes
npm run test passes
