### PR TITLE
issue #3241

### DIFF
--- a/client/modules/User/components/LoginForm.css
+++ b/client/modules/User/components/LoginForm.css
@@ -1,0 +1,31 @@
+.form__field {
+    position: relative;
+    margin-bottom: 20px;
+  }
+  
+  .form__input {
+    width: 100%;
+    padding: 10px;
+    font-size: 16px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+  
+  .form__field__password {
+    position: relative;
+  }
+  
+  .form__eye__icon {
+    position: absolute;
+    right: 10px; /* Align icon to the right */
+    top: 50%; /* Vertically center the icon */
+    transform: translateY(-50%); /* Adjust for centering */
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+  
+  .form__eye__icon svg {
+    font-size: 20px; /* Adjust size of the eye icon */
+  }
+  

--- a/client/modules/User/components/LoginForm.jsx
+++ b/client/modules/User/components/LoginForm.jsx
@@ -6,6 +6,7 @@ import { AiOutlineEye, AiOutlineEyeInvisible } from 'react-icons/ai';
 import Button from '../../../common/Button';
 import { validateLogin } from '../../../utils/reduxFormUtils';
 import { validateAndLoginUser } from '../actions';
+import './LoginForm.css'; // Added import for the CSS
 
 function LoginForm() {
   const { t } = useTranslation();


### PR DESCRIPTION
Icon Alignment Issue in Password Field – Adjust Eye Icon Vertical Centering #3241

github-7373

Fixes #issue-number

Changes:

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
