### PR TITLE
add cache busting to assets in preview

### DIFF
--- a/client/modules/Preview/previewIndex.jsx
+++ b/client/modules/Preview/previewIndex.jsx
@@ -52,6 +52,19 @@ const App = () => {
     }
   }
 
+  function addCacheBustingToAssets(files) {
+    const timestamp = new Date().getTime();
+    return files.map((file) => {
+      if (file.url) {
+        return {
+          ...file,
+          url: `${file.url}?v=${timestamp}`
+        };
+      }
+      return file;
+    });
+  }
+
   useEffect(() => {
     const unsubscribe = listen(handleMessageEvent);
     return function cleanup() {
@@ -62,7 +75,7 @@ const App = () => {
     <React.Fragment>
       <GlobalStyle />
       <EmbedFrame
-        files={state}
+        files={addCacheBustingToAssets(state)}
         isPlaying={isPlaying}
         basePath={basePath}
         gridOutput={gridOutput}


### PR DESCRIPTION
Progress on #3156 

Changes:
- Includes [suggestion to implement cache busting by appending asset URLs with timestamps](https://github.com/processing/p5.js-web-editor/issues/3156#issuecomment-2400237656), which is happening in the function `addCacheBustingtoAssets()` in `client/modules/Preview/previewIndex.jsx`.  

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
