### PR TITLE
Fix Console Errors and Update Hooks in FileNode

### DIFF
--- a/client/modules/IDE/components/ConsoleInput.jsx
+++ b/client/modules/IDE/components/ConsoleInput.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useRef, useEffect, useState } from 'react';
+import { useDispatch } from 'react-redux';
 import CodeMirror from 'codemirror';
 import { Encode } from 'console-feed';
 
@@ -15,6 +16,7 @@ function ConsoleInput({ theme, fontSize }) {
   const [commandCursor, setCommandCursor] = useState(-1);
   const codemirrorContainer = useRef(null);
   const cmInstance = useRef(null);
+  const dispatch = useDispatch();
 
   useEffect(() => {
     cmInstance.current = CodeMirror(codemirrorContainer.current, {
@@ -45,7 +47,7 @@ function ConsoleInput({ theme, fontSize }) {
           payload: { source: 'console', messages }
         });
 
-        dispatchConsoleEvent(consoleEvent);
+        dispatch(dispatchConsoleEvent(consoleEvent));
         cm.setValue('');
         setCommandHistory([value, ...commandHistory]);
         setCommandCursor(-1);

--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import React, { useState, useRef } from 'react';
-import { connect } from 'react-redux';
+import { connect, useDispatch } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 
 import * as IDEActions from '../actions/ide';
@@ -87,6 +87,7 @@ const FileNode = ({
   const [isEditingName, setIsEditingName] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [updatedName, setUpdatedName] = useState(name);
+  const dispatch = useDispatch();
 
   const { t } = useTranslation();
   const fileNameInput = useRef(null);
@@ -122,17 +123,17 @@ const FileNode = ({
   };
 
   const handleClickAddFile = () => {
-    newFile(id);
+    dispatch(newFile(id));
     setTimeout(() => hideFileOptions(), 0);
   };
 
   const handleClickAddFolder = () => {
-    newFolder(id);
+    dispatch(newFolder(id));
     setTimeout(() => hideFileOptions(), 0);
   };
 
   const handleClickUploadFile = () => {
-    openUploadFileModal(id);
+    dispatch(openUploadFileModal(id));
     setTimeout(hideFileOptions, 0);
   };
 

--- a/client/modules/IDE/components/FileNode.unit.test.jsx
+++ b/client/modules/IDE/components/FileNode.unit.test.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { useDispatch } from 'react-redux';
+import * as FileActions from '../actions/files';
 
 import {
   fireEvent,
@@ -10,19 +11,25 @@ import {
   waitFor,
   within
 } from '../../../test-utils';
-import { FileNode } from './FileNode';
+import FileNode from './FileNode';
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useDispatch: jest.fn()
 }));
 
+jest.mock('../actions/files', () => ({
+  updateFileName: jest.fn()
+}));
+
+const mockStore = configureStore([]);
+
 describe('<FileNode />', () => {
   const mockDispatch = jest.fn();
-  const mockStore = configureStore([]);
 
   beforeEach(() => {
     useDispatch.mockReturnValue(mockDispatch);
+    jest.clearAllMocks();
   });
 
   const changeName = (newFileName) => {
@@ -39,79 +46,64 @@ describe('<FileNode />', () => {
     await waitFor(() => within(name).queryByText(expectedName));
   };
 
-  const renderFileNode = (fileType, extraProps = {}) => {
+  const renderFileNode = (fileType, extraState = {}) => {
     const initialState = {
       files: [
         {
           id: '0',
           name: fileType === 'folder' ? 'afolder' : 'test.jsx',
-          fileType
+          fileType,
+          parentId: 'root',
+          children: [],
+          isSelectedFile: false,
+          isFolderClosed: false
         }
       ],
-      user: { authenticated: false }
+      user: { authenticated: false },
+      ...extraState
     };
 
     const store = mockStore(initialState);
 
-    const props = {
-      ...extraProps,
-      id: '0',
-      name: fileType === 'folder' ? 'afolder' : 'test.jsx',
-      fileType,
-      canEdit: true,
-      children: [],
-      authenticated: false,
-      setSelectedFile: jest.fn(),
-      deleteFile: jest.fn(),
-      updateFileName: jest.fn(),
-      resetSelectedFile: jest.fn(),
-      newFile: jest.fn(),
-      newFolder: jest.fn(),
-      showFolderChildren: jest.fn(),
-      hideFolderChildren: jest.fn(),
-      openUploadFileModal: jest.fn(),
-      setProjectName: jest.fn()
-    };
-
     render(
       <Provider store={store}>
-        <FileNode {...props} />
+        <FileNode id="0" canEdit />
       </Provider>
     );
 
-    return { store, props };
+    return { store };
   };
 
   describe('fileType: file', () => {
     it('cannot change to an empty name', async () => {
-      const { props } = renderFileNode('file');
+      renderFileNode('file');
 
       changeName('');
 
       await waitFor(() => expect(mockDispatch).not.toHaveBeenCalled());
-      await expectFileNameToBe(props.name);
+      await expectFileNameToBe('test.jsx');
     });
 
     it('can change to a valid filename', async () => {
       const newName = 'newname.jsx';
-      const { props } = renderFileNode('file');
+      renderFileNode('file');
 
       changeName(newName);
 
       await waitFor(() =>
-        expect(props.updateFileName).toHaveBeenCalledWith(props.id, newName)
+        expect(FileActions.updateFileName).toHaveBeenCalledWith('0', newName)
       );
       await expectFileNameToBe(newName);
     });
 
     it('must have an extension', async () => {
       const newName = 'newname';
-      const { props } = renderFileNode('file');
+      renderFileNode('file');
 
       changeName(newName);
 
       await waitFor(() => expect(mockDispatch).not.toHaveBeenCalled());
-      await expectFileNameToBe(props.name);
+      await expectFileNameToBe('test.jsx');
     });
 
     it('can change to a different extension', async () => {
@@ -119,58 +111,58 @@ describe('<FileNode />', () => {
       window.confirm = mockConfirm;
 
       const newName = 'newname.gif';
-      const { props } = renderFileNode('file');
+      renderFileNode('file');
 
       changeName(newName);
 
       expect(mockConfirm).toHaveBeenCalled();
       await waitFor(() =>
-        expect(props.updateFileName).toHaveBeenCalledWith(props.id, newName)
+        expect(FileActions.updateFileName).toHaveBeenCalledWith('0', newName)
       );
       await expectFileNameToBe(newName);
     });
 
     it('cannot be just an extension', async () => {
       const newName = '.jsx';
-      const { props } = renderFileNode('file');
+      renderFileNode('file');
 
       changeName(newName);
 
       await waitFor(() => expect(mockDispatch).not.toHaveBeenCalled());
-      await expectFileNameToBe(props.name);
+      await expectFileNameToBe('test.jsx');
     });
   });
 
   describe('fileType: folder', () => {
     it('cannot change to an empty name', async () => {
-      const { props } = renderFileNode('folder');
+      renderFileNode('folder');
 
       changeName('');
 
       await waitFor(() => expect(mockDispatch).not.toHaveBeenCalled());
-      await expectFileNameToBe(props.name);
+      await expectFileNameToBe('afolder');
     });
 
     it('can change to another name', async () => {
       const newName = 'foldername';
-      const { props } = renderFileNode('folder');
+      renderFileNode('folder');
 
       changeName(newName);
 
       await waitFor(() =>
-        expect(props.updateFileName).toHaveBeenCalledWith(props.id, newName)
+        expect(FileActions.updateFileName).toHaveBeenCalledWith('0', newName)
       );
       await expectFileNameToBe(newName);
     });
 
     it('cannot have a file extension', async () => {
       const newName = 'foldername.jsx';
-      const { props } = renderFileNode('folder');
+      renderFileNode('folder');
 
       changeName(newName);
 
       await waitFor(() => expect(mockDispatch).not.toHaveBeenCalled());
-      await expectFileNameToBe(props.name);
+      await expectFileNameToBe('afolder');
     });
   });
 });

--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -13,7 +13,7 @@ import {
 import { selectRootFile } from '../selectors/files';
 import { getAuthenticated, selectCanEditSketch } from '../selectors/users';
 
-import ConnectedFileNode from './FileNode';
+import FileNode from './FileNode';
 import { PlusIcon } from '../../../common/icons';
 import { FileDrawer } from './Editor/MobileEditor';
 
@@ -130,7 +130,7 @@ export default function SideBar() {
             </ul>
           </div>
         </header>
-        <ConnectedFileNode id={rootFile.id} canEdit={canEditProject} />
+        <FileNode id={rootFile.id} canEdit={canEditProject} />
       </section>
     </FileDrawer>
   );

--- a/client/modules/IDE/utils/parseFileName.js
+++ b/client/modules/IDE/utils/parseFileName.js
@@ -1,0 +1,28 @@
+function parseFileName(name) {
+  const nameArray = name.split('.');
+  if (nameArray.length > 1) {
+    const extension = `.${nameArray[nameArray.length - 1]}`;
+    const baseName = nameArray.slice(0, -1).join('.');
+    const firstLetter = baseName[0];
+    const lastLetter = baseName[baseName.length - 1];
+    const middleText = baseName.slice(1, -1);
+    return {
+      baseName,
+      firstLetter,
+      lastLetter,
+      middleText,
+      extension
+    };
+  }
+  const firstLetter = name[0];
+  const lastLetter = name[name.length - 1];
+  const middleText = name.slice(1, -1);
+  return {
+    baseName: name,
+    firstLetter,
+    lastLetter,
+    middleText
+  };
+}
+
+export default parseFileName;


### PR DESCRIPTION
Changes:
- fixes missing `dispatch()` in `ConsoleInput.jsx`
- continues refactoring `FileNode.jsx` to potentially address reported issue with opening the dropdown actions in the File Navigation, larger changes include using hooks instead of `connect()`

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
