### PR TITLE
Update Docker Configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.14.2 as base
+FROM node:16.14.2 AS base
 ENV APP_HOME=/usr/src/app \
   TERM=xterm
 RUN mkdir -p $APP_HOME
@@ -6,7 +6,7 @@ WORKDIR $APP_HOME
 EXPOSE 8000
 EXPOSE 8002
 
-FROM base as development
+FROM base AS development
 ENV NODE_ENV development
 COPY package.json package-lock.json ./
 RUN npm install
@@ -18,11 +18,11 @@ COPY translations/locales ./translations/locales
 COPY public ./public
 CMD ["npm", "start"]
 
-FROM development as build
+FROM development AS build
 ENV NODE_ENV production
 RUN npm run build
 
-FROM base as production
+FROM base AS production
 ENV NODE_ENV=production
 COPY package.json package-lock.json index.js ./
 RUN npm install --production

--- a/contributor_docs/installation.md
+++ b/contributor_docs/installation.md
@@ -50,6 +50,7 @@ Note that this takes up a significant amount of space on your machine. Make sure
 2. Install [Docker Desktop](https://www.docker.com/products/docker-desktop/)
 3. Clone this repository and cd into it
 4. `$ docker-compose -f docker-compose-development.yml build`
+   * Note: Depending on which version of Docker Compose you are using, the base command will be either `docker-compose` or `docker compose`. More information about it can be found in Docker Compose's documentation for their [V1 to V2 transition](https://github.com/docker/compose/tree/v1?tab=readme-ov-file#v1-vs-v2-transition-hourglass_flowing_sand). 
 5. `$ cp .env.example .env`
 6. (Optional) Update `.env` with necessary keys to enable certain app behaviors, i.e. add Github ID and Github Secret if you want to be able to log in with Github.
    * See the [GitHub API Configuration](#github-api-configuration) section for information on how to authenticate with Github.

--- a/docker-compose-development.yml
+++ b/docker-compose-development.yml
@@ -1,7 +1,6 @@
-version: '3.4'
 services:
   mongo:
-    image: mongo:4.4
+    image: mongo:5.0
     volumes:
       - dbdata:/data/db
   app:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,6 @@
-version: '3.4'
 services:
   mongo:
-    image: mongo:4.4
+    image: mongo:5.0
     volumes:
       - dbdata:/data/db
   app:

--- a/server/models/collection.js
+++ b/server/models/collection.js
@@ -48,7 +48,7 @@ collectionSchema.set('toJSON', {
 });
 
 collectionSchema.pre('save', function generateSlug(next) {
-  this.slug = slugify(this.name, { lower: true, strict: true });
+  this.slug = slugify(this.name, '_');
   next();
 });
 

--- a/server/models/project.js
+++ b/server/models/project.js
@@ -53,7 +53,7 @@ projectSchema.set('toJSON', {
 
 projectSchema.pre('save', function generateSlug(next) {
   if (!this.slug) {
-    this.slug = slugify(this.name, { lower: true, strict: true });
+    this.slug = slugify(this.name, '_');
   }
   next();
 });

--- a/server/scripts/examples.js
+++ b/server/scripts/examples.js
@@ -30,7 +30,7 @@ async function getCategories() {
   const categories = [];
   const options = {
     url:
-      'https://api.github.com/repos/processing/p5.js-website/contents/src/data/examples/en',
+      'https://api.github.com/repos/processing/p5.js-website-legacy/contents/src/data/examples/en',
     method: 'GET',
     headers: {
       ...headers,
@@ -205,7 +205,7 @@ async function addAssetsToProject(assets, response, project) {
         // for assets files that are not .vert or .frag extension
         project.files.push({
           name: assetName,
-          url: `https://cdn.jsdelivr.net/gh/processing/p5.js-website@main/src/data/examples/assets/${assetName}`,
+          url: `https://cdn.jsdelivr.net/gh/processing/p5.js-website-legacy@main/src/data/examples/assets/${assetName}`,
           id: fileID,
           _id: fileID,
           children: [],
@@ -223,7 +223,7 @@ async function addAssetsToProject(assets, response, project) {
 async function createProjectsInP5user(projectsInAllCategories) {
   const options = {
     url:
-      'https://api.github.com/repos/processing/p5.js-website/contents/src/data/examples/assets',
+      'https://api.github.com/repos/processing/p5.js-website-legacy/contents/src/data/examples/assets',
     method: 'GET',
     headers: {
       ...headers,
@@ -364,7 +364,7 @@ async function getp5User() {
   const categories = await getCategories();
   const sketchesInCategories = await getSketchesInCategories(categories);
   const sketchContent = await getSketchContent(sketchesInCategories);
-  const projectsInUser = createProjectsInP5user(sketchContent);
+  const projectsInUser = await createProjectsInP5user(sketchContent);
   return projectsInUser;
 }
 


### PR DESCRIPTION
Changes:
- Addresses deprecation warnings in `Dockerfile`
- Updates `Installation` doc with information regarding the base command transition for Docker Compose between v1 and v2. _Docker Compose v1 (`docker-compose`) -> v2 (`docker compose`)._ 
- Updates Mongo version from 4.4 -> 5.0 in Docker config files. 
- Reverts back how slugs are generated in Project and User models, which were causing a mismatch error. 
- Updates URL for retrieving p5 examples to temporarily point to the legacy p5 website. Will update once confirmed that they should point to examples on new website. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
