### PR TITLE
Fix broken file name tabs in mobile

### DIFF
--- a/client/modules/IDE/components/Editor/MobileEditor.jsx
+++ b/client/modules/IDE/components/Editor/MobileEditor.jsx
@@ -19,6 +19,7 @@ export const EditorContainer = styled.div`
       padding: ${remSize(10)};
       font-weight: bold;
       ${prop('MobilePanel.default')}
+      background-color: ${prop('backgroundColor')}
     }
   }
 

--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -582,7 +582,7 @@ class Editor extends React.Component {
             </section>
           ) : (
             <EditorContainer expanded={this.props.isExpanded}>
-              <>
+              <div>
                 <IconButton
                   onClick={this.props.expandSidebar}
                   icon={FolderIcon}
@@ -591,7 +591,7 @@ class Editor extends React.Component {
                   {this.props.file.name}
                   <UnsavedChangesIndicator />
                 </span>
-              </>
+              </div>
               <section>
                 <EditorHolder
                   ref={(element) => {


### PR DESCRIPTION
Fixes #3157

Changes:
Specifying the React fragment as a `div` fixed the issue.
Also changed the tab's bg color so it looks like an active tab.

<img width="320" alt="Screenshot 2024-06-14 at 12 52 29 AM" src="https://github.com/processing/p5.js-web-editor/assets/43021463/49e867a4-20a5-4c30-9ff0-f5e8e672c1c1">


I have verified that this pull request:
* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
