### PR TITLE
Adds menubar ARIA semantics to editor menu

### DIFF
--- a/client/components/Dropdown/DropdownMenu.jsx
+++ b/client/components/Dropdown/DropdownMenu.jsx
@@ -38,7 +38,7 @@ const DropdownMenu = forwardRef(
     };
 
     return (
-      <div ref={anchorRef} className={className}>
+      <div ref={anchorRef} className={className} aria-haspopup="menu">
         <button
           className={classes.button}
           aria-label={ariaLabel}
@@ -51,6 +51,7 @@ const DropdownMenu = forwardRef(
         </button>
         {isOpen && (
           <DropdownWrapper
+            role="menu"
             className={classes.list}
             align={align}
             onMouseUp={() => {

--- a/client/components/Dropdown/MenuItem.jsx
+++ b/client/components/Dropdown/MenuItem.jsx
@@ -10,7 +10,7 @@ function MenuItem({ hideIf, ...rest }) {
   }
 
   return (
-    <li>
+    <li role="menuitem">
       <ButtonOrLink {...rest} />
     </li>
   );

--- a/client/components/Nav/NavBar.jsx
+++ b/client/components/Nav/NavBar.jsx
@@ -69,7 +69,7 @@ function NavBar({ children, className }) {
   return (
     <NavBarContext.Provider value={contextValue}>
       <header>
-        <nav className={className} ref={nodeRef}>
+        <nav className={className} ref={nodeRef} role="menubar">
           <MenuOpenContext.Provider value={dropdownOpen}>
             {children}
           </MenuOpenContext.Provider>

--- a/client/components/Nav/NavBar.jsx
+++ b/client/components/Nav/NavBar.jsx
@@ -69,11 +69,11 @@ function NavBar({ children, className }) {
   return (
     <NavBarContext.Provider value={contextValue}>
       <header>
-        <nav className={className} ref={nodeRef} role="menubar">
+        <div className={className} ref={nodeRef} role="menubar">
           <MenuOpenContext.Provider value={dropdownOpen}>
             {children}
           </MenuOpenContext.Provider>
-        </nav>
+        </div>
       </header>
     </NavBarContext.Provider>
   );

--- a/client/components/Nav/NavBar.jsx
+++ b/client/components/Nav/NavBar.jsx
@@ -69,7 +69,7 @@ function NavBar({ children, className }) {
   return (
     <NavBarContext.Provider value={contextValue}>
       <header>
-        <div className={className} ref={nodeRef} role="menubar">
+        <div className={className} ref={nodeRef}>
           <MenuOpenContext.Provider value={dropdownOpen}>
             {children}
           </MenuOpenContext.Provider>

--- a/client/components/Nav/NavDropdownMenu.jsx
+++ b/client/components/Nav/NavDropdownMenu.jsx
@@ -23,7 +23,11 @@ function NavDropdownMenu({ id, title, children }) {
   const { isOpen, handlers } = useMenuProps(id);
 
   return (
-    <li className={classNames('nav__item', isOpen && 'nav__item--open')}>
+    <li
+      role="menuitem"
+      className={classNames('nav__item', isOpen && 'nav__item--open')}
+      aria-haspopup="menu"
+    >
       <button {...handlers}>
         <span className="nav__item-header">{title}</span>
         <TriangleIcon
@@ -32,7 +36,7 @@ function NavDropdownMenu({ id, title, children }) {
           aria-hidden="true"
         />
       </button>
-      <ul className="nav__dropdown">
+      <ul className="nav__dropdown" role="menu">
         <ParentMenuContext.Provider value={id}>
           {children}
         </ParentMenuContext.Provider>

--- a/client/components/Nav/NavDropdownMenu.jsx
+++ b/client/components/Nav/NavDropdownMenu.jsx
@@ -23,12 +23,13 @@ function NavDropdownMenu({ id, title, children }) {
   const { isOpen, handlers } = useMenuProps(id);
 
   return (
-    <li
-      role="menuitem"
-      className={classNames('nav__item', isOpen && 'nav__item--open')}
-      aria-haspopup="menu"
-    >
-      <button {...handlers}>
+    <li className={classNames('nav__item', isOpen && 'nav__item--open')}>
+      <button
+        {...handlers}
+        role="menuitem"
+        aria-haspopup="menu"
+        aria-expanded={isOpen}
+      >
         <span className="nav__item-header">{title}</span>
         <TriangleIcon
           className="nav__item-header-triangle"

--- a/client/components/Nav/NavMenuItem.jsx
+++ b/client/components/Nav/NavMenuItem.jsx
@@ -18,7 +18,7 @@ function NavMenuItem({ hideIf, className, ...rest }) {
   }
 
   return (
-    <li className={className}>
+    <li className={className} role="menuitem">
       <ButtonOrLink {...rest} {...handlers} />
     </li>
   );

--- a/client/components/Nav/NavMenuItem.jsx
+++ b/client/components/Nav/NavMenuItem.jsx
@@ -18,8 +18,8 @@ function NavMenuItem({ hideIf, className, ...rest }) {
   }
 
   return (
-    <li className={className} role="menuitem">
-      <ButtonOrLink {...rest} {...handlers} />
+    <li className={className}>
+      <ButtonOrLink {...rest} {...handlers} role="menuitem" />
     </li>
   );
 }

--- a/client/index.integration.test.jsx
+++ b/client/index.integration.test.jsx
@@ -73,15 +73,15 @@ describe('index.jsx integration', () => {
   });
 
   it('navbar items and the dropdowns in the navbar exist', () => {
-    const navigation = screen.getByRole('navigation');
+    const navigation = screen.getByRole('menubar');
     expect(navigation).toBeInTheDocument();
 
-    const fileButton = within(navigation).getByRole('button', {
+    const fileButton = within(navigation).getByRole('menuitem', {
       name: /^file$/i
     });
     expect(fileButton).toBeInTheDocument();
 
-    const newFileButton = within(navigation).getByRole('button', {
+    const newFileButton = within(navigation).getByRole('menuitem', {
       name: /^new$/i
     });
     expect(newFileButton).toBeInTheDocument();
@@ -91,17 +91,17 @@ describe('index.jsx integration', () => {
     // const exampleFileButton = within(navigation).getByRole('link', {name: /^examples$/i});
     // expect(exampleFileButton).toBeInTheDocument();
 
-    const editButton = within(navigation).getByRole('button', {
+    const editButton = within(navigation).getByRole('menuitem', {
       name: /^edit$/i
     });
     expect(editButton).toBeInTheDocument();
 
-    const sketchButton = within(navigation).getByRole('button', {
+    const sketchButton = within(navigation).getByRole('menuitem', {
       name: /^sketch$/i
     });
     expect(sketchButton).toBeInTheDocument();
 
-    const helpButton = within(navigation).getByRole('button', {
+    const helpButton = within(navigation).getByRole('menuitem', {
       name: /^help$/i
     });
     expect(helpButton).toBeInTheDocument();

--- a/client/modules/IDE/components/Header/Nav.jsx
+++ b/client/modules/IDE/components/Header/Nav.jsx
@@ -135,7 +135,7 @@ const ProjectMenu = () => {
     metaKey === 'Ctrl' ? `${metaKeyName}+H` : `${metaKeyName}+⌥+F`;
 
   return (
-    <ul className="nav__items-left">
+    <ul className="nav__items-left" role="menubar">
       <li className="nav__item-logo">
         {user && user.username !== undefined ? (
           <Link to={userSketches}>

--- a/client/modules/IDE/components/Header/Nav.jsx
+++ b/client/modules/IDE/components/Header/Nav.jsx
@@ -272,10 +272,10 @@ const LanguageMenu = () => {
 const UnauthenticatedUserMenu = () => {
   const { t } = useTranslation();
   return (
-    <ul className="nav__items-right" title="user-menu">
+    <ul className="nav__items-right" title="user-menu" role="navigation">
       {getConfig('TRANSLATIONS_ENABLED') && <LanguageMenu />}
       <li className="nav__item">
-        <Link to="/login" className="nav__auth-button">
+        <Link to="/login" className="nav__auth-button" role="menuitem">
           <span className="nav__item-header" title="Login">
             {t('Nav.Login')}
           </span>
@@ -283,7 +283,7 @@ const UnauthenticatedUserMenu = () => {
       </li>
       <li className="nav__item-or">{t('Nav.LoginOr')}</li>
       <li className="nav__item">
-        <Link to="/signup" className="nav__auth-button">
+        <Link to="/signup" className="nav__auth-button" role="menuitem">
           <span className="nav__item-header" title="SignUp">
             {t('Nav.SignUp')}
           </span>
@@ -300,7 +300,7 @@ const AuthenticatedUserMenu = () => {
   const dispatch = useDispatch();
 
   return (
-    <ul className="nav__items-right" title="user-menu">
+    <ul className="nav__items-right" title="user-menu" role="navigation">
       {getConfig('TRANSLATIONS_ENABLED') && <LanguageMenu />}
       <NavDropdownMenu
         id="account"

--- a/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
+++ b/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
@@ -3,7 +3,7 @@
 exports[`Nav renders dashboard version for desktop 1`] = `
 <DocumentFragment>
   <header>
-    <nav
+    <div
       class="nav"
     >
       <ul
@@ -39,7 +39,7 @@ exports[`Nav renders dashboard version for desktop 1`] = `
           </a>
         </li>
       </ul>
-    </nav>
+    </div>
   </header>
 </DocumentFragment>
 `;
@@ -266,7 +266,7 @@ exports[`Nav renders dashboard version for mobile 1`] = `
 }
 
 <header>
-    <nav
+    <div
       class="c0"
     >
       <div
@@ -352,14 +352,18 @@ exports[`Nav renders dashboard version for mobile 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 New
               </button>
             </li>
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Save
               </button>
             </li>
@@ -368,6 +372,7 @@ exports[`Nav renders dashboard version for mobile 1`] = `
             >
               <a
                 href="/p5/sketches"
+                role="menuitem"
               >
                 Examples
               </a>
@@ -378,14 +383,18 @@ exports[`Nav renders dashboard version for mobile 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Tidy Code
               </button>
             </li>
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Find
               </button>
             </li>
@@ -395,14 +404,18 @@ exports[`Nav renders dashboard version for mobile 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Add File
               </button>
             </li>
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Add Folder
               </button>
             </li>
@@ -412,14 +425,18 @@ exports[`Nav renders dashboard version for mobile 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Preferences
               </button>
             </li>
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Language
               </button>
             </li>
@@ -429,7 +446,9 @@ exports[`Nav renders dashboard version for mobile 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Keyboard Shortcuts
               </button>
             </li>
@@ -439,6 +458,7 @@ exports[`Nav renders dashboard version for mobile 1`] = `
               <a
                 href="https://p5js.org/reference/"
                 rel="noopener noreferrer"
+                role="menuitem"
                 target="_blank"
               >
                 Reference
@@ -449,6 +469,7 @@ exports[`Nav renders dashboard version for mobile 1`] = `
             >
               <a
                 href="/about"
+                role="menuitem"
               >
                 About
               </a>
@@ -456,7 +477,7 @@ exports[`Nav renders dashboard version for mobile 1`] = `
           </ul>
         </div>
       </div>
-    </nav>
+    </div>
   </header>
 </DocumentFragment>
 `;
@@ -464,11 +485,12 @@ exports[`Nav renders dashboard version for mobile 1`] = `
 exports[`Nav renders editor version for desktop 1`] = `
 <DocumentFragment>
   <header>
-    <nav
+    <div
       class="nav"
     >
       <ul
         class="nav__items-left"
+        role="menubar"
       >
         <li
           class="nav__item-logo"
@@ -487,7 +509,11 @@ exports[`Nav renders editor version for desktop 1`] = `
         <li
           class="nav__item"
         >
-          <button>
+          <button
+            aria-expanded="false"
+            aria-haspopup="menu"
+            role="menuitem"
+          >
             <span
               class="nav__item-header"
             >
@@ -501,11 +527,14 @@ exports[`Nav renders editor version for desktop 1`] = `
           </button>
           <ul
             class="nav__dropdown"
+            role="menu"
           >
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 New
               </button>
             </li>
@@ -514,7 +543,11 @@ exports[`Nav renders editor version for desktop 1`] = `
         <li
           class="nav__item"
         >
-          <button>
+          <button
+            aria-expanded="false"
+            aria-haspopup="menu"
+            role="menuitem"
+          >
             <span
               class="nav__item-header"
             >
@@ -528,11 +561,14 @@ exports[`Nav renders editor version for desktop 1`] = `
           </button>
           <ul
             class="nav__dropdown"
+            role="menu"
           >
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Tidy Code
                 <span
                   class="nav__keyboard-shortcut"
@@ -544,7 +580,9 @@ exports[`Nav renders editor version for desktop 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Find
                 <span
                   class="nav__keyboard-shortcut"
@@ -556,7 +594,9 @@ exports[`Nav renders editor version for desktop 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Replace
                 <span
                   class="nav__keyboard-shortcut"
@@ -570,7 +610,11 @@ exports[`Nav renders editor version for desktop 1`] = `
         <li
           class="nav__item"
         >
-          <button>
+          <button
+            aria-expanded="false"
+            aria-haspopup="menu"
+            role="menuitem"
+          >
             <span
               class="nav__item-header"
             >
@@ -584,25 +628,32 @@ exports[`Nav renders editor version for desktop 1`] = `
           </button>
           <ul
             class="nav__dropdown"
+            role="menu"
           >
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Add File
               </button>
             </li>
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Add Folder
               </button>
             </li>
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Run
                 <span
                   class="nav__keyboard-shortcut"
@@ -614,7 +665,9 @@ exports[`Nav renders editor version for desktop 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Stop
                 <span
                   class="nav__keyboard-shortcut"
@@ -628,7 +681,11 @@ exports[`Nav renders editor version for desktop 1`] = `
         <li
           class="nav__item"
         >
-          <button>
+          <button
+            aria-expanded="false"
+            aria-haspopup="menu"
+            role="menuitem"
+          >
             <span
               class="nav__item-header"
             >
@@ -642,11 +699,14 @@ exports[`Nav renders editor version for desktop 1`] = `
           </button>
           <ul
             class="nav__dropdown"
+            role="menu"
           >
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Keyboard Shortcuts
               </button>
             </li>
@@ -656,6 +716,7 @@ exports[`Nav renders editor version for desktop 1`] = `
               <a
                 href="https://p5js.org/reference/"
                 rel="noopener noreferrer"
+                role="menuitem"
                 target="_blank"
               >
                 Reference
@@ -666,6 +727,7 @@ exports[`Nav renders editor version for desktop 1`] = `
             >
               <a
                 href="/about"
+                role="menuitem"
               >
                 About
               </a>
@@ -673,7 +735,7 @@ exports[`Nav renders editor version for desktop 1`] = `
           </ul>
         </li>
       </ul>
-    </nav>
+    </div>
   </header>
 </DocumentFragment>
 `;
@@ -900,7 +962,7 @@ exports[`Nav renders editor version for mobile 1`] = `
 }
 
 <header>
-    <nav
+    <div
       class="c0"
     >
       <div
@@ -986,14 +1048,18 @@ exports[`Nav renders editor version for mobile 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 New
               </button>
             </li>
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Save
               </button>
             </li>
@@ -1002,6 +1068,7 @@ exports[`Nav renders editor version for mobile 1`] = `
             >
               <a
                 href="/p5/sketches"
+                role="menuitem"
               >
                 Examples
               </a>
@@ -1012,14 +1079,18 @@ exports[`Nav renders editor version for mobile 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Tidy Code
               </button>
             </li>
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Find
               </button>
             </li>
@@ -1029,14 +1100,18 @@ exports[`Nav renders editor version for mobile 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Add File
               </button>
             </li>
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Add Folder
               </button>
             </li>
@@ -1046,14 +1121,18 @@ exports[`Nav renders editor version for mobile 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Preferences
               </button>
             </li>
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Language
               </button>
             </li>
@@ -1063,7 +1142,9 @@ exports[`Nav renders editor version for mobile 1`] = `
             <li
               class="nav__dropdown-item"
             >
-              <button>
+              <button
+                role="menuitem"
+              >
                 Keyboard Shortcuts
               </button>
             </li>
@@ -1073,6 +1154,7 @@ exports[`Nav renders editor version for mobile 1`] = `
               <a
                 href="https://p5js.org/reference/"
                 rel="noopener noreferrer"
+                role="menuitem"
                 target="_blank"
               >
                 Reference
@@ -1083,6 +1165,7 @@ exports[`Nav renders editor version for mobile 1`] = `
             >
               <a
                 href="/about"
+                role="menuitem"
               >
                 About
               </a>
@@ -1090,7 +1173,7 @@ exports[`Nav renders editor version for mobile 1`] = `
           </ul>
         </div>
       </div>
-    </nav>
+    </div>
   </header>
 </DocumentFragment>
 `;

--- a/client/modules/IDE/components/__snapshots__/SketchList.unit.test.jsx.snap
+++ b/client/modules/IDE/components/__snapshots__/SketchList.unit.test.jsx.snap
@@ -107,6 +107,7 @@ exports[`<Sketchlist /> snapshot testing 1`] = `
             class="sketch-list__dropdown-column"
           >
             <div
+              aria-haspopup="menu"
               class="c0"
             >
               <button
@@ -143,6 +144,7 @@ exports[`<Sketchlist /> snapshot testing 1`] = `
             class="sketch-list__dropdown-column"
           >
             <div
+              aria-haspopup="menu"
               class="c0"
             >
               <button


### PR DESCRIPTION
Related to #2933, makes progress on @lindapaiste's [#2968](https://github.com/processing/p5.js-web-editor/pull/2968) (thanks for starting some of this already!)

Changes:
- moved `role="menubar"` from nav div to file menu
- moved `role="menuitem"` from `<li>` to`<button>` or `<a>`, whichever element performs a function
- added `role="menuitem"` to login and sign up links
- added `aria-expanded` to dropdowns
- updated snapshots
- updated `index.integration.test.jsx` to look for `role='menubar'` instead of `role='navigation'`

This PR tries to add ARIA `menubar` semantics to the editor navigation menu, to further support accessibility features like the ones described in issue #2933. The main challenge was resolving how to maintain both `role=menubar` and `role=navigation` on the page. ARIA guidelines differentiate on what makes a menubar (a widget offering a list of actions or functions) vs navigation (a collection of links used for navigating the web page or page content). Menubars are also more closely associated with the menus of desktop applications like Photoshop rather than typical examples of site navigation. Since the web editor's file menu functions more like an application than site navigation, I followed the W3C's menubar pattern where possible. 

The biggest change is probably substituting the header `<nav>` element for a `<div>`; I gave `role=navigation` to the right portion of the nav bar since that dealt more closely with links to other pages. It may also make sense to wrap those lists in a `<nav>` element but I have to look into that more.

Since the `menubar` pattern implies specific keyboard behaviors, it would help to implement those features as a next step.

References:
- [https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-editor/](https://www.w3.org/WAI/ARIA/apg/patterns/menubar/examples/menubar-editor/)
- [https://www.radix-ui.com/primitives/docs/components/menubar](https://www.radix-ui.com/primitives/docs/components/menubar)
- [https://adrianroselli.com/2017/10/dont-use-aria-menu-roles-for-site-nav.html](https://adrianroselli.com/2017/10/dont-use-aria-menu-roles-for-site-nav.html)

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
