### PR TITLE
The repeat check for New Password is performed only when entered

### DIFF
--- a/client/utils/reduxFormUtils.js
+++ b/client/utils/reduxFormUtils.js
@@ -51,7 +51,10 @@ export function validateSettings(formProps) {
   if (formProps.newPassword && formProps.newPassword.length < 6) {
     errors.newPassword = i18n.t('ReduxFormUtils.errorShortPassword');
   }
-  if (formProps.currentPassword === formProps.newPassword) {
+  if (
+    formProps.newPassword &&
+    formProps.currentPassword === formProps.newPassword
+  ) {
     errors.newPassword = i18n.t('ReduxFormUtils.errorNewPasswordRepeat');
   }
   return errors;


### PR DESCRIPTION
Fixes #3193

Changes:
The repeat check for New Password is performed only when New Password is entered.
This would make the current password less mandatory and allow the email change logic to work.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
