### PR TITLE
Only render change password fields if user signs up locally

### DIFF
--- a/client/modules/User/components/AccountForm.jsx
+++ b/client/modules/User/components/AccountForm.jsx
@@ -128,46 +128,50 @@ function AccountForm() {
               </p>
             )}
           </Field>
-          <Field name="currentPassword">
-            {(field) => (
-              <p className="form__field">
-                <label htmlFor="current password" className="form__label">
-                  {t('AccountForm.CurrentPassword')}
-                </label>
-                <input
-                  className="form__input"
-                  aria-label={t('AccountForm.CurrentPasswordARIA')}
-                  type="password"
-                  id="currentPassword"
-                  autoComplete="current-password"
-                  {...field.input}
-                />
-                {field.meta.touched && field.meta.error && (
-                  <span className="form-error">{field.meta.error}</span>
-                )}
-              </p>
-            )}
-          </Field>
-          <Field name="newPassword">
-            {(field) => (
-              <p className="form__field">
-                <label htmlFor="new password" className="form__label">
-                  {t('AccountForm.NewPassword')}
-                </label>
-                <input
-                  className="form__input"
-                  aria-label={t('AccountForm.NewPasswordARIA')}
-                  type="password"
-                  id="newPassword"
-                  autoComplete="new-password"
-                  {...field.input}
-                />
-                {field.meta.touched && field.meta.error && (
-                  <span className="form-error">{field.meta.error}</span>
-                )}
-              </p>
-            )}
-          </Field>
+          {user.github === undefined && user.google === undefined && (
+            <Field name="currentPassword">
+              {(field) => (
+                <p className="form__field">
+                  <label htmlFor="current password" className="form__label">
+                    {t('AccountForm.CurrentPassword')}
+                  </label>
+                  <input
+                    className="form__input"
+                    aria-label={t('AccountForm.CurrentPasswordARIA')}
+                    type="password"
+                    id="currentPassword"
+                    autoComplete="current-password"
+                    {...field.input}
+                  />
+                  {field.meta.touched && field.meta.error && (
+                    <span className="form-error">{field.meta.error}</span>
+                  )}
+                </p>
+              )}
+            </Field>
+          )}
+          {user.github === undefined && user.google === undefined && (
+            <Field name="newPassword">
+              {(field) => (
+                <p className="form__field">
+                  <label htmlFor="new password" className="form__label">
+                    {t('AccountForm.NewPassword')}
+                  </label>
+                  <input
+                    className="form__input"
+                    aria-label={t('AccountForm.NewPasswordARIA')}
+                    type="password"
+                    id="newPassword"
+                    autoComplete="new-password"
+                    {...field.input}
+                  />
+                  {field.meta.touched && field.meta.error && (
+                    <span className="form-error">{field.meta.error}</span>
+                  )}
+                </p>
+              )}
+            </Field>
+          )}
           <Button type="submit" disabled={submitting || invalid}>
             {t('AccountForm.SubmitSaveAllSettings')}
           </Button>


### PR DESCRIPTION
Addresses same issue with undefined arguments in `comparePassword()` method in the `user` model. 

Changes:
- Conditionally renders the "New Password" and "Current Password" form fields in the user settings if the user does not have any linked socials to their account. This can be a temporary fix. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
