### PR TITLE
Updates to MongoDB Connection and Kubernetes

### DIFF
--- a/kubernetes_app.yml
+++ b/kubernetes_app.yml
@@ -65,7 +65,7 @@ spec:
   selector:
     matchLabels:
       app: web-editor
-  replicas: 3
+  replicas: 4
   template:
     metadata:
       labels:
@@ -99,8 +99,8 @@ metadata:
   name: web-editor-node
   namespace: production
 spec:
-  maxReplicas: 6
-  minReplicas: 2
+  maxReplicas: 9
+  minReplicas: 3
   scaleTargetRef:
     apiVersion: extensions/v1beta1
     kind: Deployment

--- a/server/previewServer.js
+++ b/server/previewServer.js
@@ -15,12 +15,24 @@ const app = new Express();
 // This also works if you take out the mongoose connection
 // but i have no idea why
 const mongoConnectionString = process.env.MONGO_URL;
+
 // Connect to MongoDB
-mongoose.Promise = global.Promise;
-mongoose.connect(mongoConnectionString, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true
-});
+const connectToMongoDB = async () => {
+  try {
+    await mongoose.connect(mongoConnectionString, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      useCreateIndex: true,
+      useFindAndModify: false
+    });
+  } catch (error) {
+    console.error('Failed to connect to MongoDB: ', error);
+    process.exit(1);
+  }
+};
+
+connectToMongoDB();
+
 mongoose.set('useCreateIndex', true);
 mongoose.connection.on('error', () => {
   console.error(

--- a/server/server.js
+++ b/server/server.js
@@ -152,11 +152,22 @@ app.use('/', passportRoutes);
 require('./config/passport');
 
 // Connect to MongoDB
-mongoose.Promise = global.Promise;
-mongoose.connect(mongoConnectionString, {
-  useNewUrlParser: true,
-  useUnifiedTopology: true
-});
+const connectToMongoDB = async () => {
+  try {
+    await mongoose.connect(mongoConnectionString, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+      useCreateIndex: true,
+      useFindAndModify: false
+    });
+  } catch (error) {
+    console.error('Failed to connect to MongoDB: ', error);
+    process.exit(1);
+  }
+};
+
+connectToMongoDB();
+
 mongoose.set('useCreateIndex', true);
 mongoose.connection.on('error', () => {
   console.error(


### PR DESCRIPTION
Fixes #3096 

Changes:
- Updates connection to MongoDB to use async/await syntax in `server.js` and `previewServer.js`. Other files that use this connection should also eventually be updated. 
- Increases the number of replicas within `kubernetes_app.yml` to account for increased traffic. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
