### PR TITLE
Updates to earlier fixes to address outage logs

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -22,7 +22,11 @@ function generateUniqueUsername(username) {
 }
 
 passport.serializeUser((user, done) => {
-  done(null, user.id);
+  if (user) {
+    done(null, user.id);
+  } else {
+    done(new Error('User is not available for serialization.'));
+  }
 });
 
 passport.deserializeUser((id, done) => {

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -39,7 +39,7 @@ export function getObjectKey(url) {
   }
   return objectKey;
 }
-
+// TODO: callback should be removed
 export async function deleteObjectsFromS3(keyList, callback) {
   const objectsToDelete = keyList?.map((key) => ({ Key: key }));
 

--- a/server/controllers/project.controller/deleteProject.js
+++ b/server/controllers/project.controller/deleteProject.js
@@ -7,45 +7,42 @@ const ProjectDeletionError = createApplicationErrorClass(
   'ProjectDeletionError'
 );
 
-function deleteFilesFromS3(files) {
-  deleteObjectsFromS3(
-    files
-      .filter((file) => {
-        if (
-          file.url &&
+async function deleteFilesFromS3(files) {
+  const filteredFiles = files
+    .filter((file) => {
+      const isValidFile =
+        (file.url &&
           (file.url.includes(process.env.S3_BUCKET_URL_BASE) ||
-            file.url.includes(process.env.S3_BUCKET))
-        ) {
-          if (
-            !process.env.S3_DATE ||
-            (process.env.S3_DATE &&
-              isBefore(new Date(process.env.S3_DATE), new Date(file.createdAt)))
-          ) {
-            return true;
-          }
-        }
-        return false;
-      })
-      .map((file) => getObjectKey(file.url))
-  );
+            file.url.includes(process.env.S3_BUCKET)) &&
+          !process.env.S3_DATE) ||
+        (process.env.S3_DATE &&
+          isBefore(new Date(process.env.S3_DATE), new Date(file.createdAt)));
+
+      return isValidFile;
+    })
+    .map((file) => getObjectKey(file.url));
+
+  try {
+    await deleteObjectsFromS3(filteredFiles);
+  } catch (error) {
+    console.error('Failed to delete files from S3:', error);
+  }
 }
 
-export default function deleteProject(req, res) {
-  function sendFailure(error) {
+export default async function deleteProject(req, res) {
+  const sendFailure = (error) => {
     res.status(error.code).json({ message: error.message });
-  }
+  };
 
-  function sendProjectNotFound() {
-    sendFailure(
-      new ProjectDeletionError('Project with that id does not exist', {
-        code: 404
-      })
-    );
-  }
+  try {
+    const project = await Project.findById(req.params.project_id);
 
-  function handleProjectDeletion(project) {
-    if (project == null) {
-      sendProjectNotFound();
+    if (!project) {
+      sendFailure(
+        new ProjectDeletionError('Project with that id does not exist', {
+          code: 404
+        })
+      );
       return;
     }
 
@@ -59,19 +56,20 @@ export default function deleteProject(req, res) {
       return;
     }
 
-    deleteFilesFromS3(project.files);
+    try {
+      await deleteFilesFromS3(project.files);
+    } catch (error) {
+      sendFailure(
+        new ProjectDeletionError('Failed to delete associated project files.', {
+          code: 500
+        })
+      );
+      return;
+    }
 
-    project.remove((removeProjectError) => {
-      if (removeProjectError) {
-        sendProjectNotFound();
-        return;
-      }
-
-      res.status(200).end();
-    });
+    await project.remove();
+    res.status(200).end();
+  } catch (error) {
+    sendFailure(error);
   }
-
-  return Project.findById(req.params.project_id)
-    .then(handleProjectDeletion)
-    .catch(sendFailure);
 }

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -163,7 +163,6 @@ userSchema.methods.comparePassword = async function comparePassword(
   candidatePassword
 ) {
   if (!this.password) {
-    console.error('No password is set for this user.');
     return false;
   }
 

--- a/server/routes/passport.routes.js
+++ b/server/routes/passport.routes.js
@@ -3,15 +3,19 @@ import passport from 'passport';
 
 const router = new Router();
 
-router.get('/auth/github', passport.authenticate('github'));
-router.get('/auth/github/callback', (req, res, next) => {
+const authenticateOAuth = (service) => (req, res, next) => {
   passport.authenticate(
-    'github',
+    service,
     { failureRedirect: '/login' },
-    (err, user) => {
+    (err, user, info) => {
       if (err) {
         // use query string param to show error;
-        res.redirect('/account?error=github');
+        res.redirect(`/account?error=${service}`);
+        return;
+      }
+
+      if (!user) {
+        res.redirect(`/account?error=${service}NoUser`);
         return;
       }
 
@@ -24,29 +28,12 @@ router.get('/auth/github/callback', (req, res, next) => {
       });
     }
   )(req, res, next);
-});
+};
+
+router.get('/auth/github', passport.authenticate('github'));
+router.get('/auth/github/callback', authenticateOAuth('github'));
 
 router.get('/auth/google', passport.authenticate('google'));
-router.get('/auth/google/callback', (req, res, next) => {
-  passport.authenticate(
-    'google',
-    { failureRedirect: '/login' },
-    (err, user) => {
-      if (err) {
-        // use query string param to show error;
-        res.redirect('/account?error=google');
-        return;
-      }
-
-      req.logIn(user, (loginErr) => {
-        if (loginErr) {
-          next(loginErr);
-          return;
-        }
-        res.redirect('/');
-      });
-    }
-  )(req, res, next);
-});
+router.get('/auth/google/callback', authenticateOAuth('google'));
 
 export default router;

--- a/server/routes/passport.routes.js
+++ b/server/routes/passport.routes.js
@@ -4,30 +4,26 @@ import passport from 'passport';
 const router = new Router();
 
 const authenticateOAuth = (service) => (req, res, next) => {
-  passport.authenticate(
-    service,
-    { failureRedirect: '/login' },
-    (err, user, info) => {
-      if (err) {
-        // use query string param to show error;
-        res.redirect(`/account?error=${service}`);
-        return;
-      }
-
-      if (!user) {
-        res.redirect(`/account?error=${service}NoUser`);
-        return;
-      }
-
-      req.logIn(user, (loginErr) => {
-        if (loginErr) {
-          next(loginErr);
-          return;
-        }
-        res.redirect('/');
-      });
+  passport.authenticate(service, { failureRedirect: '/login' }, (err, user) => {
+    if (err) {
+      // use query string param to show error;
+      res.redirect(`/account?error=${service}`);
+      return;
     }
-  )(req, res, next);
+
+    if (!user) {
+      res.redirect(`/account?error=${service}NoUser`);
+      return;
+    }
+
+    req.logIn(user, (loginErr) => {
+      if (loginErr) {
+        next(loginErr);
+        return;
+      }
+      res.redirect('/');
+    });
+  })(req, res, next);
 };
 
 router.get('/auth/github', passport.authenticate('github'));


### PR DESCRIPTION
Progress towards #3096 

Changes:
- Explicitly returns error if no user data is present in `serializeUser()` in `server/config/passport.js`
- Updates to `async/await` syntax and adds more specified error messaging in `server/controllers/aws.controller.js` and `server/controllers/project.controller/deleteProject.js`
- Updates `server/controllers/project.controller/__test__/deleteProject.test.js` with changes to `deleteProject.js`
- Removes `console.error()` in ``server/models/user.js`. This scenario happens when a user who signed up via Google or Github attempts to login through email/password. A better way to handle this can be revisited. 
- Creates generic `authenticateOauth()` function to create route handlers for each login service and adds error handling when no user is present in `server/routes/passport.routes.js`

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
