### PR TITLE
src button a file icon for a seemless experience.

### DIFF
--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -52,8 +52,6 @@ import * as hinter from '../../../../utils/p5-hinter';
 import '../../../../utils/codemirror-search';
 
 import beepUrl from '../../../../sounds/audioAlert.mp3';
-import RightArrowIcon from '../../../../images/right-arrow.svg';
-import LeftArrowIcon from '../../../../images/left-arrow.svg';
 import { getHTMLFile } from '../../reducers/files';
 import { selectActiveFile } from '../../selectors/files';
 
@@ -543,14 +541,20 @@ class Editor extends React.Component {
                     this.props.closeProjectOptions();
                   }}
                 >
-                  <LeftArrowIcon focusable="false" aria-hidden="true" />
+                  <IconButton
+                    onClick={this.props.expandSidebar}
+                    icon={FolderIcon}
+                  />{' '}
                 </button>
                 <button
                   aria-label={this.props.t('Editor.CloseSketchARIA')}
                   className="sidebar__expand"
                   onClick={this.props.expandSidebar}
                 >
-                  <RightArrowIcon focusable="false" aria-hidden="true" />
+                  <IconButton
+                    onClick={this.props.expandSidebar}
+                    icon={FolderIcon}
+                  />{' '}
                 </button>
                 <div className="editor__file-name">
                   <span>


### PR DESCRIPTION
I replaced the Left and Right Arrow Icons with a Folder Icon, ensuring consistency across different screen sizes. This update aligns the desktop view with the mobile view, making the UI more intuitive and uniform.

Fixes #issue-[2888](https://github.com/processing/p5.js-web-editor/issues/2888)

Changes Made:
✅ Removed the Left and Right Arrow Icons from the sidebar.
✅ Replaced them with the Folder Icon, as seen in the mobile view.
✅ Ensured visual consistency across different screen sizes.
✅ Verified that the new icon behaves as expected and does not break any functionality



I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
