### PR TITLE
fix: escape key closes hints without blocking typing

### DIFF
--- a/client/modules/IDE/components/show-hint.js
+++ b/client/modules/IDE/components/show-hint.js
@@ -24,6 +24,21 @@
 
   // This is the old interface, kept around for now to stay
   // backwards-compatible.
+
+  //event listener to enable escape key functionality
+  function addEscapeKeyListener(cm) {
+    const escapeHandler = (event) => {
+      if (event.key === 'Escape' && cm.state.completionActive) {
+        cm.closeHint(); // Close the hint
+        cm.focus(); // Ensure the editor regains focus
+        document.removeEventListener('keydown', escapeHandler); // Clean up listener
+      }
+    };
+  
+    // Add the event listener when hints are active
+    document.addEventListener('keydown', escapeHandler);
+  }
+
   CodeMirror.showHint = function (cm, getHints, options) {
     if (!getHints) return cm.showHint(options);
     if (options && options.async) getHints.async = true;
@@ -55,6 +70,8 @@
 
     CodeMirror.signal(this, 'startCompletion', this);
     completion.update(true);
+    // Add Escape key listener
+    addEscapeKeyListener(this);
   });
 
   CodeMirror.defineExtension('closeHint', function () {


### PR DESCRIPTION
Fixes #3252

Changes: Ensures that pressing the escape key closes the hint box without preventing the user from typing in the editor. The editor should remain responsive after closing the hint.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #3252`
