### PR TITLE
FIX : Unable to Create Files or Folders Through the File Actions Modal

### DIFF
--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -91,7 +91,7 @@ export default function SideBar() {
             <ul className="sidebar__project-options">
               <li>
                 <button
-                  onMouseDown={(e) => e.preventDefault()} // prevents triggering the blur event before onClick
+                  onMouseDown={(e) => e.preventDefault()}
                   aria-label={t('Sidebar.AddFolderARIA')}
                   onClick={() => {
                     dispatch(newFolder(rootFile.id));
@@ -104,7 +104,7 @@ export default function SideBar() {
               </li>
               <li>
                 <button
-                  onMouseDown={(e) => e.preventDefault()} // prevents triggering the blur event before onClick
+                  onMouseDown={(e) => e.preventDefault()}
                   aria-label={t('Sidebar.AddFileARIA')}
                   onClick={() => {
                     dispatch(newFile(rootFile.id));
@@ -118,7 +118,7 @@ export default function SideBar() {
               {isAuthenticated && (
                 <li>
                   <button
-                    onMouseDown={(e) => e.preventDefault()} // prevents triggering the blur event before onClick
+                    onMouseDown={(e) => e.preventDefault()}
                     aria-label={t('Sidebar.UploadFileARIA')}
                     onClick={() => {
                       dispatch(openUploadFileModal(rootFile.id));

--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -91,6 +91,7 @@ export default function SideBar() {
             <ul className="sidebar__project-options">
               <li>
                 <button
+                  onMouseDown={(e) => e.preventDefault()} // prevents triggering the blur event before onClick
                   aria-label={t('Sidebar.AddFolderARIA')}
                   onClick={() => {
                     dispatch(newFolder(rootFile.id));
@@ -103,6 +104,7 @@ export default function SideBar() {
               </li>
               <li>
                 <button
+                  onMouseDown={(e) => e.preventDefault()} // prevents triggering the blur event before onClick
                   aria-label={t('Sidebar.AddFileARIA')}
                   onClick={() => {
                     dispatch(newFile(rootFile.id));

--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -118,6 +118,7 @@ export default function SideBar() {
               {isAuthenticated && (
                 <li>
                   <button
+                    onMouseDown={(e) => e.preventDefault()} // prevents triggering the blur event before onClick
                     aria-label={t('Sidebar.UploadFileARIA')}
                     onClick={() => {
                       dispatch(openUploadFileModal(rootFile.id));


### PR DESCRIPTION
Fixes #3329

**PROBLEM:**
The problem that was occurring was when clicking on Add button in Sidebar -> and then TOUCH CLICKING "Add new file"/ "Add new folder" USING TOUCHPAD . The modal for creating new file or folder was not popping up.

When interacting with a button, events fire in this order:
onMouseDown → onMouseUp → onClick → onBlur

When we Click using mouse :- It directly triggers Onclick
When we use Touch: it triggers `onTouchStart` and `onTouchEnd`, which then polyfill to `onClick`.
But When we TOUCH CLICK USING MOUSEPAD: it triggers `onMouseDown`.

The default behavior of `onMouseDown ` is to shift focus as soon as possible. 
It doesn't wait for `onClick` to occur. 
Therefore directly executing `onBlur`.
And hence not opening the modal.

**SOLUTION:**
The most appropriate solution to this problem i found was:-
`onMouseDown={(e) => e.preventDefault()}` 
Basically, this removes the default focus shifting behavior of `onMouseDown`. 
And, 'waits' for `onClick` to execute.
After which, `onBlur ` is executed.
Therefore, it now adds a file or folder when Touch Clicking using touchpad.

Solution executed in file:-
In p5.js-web-editor\client\modules\IDE\components\Sidebar.jsx

I have verified that this pull request:

* [ ✔] has no linting errors (`npm run lint`)
* [✔ ] has no test errors (`npm run test`)
* [✔ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [✔] is descriptively named and links to an issue number, i.e. `Fixes #123`
