### PR TITLE
Fix#3241 - Icon Alignment issue in Password Field

### DIFF
--- a/client/styles/components/_forms.scss
+++ b/client/styles/components/_forms.scss
@@ -75,13 +75,15 @@
 
 .form__field__password {
   position: relative;
+  display: flex;
+  align-items: center;
 }
 
 .form__eye__icon {
   font-size: 28px;
   position: absolute;
   right: 0px;
-  top: 4px;
+  display: flex;
   vertical-align: middle;
 }
 

--- a/client/styles/components/_forms.scss
+++ b/client/styles/components/_forms.scss
@@ -80,11 +80,13 @@
 }
 
 .form__eye__icon {
-  font-size: 28px;
+  font-size: #{math.div(30, $base-font-size)}rem;
   position: absolute;
   right: 0px;
-  display: flex;
-  vertical-align: middle;
+  
+  & svg {
+    transform: translateY(10%);
+  }
 }
 
 


### PR DESCRIPTION
Fixes #3241 

Changes:

Previously, a top margin of 4px was added to the eye icon, which aligned it centrally on some screens but wasn’t consistent for all users. I added a few lines of adjustments to ensure consistency across all screen aspect ratios.


I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`

Changes OUTPUTS:
OUTPUT 1:
<img width="852" alt="image" src="https://github.com/user-attachments/assets/39152940-8e0c-4b79-91a6-431bf60a4a4e">

OUTPUT 2:
<img width="814" alt="image" src="https://github.com/user-attachments/assets/1181e447-de73-4cfa-86c1-712a2e58404f">

