### PR TITLE
Fix: Close file options drowndown when clicking outside (Issue #3332)

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -292,6 +292,7 @@ const FileNode = ({
             ref={fileOptionsRef}
             tabIndex="0"
             onClick={toggleFileOptions}
+            onBlur={() => setTimeout(hideFileOptions, 200)}
           >
             <DownArrowIcon focusable="false" aria-hidden="true" />
           </button>


### PR DESCRIPTION
Fixes #3332 

Changes: In the file named FileNode.jsx, I have updated the following button component:
<button
            className="sidebar__file-item-show-options"
            aria-label={t('FileNode.ToggleFileOptionsARIA')}
            ref={fileOptionsRef}
            tabIndex="0"
            onClick={toggleFileOptions}
            onBlur={() => setTimeout(hideFileOptions, 200)}
          >
            <DownArrowIcon focusable="false" aria-hidden="true" />
          </button>

The change is the addition of the line: onBlur={() => setTimeout(hideFileOptions, 200)}

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
