### PR TITLE
Address Undefined Arguments Error in comparePassword

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -162,7 +162,16 @@ userSchema.set('toJSON', {
 userSchema.methods.comparePassword = async function comparePassword(
   candidatePassword
 ) {
-  return bcrypt.compare(candidatePassword, this.password);
+  if (!this.password) {
+    throw new Error('No password is set for this user.');
+  }
+
+  try {
+    return await bcrypt.compare(candidatePassword, this.password);
+  } catch (error) {
+    console.error('Password comparison failed!', error);
+    return false;
+  }
 };
 
 /**


### PR DESCRIPTION
Addresses Server Log (pictured below) that identifies undefined arguments being passed to the `comparePassword()` method in the `user` model. 

<img width="802" alt="Screenshot 2024-04-23 at 2 27 16 PM" src="https://github.com/processing/p5.js-web-editor/assets/43053081/c4505bd2-bb5a-4b46-b3cb-1f9286b1527f">

Changes:
- Checks if `this.password` exists before calling `bcrypt.compare`
- Adds explicit try/catch and error messaging

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
