### PR TITLE
Fixed a comment typo in custom-hooks.js

### DIFF
--- a/client/modules/IDE/hooks/custom-hooks.js
+++ b/client/modules/IDE/hooks/custom-hooks.js
@@ -47,8 +47,8 @@ export const useModalBehavior = (hideOverlay) => {
 };
 
 // Usage: useEffectWithComparison((props, prevProps) => { ... }, { prop1, prop2 })
-// This hook basically applies useEffect but keeping track of the last value of relevant props
-// So you can passa a 2-param function to capture new and old values and do whatever with them.
+// This hook basically applies useEffect but keeps track of the last value of relevant props
+// So you can pass a 2-param function to capture new and old values and do whatever with them.
 export const useEffectWithComparison = (fn, props) => {
   const [prevProps, update] = useState({});
 


### PR DESCRIPTION
It does not fix any issue, rather just a typo in a comment made in custom-hooks.js