### PR TITLE
Adding ShortCut Key 'Ctrl/Cmd+Alt+f' for newFolder

### DIFF
--- a/client/common/useKeyDownHandlers.js
+++ b/client/common/useKeyDownHandlers.js
@@ -41,6 +41,9 @@ export default function useKeyDownHandlers(keyHandlers) {
     } else if (isCtrl && e.altKey && e.code === 'KeyN') {
       // specifically for creating a new file
       handlers.current[`ctrl-alt-n`]?.(e);
+    } else if (isCtrl && e.altKey && e.code === 'KeyF') {
+      // specifically for creating a new folder
+      handlers.current[`ctrl-alt-f`]?.(e);
     } else if (isCtrl) {
       handlers.current[`ctrl-${e.key.toLowerCase()}`]?.(e);
     }

--- a/client/modules/IDE/components/Header/Nav.jsx
+++ b/client/modules/IDE/components/Header/Nav.jsx
@@ -139,6 +139,8 @@ const ProjectMenu = () => {
     metaKey === 'Ctrl' ? `${metaKeyName}+H` : `${metaKeyName}+⌥+F`;
   const newFileCommand =
     metaKey === 'Ctrl' ? `${metaKeyName}+Alt+N` : `${metaKeyName}+⌥+N`;
+  const newFolderCommand =
+    metaKey === 'Ctrl' ? `${metaKeyName}+Alt+F` : `${metaKeyName}+⌥+F`;
 
   return (
     <ul className="nav__items-left" role="menubar">
@@ -230,6 +232,7 @@ const ProjectMenu = () => {
         </MenubarItem>
         <MenubarItem onClick={() => dispatch(newFolder(rootFile.id))}>
           {t('Nav.Sketch.AddFolder')}
+          <span className="nav__keyboard-shortcut">{newFolderCommand}</span>
         </MenubarItem>
         <MenubarItem onClick={() => dispatch(startSketch())}>
           {t('Nav.Sketch.Run')}

--- a/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
+++ b/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
@@ -653,7 +653,7 @@ exports[`Nav renders editor version for desktop 1`] = `
                 role="menuitem"
               >
                 Add Folder
-                 <span
+                <span
                   class="nav__keyboard-shortcut"
                 >
                   Ctrl+Alt+F

--- a/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
+++ b/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
@@ -653,6 +653,11 @@ exports[`Nav renders editor version for desktop 1`] = `
                 role="menuitem"
               >
                 Add Folder
+                 <span
+                  class="nav__keyboard-shortcut"
+                >
+                  Ctrl+Alt+F
+                </span>
               </button>
             </li>
             <li

--- a/client/modules/IDE/components/IDEKeyHandlers.jsx
+++ b/client/modules/IDE/components/IDEKeyHandlers.jsx
@@ -9,7 +9,8 @@ import {
   showErrorModal,
   startSketch,
   stopSketch,
-  newFile
+  newFile,
+  newFolder
 } from '../actions/ide';
 import { setAllAccessibleOutput } from '../actions/preferences';
 import { cloneProject, saveProject } from '../actions/project';
@@ -81,6 +82,11 @@ export const useIDEKeyHandlers = ({ getContent }) => {
       e.preventDefault();
       e.stopPropagation();
       dispatch(newFile(rootFile.id));
+    },
+    'ctrl-alt-f': (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      dispatch(newFolder(rootFile.id));
     },
     'ctrl-`': (e) => {
       e.preventDefault();

--- a/client/modules/IDE/components/KeyboardShortcutModal.jsx
+++ b/client/modules/IDE/components/KeyboardShortcutModal.jsx
@@ -8,6 +8,8 @@ function KeyboardShortcutModal() {
     metaKey === 'Ctrl' ? `${metaKeyName} + H` : `${metaKeyName} + ⌥ + F`;
   const newFileCommand =
     metaKey === 'Ctrl' ? `${metaKeyName} + Alt + N` : `${metaKeyName} + ⌥ + N`;
+  const newFolderCommand =
+    metaKey === 'Ctrl' ? `${metaKeyName} + Alt + F` : `${metaKeyName} + ⌥ + F`;
   return (
     <div className="keyboard-shortcuts">
       <h3 className="keyboard-shortcuts__title">
@@ -74,6 +76,10 @@ function KeyboardShortcutModal() {
         <li className="keyboard-shortcut-item">
           <span className="keyboard-shortcut__command">{newFileCommand}</span>
           <span>{t('KeyboardShortcuts.CodeEditing.CreateNewFile')}</span>
+        </li>
+        <li className="keyboard-shortcut-item">
+          <span className="keyboard-shortcut__command">{newFolderCommand}</span>
+          <span>{t('KeyboardShortcuts.CodeEditing.CreateNewFolder')}</span>
         </li>
       </ul>
       <h3 className="keyboard-shortcuts__title">General</h3>

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -228,7 +228,8 @@
       "FindPreviousTextMatch": "Find Previous Text Match",
       "CodeEditing": "Code Editing",
       "ColorPicker": "Show Inline Color Picker",
-      "CreateNewFile": "Create New File"
+      "CreateNewFile": "Create New File",
+      "CreateNewFolder": "Create New Folder"
     },
     "General": {
       "StartSketch": "Start Sketch",


### PR DESCRIPTION
- Fixes #3376 

Changes:

https://github.com/user-attachments/assets/a8772775-f19e-44ba-a28c-899099f34858




I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
