### PR TITLE
fix (some) test suite warnings

### DIFF
--- a/client/modules/IDE/components/EditorAccessibility.unit.test.jsx
+++ b/client/modules/IDE/components/EditorAccessibility.unit.test.jsx
@@ -6,7 +6,7 @@ import EditorAccessibility from './EditorAccessibility';
 
 describe('<EditorAccessibility />', () => {
   it('renders empty message with no lines', () => {
-    render(<EditorAccessibility lintMessages={[]} />);
+    render(<EditorAccessibility lintMessages={[]} currentLine={0}/>);
 
     expect(
       screen.getByRole('listitem', {
@@ -21,11 +21,12 @@ describe('<EditorAccessibility />', () => {
         lintMessages={[
           {
             severity: 'info',
-            line: '1',
+            line: 1,
             message: 'foo',
-            id: '1a2b3c'
+            id: 123
           }
         ]}
+        currentLine={0}
       />
     );
 

--- a/client/modules/IDE/components/EditorAccessibility.unit.test.jsx
+++ b/client/modules/IDE/components/EditorAccessibility.unit.test.jsx
@@ -6,7 +6,7 @@ import EditorAccessibility from './EditorAccessibility';
 
 describe('<EditorAccessibility />', () => {
   it('renders empty message with no lines', () => {
-    render(<EditorAccessibility lintMessages={[]} currentLine={0}/>);
+    render(<EditorAccessibility lintMessages={[]} currentLine={0} />);
 
     expect(
       screen.getByRole('listitem', {

--- a/client/modules/IDE/components/ErrorModal.unit.test.jsx
+++ b/client/modules/IDE/components/ErrorModal.unit.test.jsx
@@ -8,20 +8,20 @@ jest.mock('../../../i18n');
 
 describe('<ErrorModal />', () => {
   it('renders type forceAuthentication', () => {
-    render(<ErrorModal type="forceAuthentication" closeModal={jest.fn()} />);
+    render(<ErrorModal type="forceAuthentication" closeModal={jest.fn()} service="google" />);
 
     expect(screen.getByText('Login')).toBeVisible();
     expect(screen.getByText('Sign Up')).toBeVisible();
   });
 
   it('renders type staleSession', () => {
-    render(<ErrorModal type="staleSession" closeModal={jest.fn()} />);
+    render(<ErrorModal type="staleSession" closeModal={jest.fn()} service="google" />);
 
     expect(screen.getByText('log in')).toBeVisible();
   });
 
   it('renders type staleProject', () => {
-    render(<ErrorModal type="staleProject" closeModal={jest.fn()} />);
+    render(<ErrorModal type="staleProject" closeModal={jest.fn()} service="google" />);
 
     expect(
       screen.getByText(

--- a/client/modules/IDE/components/ErrorModal.unit.test.jsx
+++ b/client/modules/IDE/components/ErrorModal.unit.test.jsx
@@ -8,20 +8,30 @@ jest.mock('../../../i18n');
 
 describe('<ErrorModal />', () => {
   it('renders type forceAuthentication', () => {
-    render(<ErrorModal type="forceAuthentication" closeModal={jest.fn()} service="google" />);
+    render(
+      <ErrorModal
+        type="forceAuthentication"
+        closeModal={jest.fn()}
+        service="google"
+      />
+    );
 
     expect(screen.getByText('Login')).toBeVisible();
     expect(screen.getByText('Sign Up')).toBeVisible();
   });
 
   it('renders type staleSession', () => {
-    render(<ErrorModal type="staleSession" closeModal={jest.fn()} service="google" />);
+    render(
+      <ErrorModal type="staleSession" closeModal={jest.fn()} service="google" />
+    );
 
     expect(screen.getByText('log in')).toBeVisible();
   });
 
   it('renders type staleProject', () => {
-    render(<ErrorModal type="staleProject" closeModal={jest.fn()} service="google" />);
+    render(
+      <ErrorModal type="staleProject" closeModal={jest.fn()} service="google" />
+    );
 
     expect(
       screen.getByText(

--- a/client/modules/IDE/components/FileNode.unit.test.jsx
+++ b/client/modules/IDE/components/FileNode.unit.test.jsx
@@ -83,8 +83,8 @@ describe('<FileNode />', () => {
     });
 
     it('can change to a different extension', async () => {
-      let mockConfirm = jest.fn(() => true);
-      window.confirm = mockConfirm;  
+      const mockConfirm = jest.fn(() => true);
+      window.confirm = mockConfirm;
 
       const newName = 'newname.gif';
       const props = renderFileNode('file');
@@ -92,7 +92,9 @@ describe('<FileNode />', () => {
       changeName(newName);
 
       expect(mockConfirm).toHaveBeenCalled();
-      await waitFor(() => expect(props.updateFileName).toHaveBeenCalledWith(props.id, newName));
+      await waitFor(() =>
+        expect(props.updateFileName).toHaveBeenCalledWith(props.id, newName)
+      );
       await expectFileNameToBe(props.name);
     });
 

--- a/client/modules/IDE/components/FileNode.unit.test.jsx
+++ b/client/modules/IDE/components/FileNode.unit.test.jsx
@@ -83,12 +83,16 @@ describe('<FileNode />', () => {
     });
 
     it('can change to a different extension', async () => {
+      let mockConfirm = jest.fn(() => true);
+      window.confirm = mockConfirm;  
+
       const newName = 'newname.gif';
       const props = renderFileNode('file');
 
       changeName(newName);
 
-      await waitFor(() => expect(props.updateFileName).not.toHaveBeenCalled());
+      expect(mockConfirm).toHaveBeenCalled();
+      await waitFor(() => expect(props.updateFileName).toHaveBeenCalledWith(props.id, newName));
       await expectFileNameToBe(props.name);
     });
 

--- a/server/controllers/project.controller/__test__/createProject.test.js
+++ b/server/controllers/project.controller/__test__/createProject.test.js
@@ -179,6 +179,10 @@ describe('project.controller', () => {
     });
 
     it('fails if user does not have permission', async () => {
+      // We don't want to clog up the jest output with extra
+      // logs, so we turn off console warn for this one test.
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+
       request.user = { _id: 'abc123', username: 'alice' };
       request.params = {
         username: 'dana'

--- a/server/controllers/project.controller/createProject.js
+++ b/server/controllers/project.controller/createProject.js
@@ -59,7 +59,7 @@ export async function apiCreateProject(req, res) {
 
   const checkUserHasPermission = () => {
     if (req.user.username !== req.params.username) {
-      console.log('no permission');
+      console.warn('no permission');
       const error = new ProjectValidationError(
         `'${req.user.username}' does not have permission to create for '${req.params.username}'`
       );


### PR DESCRIPTION
Fixes the test suite warnings that are unrelated to the React lifecycle, which I assume will be resolved as a side effect of the ongoing class -> functional conversion.

Changes:
- Provides the props that were missing but marked as required in the EditorAccessibility tests and ErrorModal tests
- creates a fake version of window.confirm which is missing from the jsdom environment but used in the FileNode tests
- hides the extra log in the createProject test and changes it from a log to a warning type in the controller itself

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
