### PR TITLE
Update Collection View

### DIFF
--- a/client/modules/User/components/Collection.jsx
+++ b/client/modules/User/components/Collection.jsx
@@ -13,19 +13,16 @@ import ArrowDownIcon from '../../../images/sort-arrow-down.svg';
 import CollectionMetadata from './CollectionMetadata';
 import CollectionItemRow from './CollectionItemRow';
 
-const Collection = ({ collectionId }) => {
+const Collection = ({ collectionId, username }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
-  const { user, collection, sorting, loading, username } = useSelector(
-    (state) => ({
-      user: state.user,
-      collection: getCollection(state, collectionId),
-      sorting: state.sorting,
-      loading: state.loading,
-      username: state.user.username
-    })
-  );
+  const { user, collection, sorting, loading } = useSelector((state) => ({
+    user: state.user,
+    collection: getCollection(state, collectionId),
+    sorting: state.sorting,
+    loading: state.loading
+  }));
 
   useEffect(() => {
     dispatch(CollectionsActions.getCollections(username));
@@ -34,7 +31,7 @@ const Collection = ({ collectionId }) => {
 
   const isOwner = () =>
     user != null &&
-    user.username &&
+    typeof user.username !== 'undefined' &&
     collection?.owner?.username === user.username;
 
   const hasCollection = () => !!collection;
@@ -160,7 +157,8 @@ const Collection = ({ collectionId }) => {
 };
 
 Collection.propTypes = {
-  collectionId: PropTypes.string.isRequired
+  collectionId: PropTypes.string.isRequired,
+  username: PropTypes.string.isRequired
 };
 
 export default Collection;

--- a/client/modules/User/components/Collection.jsx
+++ b/client/modules/User/components/Collection.jsx
@@ -17,12 +17,10 @@ const Collection = ({ collectionId, username }) => {
   const { t } = useTranslation();
   const dispatch = useDispatch();
 
-  const { user, collection, sorting, loading } = useSelector((state) => ({
-    user: state.user,
-    collection: getCollection(state, collectionId),
-    sorting: state.sorting,
-    loading: state.loading
-  }));
+  const user = useSelector((state) => state.user);
+  const collection = useSelector((state) => getCollection(state, collectionId));
+  const sorting = useSelector((state) => state.sorting);
+  const loading = useSelector((state) => state.loading);
 
   useEffect(() => {
     dispatch(CollectionsActions.getCollections(username));

--- a/client/modules/User/components/CollectionItemRow.jsx
+++ b/client/modules/User/components/CollectionItemRow.jsx
@@ -2,18 +2,15 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { useDispatch } from 'react-redux';
+import { removeFromCollection } from '../../IDE/actions/collections';
 import dates from '../../../utils/formatDate';
 import RemoveIcon from '../../../images/close.svg';
 
-const CollectionItemRow = ({
-  collection,
-  item,
-  isOwner,
-  removeFromCollection
-}) => {
+const CollectionItemRow = ({ collection, item, isOwner }) => {
   const { t } = useTranslation();
+  const dispatch = useDispatch();
   const projectIsDeleted = item.isDeleted;
-
   const handleSketchRemove = () => {
     const name = projectIsDeleted ? 'deleted sketch' : item.project.name;
 
@@ -22,7 +19,7 @@ const CollectionItemRow = ({
         t('Collection.DeleteFromCollection', { name_sketch: name })
       )
     ) {
-      removeFromCollection(collection.id, item.projectId);
+      dispatch(removeFromCollection(collection.id, item.projectId));
     }
   };
 
@@ -75,10 +72,9 @@ CollectionItemRow.propTypes = {
       user: PropTypes.shape({
         username: PropTypes.string.isRequired
       })
-    }).isRequired
+    })
   }).isRequired,
-  isOwner: PropTypes.bool.isRequired,
-  removeFromCollection: PropTypes.func.isRequired
+  isOwner: PropTypes.bool.isRequired
 };
 
 export default CollectionItemRow;


### PR DESCRIPTION
Fixes #3269 

Changes:
- passes `username` as a prop to `Collection` component, which was previously not accessible 
- updates conditions to determine `isOwner`, which was previously returning `undefined` instead of a boolean
- imports `removeFromCollection` action directly into `CollectionItemRow`

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
