### PR TITLE
Fixed broken autocomplete reference link for Issue #3196

### DIFF
--- a/client/modules/IDE/components/show-hint.js
+++ b/client/modules/IDE/components/show-hint.js
@@ -283,7 +283,7 @@
 <span class="hint-hidden">, </span>\
 ${
   p5
-    ? `<a href="https://p5js.org/reference/#/p5/${
+    ? `<a href="https://p5js.org/reference/p5/${
         typeof p5 === 'string' ? p5 : name
       }" role="link" onclick="event.stopPropagation()" target="_blank">\
 <span class="hint-hidden">open ${name} reference</span>\


### PR DESCRIPTION
Fixes #3196 

Changes: 

_p5.js-web-editor/client/modules/IDE/components/show-hint.js line 286_ 
- From ```? `<a href="https://p5js.org/reference/#/p5/${``` to ```? `<a href="https://p5js.org/reference/p5/${```

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
