### PR TITLE
Fix iframe scroll bars and added expand button for p5.js sketches

### DIFF
--- a/client/modules/Preview/EmbedFrame.jsx
+++ b/client/modules/Preview/EmbedFrame.jsx
@@ -314,13 +314,50 @@ function EmbedFrame({ files, isPlaying, basePath, gridOutput, textOutput }) {
 
   useEffect(renderSketch, [files, isPlaying]);
   return (
-    <Frame
-      aria-label="Sketch Preview"
-      role="main"
-      frameBorder="0"
-      ref={iframe}
-    />
+    <div style={{ position: "relative" }}>
+      {/* Expand Button */}
+      <button
+        onClick={() => {
+          if (iframe.current.style.width === "100vw") {
+            // Minimize
+            iframe.current.style.width = "600px";
+            iframe.current.style.height = "400px";
+            iframe.current.style.position = "static";
+          } else {
+            // Expand to full screen
+            iframe.current.style.width = "100vw";
+            iframe.current.style.height = "100vh";
+            iframe.current.style.position = "fixed";
+            iframe.current.style.top = "0";
+            iframe.current.style.left = "0";
+          }
+        }}
+        style={{
+          position: "absolute",
+          top: "5px",
+          right: "5px",
+          zIndex: 1000,
+          padding: "5px 10px",
+          background: "#333",
+          color: "#fff",
+          border: "none",
+          cursor: "pointer",
+        }}
+      >
+        Expand
+      </button>
+
+      {/* Sketch Preview */}
+      <Frame
+        aria-label="Sketch Preview"
+        role="main"
+        frameBorder="0"
+        ref={iframe}
+        style={{ overflow: "hidden", width: "100%", height: "100%" }}
+      />
+    </div>
   );
+
 }
 
 EmbedFrame.propTypes = {


### PR DESCRIPTION
Fixes [#7620](https://github.com/processing/p5.js/issues/7620)

Changes:
Updated EmbedFrame.jsx to hide unwanted scroll bars.
Ensured the iframe properly scales within the container.
Added an "Expand" button that allows toggling between default size and full screen mode.

I have verified that this pull request:

* [✅ ] has no linting errors (`npm run lint`)
* [✅ ] has no test errors (`npm run test`)
* [ ✅] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ✅] is descriptively named and links to an issue number, i.e. `Fixes #123`
