### PR TITLE
Corrected the loadfont() issue #2750

### DIFF
--- a/client/modules/Preview/EmbedFrame.jsx
+++ b/client/modules/Preview/EmbedFrame.jsx
@@ -41,7 +41,22 @@ function resolvePathsForElementsWithAttribute(attr, sketchDoc, files) {
     if (element.getAttribute(attr).match(MEDIA_FILE_REGEX)) {
       const resolvedFile = resolvePathToFile(element.getAttribute(attr), files);
       if (resolvedFile && resolvedFile.url) {
+        // Set the resolved URL as the attribute value
         element.setAttribute(attr, resolvedFile.url);
+
+        // Extract the font name from the file name with multiple dots.
+        const fontName = resolvedFile.name.replace(/\.[^/.]+$/, '');
+        // Create a <style> element with the correct @font-face rule
+        const style = document.createElement('style');
+        style.innerHTML = `
+          @font-face {
+            font-family: "${fontName}";
+            src: url("${resolvedFile.url}");
+          }
+        `;
+
+        // Append the <style> element to the document head
+        document.head.appendChild(style);
       }
     }
   });


### PR DESCRIPTION
Fixes #2750 

Changes:
1. Updated the Embedframe.jsx as it is responsible for resolving file paths and managing assets.
Please See the Comment Section of this PR once.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
