### PR TITLE
feat: support typescript

### DIFF
--- a/client/modules/IDE/components/FileTypeIcon.jsx
+++ b/client/modules/IDE/components/FileTypeIcon.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { IoLogoHtml5, IoLogoCss3, IoLogoJavascript } from 'react-icons/io';
 import { TbFileTypeXml, TbTxt, TbCsv } from 'react-icons/tb';
+import { SiTypescript } from 'react-icons/si';
 import { VscJson } from 'react-icons/vsc';
 import FileIcon from '../../../images/file.svg';
 
@@ -23,6 +24,12 @@ export default function FileTypeIcon({ fileExtension }) {
       return (
         <span>
           <IoLogoJavascript />
+        </span>
+      );
+    case '.ts':
+      return (
+        <span>
+          <SiTypescript />
         </span>
       );
     case '.json':

--- a/client/modules/Preview/filesReducer.js
+++ b/client/modules/Preview/filesReducer.js
@@ -9,6 +9,8 @@ export function useSelectors(state, mapStateToSelectors) {
   return selectors;
 }
 
+mime.define({ 'application/typescript': ['ts'] }, true);
+
 export function getFileSelectors(state) {
   return {
     getHTMLFile: () => state.filter((file) => file.name.match(/.*\.html$/i))[0],

--- a/package.json
+++ b/package.json
@@ -253,6 +253,7 @@
     "stacktrace-js": "^2.0.2",
     "styled-components": "^5.3.0",
     "styled-theming": "^2.2.0",
+    "typescript": "^5.5.4",
     "url": "^0.11.0",
     "uuid": "^8.3.2",
     "webpack": "^5.76.0",

--- a/server/utils/fileUtils.js
+++ b/server/utils/fileUtils.js
@@ -23,6 +23,7 @@ export const fileExtensionsArray = [
   'mpe',
   'mpv',
   'js',
+  'ts',
   'jsx',
   'html',
   'htm',
@@ -46,7 +47,7 @@ export const fileExtensionsArray = [
 
 export const mimeTypes = `image/*,audio/*,text/javascript,text/html,text/css,
 application/json,application/x-font-ttf,application/x-font-truetype,text/plain,
-text/csv,.obj,video/webm,video/ogg,video/quicktime,video/mp4,application/xml,.stl`;
+text/csv,.obj,video/webm,video/ogg,video/quicktime,video/mp4,application/xml,.stl,application/typescript`;
 
 export const fileExtensions = fileExtensionsArray
   .map((ext) => `.${ext}`)
@@ -69,8 +70,8 @@ export const STRING_REGEX = /(['"])((\\\1|.)*?)\1/gm;
 // these are files that have to be linked to with a blob url
 export const PLAINTEXT_FILE_REGEX = /.+\.(json|txt|csv|vert|frag|tsv|xml|stl|mtl)$/i;
 // these are files that users would want to edit as text (maybe svg should be here?)
-export const TEXT_FILE_REGEX = /.+\.(json|txt|csv|tsv|vert|frag|js|css|html|htm|jsx|xml|stl|mtl)$/i;
+export const TEXT_FILE_REGEX = /.+\.(json|txt|csv|tsv|vert|frag|js|ts|css|html|htm|jsx|xml|stl|mtl)$/i;
 export const NOT_EXTERNAL_LINK_REGEX = /^(?!(http:\/\/|https:\/\/))/;
 export const EXTERNAL_LINK_REGEX = /^(http:\/\/|https:\/\/)/;
 
-export const CREATE_FILE_REGEX = /.+\.(json|txt|csv|tsv|js|css|frag|vert|xml|html|htm|stl|mtl)$/i;
+export const CREATE_FILE_REGEX = /.+\.(json|txt|csv|tsv|js|ts|css|frag|vert|xml|html|htm|stl|mtl)$/i;


### PR DESCRIPTION
Fixes #2354

Changes:

- Added typescript support by transpiling ts code into js based on [discussion](https://github.com/processing/p5.js-web-editor/issues/2354) and [suggestion](https://github.com/processing/p5.js-web-editor/pull/2718#issuecomment-1858269212)
- Added typescript icon when `.ts` file is created


https://github.com/user-attachments/assets/9a7650f7-600f-41aa-953b-2b7352cd68e3

I have verified that this pull request:

* [✅] has no linting errors (`npm run lint`)
* [✅] has no test errors (`npm run test`)
* [✅] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [✅] is descriptively named and links to an issue number, i.e. `Fixes #123`
