### PR TITLE
Solved issue #3329

### DIFF
--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -92,6 +92,7 @@ export default function SideBar() {
               <li>
                 <button
                   aria-label={t('Sidebar.AddFolderARIA')}
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
                     dispatch(newFolder(rootFile.id));
                     setTimeout(() => dispatch(closeProjectOptions()), 0);
@@ -104,6 +105,7 @@ export default function SideBar() {
               <li>
                 <button
                   aria-label={t('Sidebar.AddFileARIA')}
+                  onMouseDown={(e) => e.preventDefault()}
                   onClick={() => {
                     dispatch(newFile(rootFile.id));
                     setTimeout(() => dispatch(closeProjectOptions()), 0);
@@ -117,6 +119,7 @@ export default function SideBar() {
                 <li>
                   <button
                     aria-label={t('Sidebar.UploadFileARIA')}
+                    onMouseDown={(e) => e.preventDefault()}
                     onClick={() => {
                       dispatch(openUploadFileModal(rootFile.id));
                       setTimeout(() => dispatch(closeProjectOptions()), 0);

--- a/translations/locales/fr-CA/translations.json
+++ b/translations/locales/fr-CA/translations.json
@@ -68,7 +68,11 @@
       "UsernameOrEmailARIA": "Courriel ou nom d'utilisateur",
       "Password": "Mot de passe",
       "PasswordARIA": "Mot de passe",
-      "Submit": "Se connecter"
+      "Submit": "Se connecter",
+      "Errors": {
+      "invalidCredentials": "E-mail ou mot de passe invalide.",
+      "networkError": "Erreur réseau. Veuillez réessayer plus tard."
+    }
     },
     "LoginView": {
       "Title": "Editeur web p5.js | Se connecter",


### PR DESCRIPTION
Unable to Create Files or Folders Through the File Actions Modal - #3329

Fixes #3329 

Changes:
1. Added "onMouseDown={(e) => e.preventDefault()}" this line in all the three section :
   a. Add File
   b. Add Folder
   c. Upload File

2. This solves this issue.

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
