### PR TITLE
Fixes form reinitialization on language change (#3229)

### DIFF
--- a/client/common/useSyncFormTranslations.js
+++ b/client/common/useSyncFormTranslations.js
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+
+// Usage: useSyncFormTranslations(formRef, language)
+// This hook ensures that form values are preserved when the language changes.
+// Pass a ref to the form instance and the current language as arguments.
+const useSyncFormTranslations = (formRef, language) => {
+  useEffect(() => {
+    const form = formRef.current;
+    if (!form) return;
+
+    const { values } = form.getState();
+    form.reset();
+
+    Object.keys(values).forEach((field) => {
+      if (values[field]) {
+        form.change(field, values[field]);
+      }
+    });
+  }, [language]);
+};
+
+export default useSyncFormTranslations;

--- a/client/modules/IDE/hooks/custom-hooks.js
+++ b/client/modules/IDE/hooks/custom-hooks.js
@@ -68,22 +68,3 @@ export const useEventListener = (
     document.addEventListener(event, callback, useCapture);
     return () => document.removeEventListener(event, callback, useCapture);
   }, list);
-
-// Usage: usePreserveFormValuesOnLanguageChange(formRef, language)
-// This hook ensures that form values are preserved when the language changes.
-// Pass a ref to the form instance and the current language as arguments.
-export const usePreserveFormValuesOnLanguageChange = (formRef, language) => {
-  useEffect(() => {
-    const form = formRef.current;
-    if (!form) return;
-
-    const { values } = form.getState();
-    form.reset();
-
-    Object.keys(values).forEach((field) => {
-      if (values[field]) {
-        form.change(field, values[field]);
-      }
-    });
-  }, [language]);
-};

--- a/client/modules/IDE/hooks/custom-hooks.js
+++ b/client/modules/IDE/hooks/custom-hooks.js
@@ -68,3 +68,22 @@ export const useEventListener = (
     document.addEventListener(event, callback, useCapture);
     return () => document.removeEventListener(event, callback, useCapture);
   }, list);
+
+// Usage: usePreserveFormValuesOnLanguageChange(formRef, language)
+// This hook ensures that form values are preserved when the language changes.
+// Pass a ref to the form instance and the current language as arguments.
+export const usePreserveFormValuesOnLanguageChange = (formRef, language) => {
+  useEffect(() => {
+    const form = formRef.current;
+    if (!form) return;
+
+    const { values } = form.getState();
+    form.reset();
+
+    Object.keys(values).forEach((field) => {
+      if (values[field]) {
+        form.change(field, values[field]);
+      }
+    });
+  }, [language]);
+};

--- a/client/modules/User/components/LoginForm.jsx
+++ b/client/modules/User/components/LoginForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form, Field } from 'react-final-form';
 import { useDispatch } from 'react-redux';
@@ -6,6 +6,7 @@ import { AiOutlineEye, AiOutlineEyeInvisible } from 'react-icons/ai';
 import Button from '../../../common/Button';
 import { validateLogin } from '../../../utils/reduxFormUtils';
 import { validateAndLoginUser } from '../actions';
+import { usePreserveFormValuesOnLanguageChange } from '../../IDE/hooks/custom-hooks';
 
 function LoginForm() {
   const { t, i18n } = useTranslation();
@@ -20,21 +21,8 @@ function LoginForm() {
   const handleVisibility = () => {
     setShowPassword(!showPassword);
   };
-  useEffect(() => {
-    const form = formRef.current;
-    if (!form) return;
 
-    const { values } = form.getState(); // store current form touched values
-    form.reset();
-
-    // Restore prev form values and trigger validation
-    Object.keys(values).forEach((field) => {
-      if (values[field]) {
-        // Only reapply touched values
-        form.change(field, values[field]);
-      }
-    });
-  }, [i18n.language]);
+  usePreserveFormValuesOnLanguageChange(formRef, i18n.language);
 
   return (
     <Form

--- a/client/modules/User/components/LoginForm.jsx
+++ b/client/modules/User/components/LoginForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form, Field } from 'react-final-form';
 import { useDispatch } from 'react-redux';
@@ -8,22 +8,28 @@ import { validateLogin } from '../../../utils/reduxFormUtils';
 import { validateAndLoginUser } from '../actions';
 
 function LoginForm() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const dispatch = useDispatch();
   function onSubmit(formProps) {
     return dispatch(validateAndLoginUser(formProps));
   }
   const [showPassword, setShowPassword] = useState(false);
+  const [formUpdateKey, setFormUpdateKey] = useState(false);
+
   const handleVisibility = () => {
     setShowPassword(!showPassword);
   };
+  useEffect(() => {
+    setFormUpdateKey(!formUpdateKey);
+  }, [i18n.language]);
 
   return (
     <Form
       fields={['email', 'password']}
       validate={validateLogin}
       onSubmit={onSubmit}
+      key={formUpdateKey}
     >
       {({ handleSubmit, submitError, submitting, modifiedSinceLastSubmit }) => (
         <form className="form" onSubmit={handleSubmit}>

--- a/client/modules/User/components/LoginForm.jsx
+++ b/client/modules/User/components/LoginForm.jsx
@@ -6,7 +6,7 @@ import { AiOutlineEye, AiOutlineEyeInvisible } from 'react-icons/ai';
 import Button from '../../../common/Button';
 import { validateLogin } from '../../../utils/reduxFormUtils';
 import { validateAndLoginUser } from '../actions';
-import { usePreserveFormValuesOnLanguageChange } from '../../IDE/hooks/custom-hooks';
+import { useSyncFormTranslations } from '../../../common/useSyncFormTranslations';
 
 function LoginForm() {
   const { t, i18n } = useTranslation();
@@ -22,7 +22,7 @@ function LoginForm() {
     setShowPassword(!showPassword);
   };
 
-  usePreserveFormValuesOnLanguageChange(formRef, i18n.language);
+  useSyncFormTranslations(formRef, i18n.language);
 
   return (
     <Form

--- a/client/modules/User/components/LoginForm.unit.test.jsx
+++ b/client/modules/User/components/LoginForm.unit.test.jsx
@@ -23,6 +23,10 @@ jest.mock('../actions', () => ({
   )
 }));
 
+jest.mock('../../../common/useSyncFormTranslations', () => ({
+  useSyncFormTranslations: jest.fn()
+}));
+
 const subject = () => {
   reduxRender(<LoginForm />, {
     store

--- a/client/modules/User/components/SignupForm.jsx
+++ b/client/modules/User/components/SignupForm.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form, Field } from 'react-final-form';
 import { useDispatch } from 'react-redux';
@@ -34,7 +34,7 @@ function validateEmail(email) {
 }
 
 function SignupForm() {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const dispatch = useDispatch();
   function onSubmit(formProps) {
@@ -42,18 +42,23 @@ function SignupForm() {
   }
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [formUpdateKey, setFormUpdateKey] = useState(false);
   const handleVisibility = () => {
     setShowPassword(!showPassword);
   };
   const handleConfirmVisibility = () => {
     setShowConfirmPassword(!showConfirmPassword);
   };
+  useEffect(() => {
+    setFormUpdateKey(!formUpdateKey);
+  }, [i18n.language]);
 
   return (
     <Form
       fields={['username', 'email', 'password', 'confirmPassword']}
       validate={validateSignup}
       onSubmit={onSubmit}
+      key={formUpdateKey}
     >
       {({ handleSubmit, pristine, submitting, invalid }) => (
         <form className="form" onSubmit={handleSubmit}>

--- a/client/modules/User/components/SignupForm.jsx
+++ b/client/modules/User/components/SignupForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form, Field } from 'react-final-form';
 import { useDispatch } from 'react-redux';
@@ -42,7 +42,7 @@ function SignupForm() {
   }
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
-  const [formUpdateKey, setFormUpdateKey] = useState(false);
+  const formRef = useRef(null);
   const handleVisibility = () => {
     setShowPassword(!showPassword);
   };
@@ -50,7 +50,19 @@ function SignupForm() {
     setShowConfirmPassword(!showConfirmPassword);
   };
   useEffect(() => {
-    setFormUpdateKey(!formUpdateKey);
+    const form = formRef.current;
+    if (!form) return;
+
+    const { values } = form.getState(); // store current form touched values
+    form.reset();
+
+    // Restore prev form values and trigger validation
+    Object.keys(values).forEach((field) => {
+      if (values[field]) {
+        // Only reapply touched values
+        form.change(field, values[field]);
+      }
+    });
   }, [i18n.language]);
 
   return (
@@ -58,136 +70,138 @@ function SignupForm() {
       fields={['username', 'email', 'password', 'confirmPassword']}
       validate={validateSignup}
       onSubmit={onSubmit}
-      key={formUpdateKey}
     >
-      {({ handleSubmit, pristine, submitting, invalid }) => (
-        <form className="form" onSubmit={handleSubmit}>
-          <Field
-            name="username"
-            validate={validateUsername}
-            validateFields={[]}
-          >
-            {(field) => (
-              <div className="form__field">
-                <label htmlFor="username" className="form__label">
-                  {t('SignupForm.Title')}
-                </label>
-                <input
-                  className="form__input"
-                  aria-label={t('SignupForm.TitleARIA')}
-                  type="text"
-                  id="username"
-                  autoComplete="username"
-                  autoCapitalize="none"
-                  {...field.input}
-                />
-                {field.meta.touched && field.meta.error && (
-                  <span className="form-error" aria-live="polite">
-                    {field.meta.error}
-                  </span>
-                )}
-              </div>
-            )}
-          </Field>
-          <Field name="email" validate={validateEmail} validateFields={[]}>
-            {(field) => (
-              <div className="form__field">
-                <label htmlFor="email" className="form__label">
-                  {t('SignupForm.Email')}
-                </label>
-                <input
-                  className="form__input"
-                  aria-label={t('SignupForm.EmailARIA')}
-                  type="email"
-                  id="email"
-                  autoComplete="email"
-                  {...field.input}
-                />
-                {field.meta.touched && field.meta.error && (
-                  <span className="form-error" aria-live="polite">
-                    {field.meta.error}
-                  </span>
-                )}
-              </div>
-            )}
-          </Field>
-          <Field name="password">
-            {(field) => (
-              <div className="form__field">
-                <label htmlFor="password" className="form__label">
-                  {t('SignupForm.Password')}
-                </label>
-                <div className="form__field__password">
+      {({ handleSubmit, pristine, submitting, invalid, form }) => {
+        formRef.current = form;
+        return (
+          <form className="form" onSubmit={handleSubmit}>
+            <Field
+              name="username"
+              validate={validateUsername}
+              validateFields={[]}
+            >
+              {(field) => (
+                <div className="form__field">
+                  <label htmlFor="username" className="form__label">
+                    {t('SignupForm.Title')}
+                  </label>
                   <input
                     className="form__input"
-                    aria-label={t('SignupForm.PasswordARIA')}
-                    type={showPassword ? 'text' : 'password'}
-                    id="password"
-                    autoComplete="new-password"
+                    aria-label={t('SignupForm.TitleARIA')}
+                    type="text"
+                    id="username"
+                    autoComplete="username"
+                    autoCapitalize="none"
                     {...field.input}
                   />
-                  <button
-                    className="form__eye__icon"
-                    type="button"
-                    onClick={handleVisibility}
-                    aria-hidden="true"
-                  >
-                    {showPassword ? (
-                      <AiOutlineEyeInvisible />
-                    ) : (
-                      <AiOutlineEye />
-                    )}
-                  </button>
+                  {field.meta.touched && field.meta.error && (
+                    <span className="form-error" aria-live="polite">
+                      {field.meta.error}
+                    </span>
+                  )}
                 </div>
-                {field.meta.touched && field.meta.error && (
-                  <span className="form-error" aria-live="polite">
-                    {field.meta.error}
-                  </span>
-                )}
-              </div>
-            )}
-          </Field>
-          <Field name="confirmPassword">
-            {(field) => (
-              <div className="form__field">
-                <label htmlFor="confirmPassword" className="form__label">
-                  {t('SignupForm.ConfirmPassword')}
-                </label>
-                <div className="form__field__password">
+              )}
+            </Field>
+            <Field name="email" validate={validateEmail} validateFields={[]}>
+              {(field) => (
+                <div className="form__field">
+                  <label htmlFor="email" className="form__label">
+                    {t('SignupForm.Email')}
+                  </label>
                   <input
                     className="form__input"
-                    type={showConfirmPassword ? 'text' : 'password'}
-                    aria-label={t('SignupForm.ConfirmPasswordARIA')}
-                    id="confirmPassword" // Match the id with htmlFor
-                    autoComplete="new-password"
+                    aria-label={t('SignupForm.EmailARIA')}
+                    type="email"
+                    id="email"
+                    autoComplete="email"
                     {...field.input}
                   />
-                  <button
-                    className="form__eye__icon"
-                    type="button"
-                    onClick={handleConfirmVisibility}
-                    aria-hidden="true"
-                  >
-                    {showConfirmPassword ? (
-                      <AiOutlineEyeInvisible />
-                    ) : (
-                      <AiOutlineEye />
-                    )}
-                  </button>
+                  {field.meta.touched && field.meta.error && (
+                    <span className="form-error" aria-live="polite">
+                      {field.meta.error}
+                    </span>
+                  )}
                 </div>
-                {field.meta.touched && field.meta.error && (
-                  <span className="form-error" aria-live="polite">
-                    {field.meta.error}
-                  </span>
-                )}
-              </div>
-            )}
-          </Field>
-          <Button type="submit" disabled={submitting || invalid || pristine}>
-            {t('SignupForm.SubmitSignup')}
-          </Button>
-        </form>
-      )}
+              )}
+            </Field>
+            <Field name="password">
+              {(field) => (
+                <div className="form__field">
+                  <label htmlFor="password" className="form__label">
+                    {t('SignupForm.Password')}
+                  </label>
+                  <div className="form__field__password">
+                    <input
+                      className="form__input"
+                      aria-label={t('SignupForm.PasswordARIA')}
+                      type={showPassword ? 'text' : 'password'}
+                      id="password"
+                      autoComplete="new-password"
+                      {...field.input}
+                    />
+                    <button
+                      className="form__eye__icon"
+                      type="button"
+                      onClick={handleVisibility}
+                      aria-hidden="true"
+                    >
+                      {showPassword ? (
+                        <AiOutlineEyeInvisible />
+                      ) : (
+                        <AiOutlineEye />
+                      )}
+                    </button>
+                  </div>
+                  {field.meta.touched && field.meta.error && (
+                    <span className="form-error" aria-live="polite">
+                      {field.meta.error}
+                    </span>
+                  )}
+                </div>
+              )}
+            </Field>
+            <Field name="confirmPassword">
+              {(field) => (
+                <div className="form__field">
+                  <label htmlFor="confirmPassword" className="form__label">
+                    {t('SignupForm.ConfirmPassword')}
+                  </label>
+                  <div className="form__field__password">
+                    <input
+                      className="form__input"
+                      type={showConfirmPassword ? 'text' : 'password'}
+                      aria-label={t('SignupForm.ConfirmPasswordARIA')}
+                      id="confirmPassword" // Match the id with htmlFor
+                      autoComplete="new-password"
+                      {...field.input}
+                    />
+                    <button
+                      className="form__eye__icon"
+                      type="button"
+                      onClick={handleConfirmVisibility}
+                      aria-hidden="true"
+                    >
+                      {showConfirmPassword ? (
+                        <AiOutlineEyeInvisible />
+                      ) : (
+                        <AiOutlineEye />
+                      )}
+                    </button>
+                  </div>
+                  {field.meta.touched && field.meta.error && (
+                    <span className="form-error" aria-live="polite">
+                      {field.meta.error}
+                    </span>
+                  )}
+                </div>
+              )}
+            </Field>
+            <Button type="submit" disabled={submitting || invalid || pristine}>
+              {t('SignupForm.SubmitSignup')}
+            </Button>
+          </form>
+        );
+      }}
     </Form>
   );
 }

--- a/client/modules/User/components/SignupForm.jsx
+++ b/client/modules/User/components/SignupForm.jsx
@@ -7,7 +7,7 @@ import { validateSignup } from '../../../utils/reduxFormUtils';
 import { validateAndSignUpUser } from '../actions';
 import Button from '../../../common/Button';
 import apiClient from '../../../utils/apiClient';
-import { usePreserveFormValuesOnLanguageChange } from '../../IDE/hooks/custom-hooks';
+import { useSyncFormTranslations } from '../../../common/useSyncFormTranslations';
 
 function asyncValidate(fieldToValidate, value) {
   if (!value || value.trim().length === 0) {
@@ -50,7 +50,7 @@ function SignupForm() {
   const handleConfirmVisibility = () => {
     setShowConfirmPassword(!showConfirmPassword);
   };
-  usePreserveFormValuesOnLanguageChange(formRef, i18n.language);
+  useSyncFormTranslations(formRef, i18n.language);
 
   return (
     <Form

--- a/client/modules/User/components/SignupForm.jsx
+++ b/client/modules/User/components/SignupForm.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Form, Field } from 'react-final-form';
 import { useDispatch } from 'react-redux';
@@ -7,6 +7,7 @@ import { validateSignup } from '../../../utils/reduxFormUtils';
 import { validateAndSignUpUser } from '../actions';
 import Button from '../../../common/Button';
 import apiClient from '../../../utils/apiClient';
+import { usePreserveFormValuesOnLanguageChange } from '../../IDE/hooks/custom-hooks';
 
 function asyncValidate(fieldToValidate, value) {
   if (!value || value.trim().length === 0) {
@@ -49,21 +50,7 @@ function SignupForm() {
   const handleConfirmVisibility = () => {
     setShowConfirmPassword(!showConfirmPassword);
   };
-  useEffect(() => {
-    const form = formRef.current;
-    if (!form) return;
-
-    const { values } = form.getState(); // store current form touched values
-    form.reset();
-
-    // Restore prev form values and trigger validation
-    Object.keys(values).forEach((field) => {
-      if (values[field]) {
-        // Only reapply touched values
-        form.change(field, values[field]);
-      }
-    });
-  }, [i18n.language]);
+  usePreserveFormValuesOnLanguageChange(formRef, i18n.language);
 
   return (
     <Form


### PR DESCRIPTION
Fixes #3229

Changes:
- Introduced a `formUpdateKey` state to force form reinitialization
- Added useEffect hook to update `formUpdateKey` when language changes
- Set `formUpdateKey` as the `key` prop for the Form component to ensure remount

This change ensures that the form reinitializes properly when the language is switched, even if error messages were displayed in the previous language.

I have verified that this pull request:
* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #3229`