### PR TITLE
Fix: Vertically Center Eye Icon in Password Fiel

### DIFF
--- a/client/styles/components/_forms.scss
+++ b/client/styles/components/_forms.scss
@@ -81,7 +81,8 @@
   font-size: 28px;
   position: absolute;
   right: 0px;
-  top: 4px;
+  top: 50%;
+  transform: translateY(-50%);
   vertical-align: middle;
 }
 


### PR DESCRIPTION
Fixes #3241

Changes: This PR addresses the visual alignment issue where the eye icon in the password field is not vertically centered. By adjusting the CSS for .form__eye__icon, the icon is now properly aligned within the input field.

Changes Introduced:

Updated the `.form__eye__icon` class to vertically center the icon using `top: 50% and transform: translateY(-50%)`.
Maintained the current horizontal alignment but adjusted the vertical alignment for a more consistent appearance

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
