### PR TITLE
Refactor retrieving 404 Sketch

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -189,10 +189,16 @@ app.use('/api', (error, req, res, next) => {
 });
 
 // Handle missing routes.
-app.get('*', (req, res) => {
+app.get('*', async (req, res) => {
   res.status(404);
   if (req.accepts('html')) {
-    get404Sketch((html) => res.send(html));
+    try {
+      const html = await get404Sketch();
+      res.send(html);
+    } catch (err) {
+      console.error('Error generating 404 sketch:', err);
+      res.send('Error generating 404 page.');
+    }
     return;
   }
   if (req.accepts('json')) {


### PR DESCRIPTION
Changes:
- Refactors fetching the 404 page sketch in `server/views/404Page.js` to use async/await syntax. Will eventually need to be overall changed to render on the client side. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
