### PR TITLE
FIX:Inputboxes are cut off on Login and Signup forms on smaller screens

### DIFF
--- a/client/styles/components/_forms.scss
+++ b/client/styles/components/_forms.scss
@@ -71,6 +71,11 @@
     max-width: 100%;
     width: 100%;
   }
+
+  @media (max-width: 360px) {
+    min-width: 100%;
+    width: 100%;
+  }
 }
 
 .form__eye__icon {
@@ -79,6 +84,10 @@
   top: 7px;
   right: -355px;
   margin-left: -40px;
+
+  @media (max-width: 360px) {
+    right: -200px;
+  }
 }
 
 


### PR DESCRIPTION
Fixes [#3158](https://github.com/processing/p5.js-web-editor/issues/3158)

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

https://github.com/processing/p5.js-web-editor/assets/45139653/e9ccfdd0-e1bc-4270-bf47-0316283a6fe7

Added some CSS styles in media queries to target smaller screens