### PR TITLE
Fix editor accessibility test

### DIFF
--- a/client/modules/IDE/components/EditorAccessibility.unit.test.jsx
+++ b/client/modules/IDE/components/EditorAccessibility.unit.test.jsx
@@ -8,11 +8,7 @@ describe('<EditorAccessibility />', () => {
   it('renders empty message with no lines', () => {
     render(<EditorAccessibility lintMessages={[]} currentLine={0} />);
 
-    expect(
-      screen.getByRole('listitem', {
-        description: 'There are no lint messages'
-      })
-    ).toBeInTheDocument();
+    expect(screen.getByText(/there are no lint messages/i)).toBeInTheDocument();
   });
 
   it('renders lint message', () => {


### PR DESCRIPTION
Fixes the editor accessibility issue that appears to happen on the develop branch:
```
 FAIL  client/modules/IDE/components/EditorAccessibility.unit.test.jsx
  ● <EditorAccessibility /> › renders empty message with no lines

    TestingLibraryElementError: Unable to find an accessible element with the role "listitem" and description "There are no lint messages"
```

Changes: The issue (not sure when it was first introduced) is that the "there are no lint messages" list item element does not have an aria-describedby attribute so the original method of fetching by role and description does not actually detect what it's looking for. This switches the test to look for the string instead.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
