### PR TITLE
Toast notifications now announced properly by screen reader

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -174,15 +174,15 @@ export function saveProject(
           dispatch(projectSaveSuccess());
           if (!autosave) {
             if (state.ide.justOpenedProject && state.preferences.autosave) {
-              dispatch(showToast(5500));
+              dispatch(showToast(12000));
               dispatch(setToastText('Toast.SketchSaved'));
               setTimeout(
                 () => dispatch(setToastText('Toast.AutosaveEnabled')),
-                1500
+                60000
               );
               dispatch(resetJustOpenedProject());
             } else {
-              dispatch(showToast(1500));
+              dispatch(showToast(6000));
               dispatch(setToastText('Toast.SketchSaved'));
             }
           }
@@ -224,15 +224,15 @@ export function saveProject(
         dispatch(projectSaveSuccess());
         if (!autosave) {
           if (state.preferences.autosave) {
-            dispatch(showToast(5500));
+            dispatch(showToast(12000));
             dispatch(setToastText('Toast.SketchSaved'));
             setTimeout(
               () => dispatch(setToastText('Toast.AutosaveEnabled')),
-              1500
+              6000
             );
             dispatch(resetJustOpenedProject());
           } else {
-            dispatch(showToast(1500));
+            dispatch(showToast(6000));
             dispatch(setToastText('Toast.SketchSaved'));
           }
         }

--- a/client/modules/IDE/actions/toast.js
+++ b/client/modules/IDE/actions/toast.js
@@ -10,12 +10,12 @@ export function hideToast() {
  * Temporary fix until #2206 is merged.
  * Supports legacy two-action syntax:
  *    dispatch(setToastText('Toast.SketchFailedSave'));
- *    dispatch(showToast(1500));
+ *    dispatch(showToast(6000));
  * And also supports proposed single-action syntax with message and optional timeout.
  *    dispatch(showToast('Toast.SketchFailedSave'));
- *    dispatch(showToast('Toast.SketchSaved', 5500));
+ *    dispatch(showToast('Toast.SketchSaved', 6000));
  */
-export function showToast(textOrTime, timeout = 1500) {
+export function showToast(textOrTime, timeout = 6000) {
   return (dispatch) => {
     let time = timeout;
     if (typeof textOrTime === 'string') {

--- a/client/modules/IDE/components/Toast.jsx
+++ b/client/modules/IDE/components/Toast.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useTranslation } from 'react-i18next';
 import { hideToast } from '../actions/toast';
@@ -9,19 +9,40 @@ export default function Toast() {
   const { text, isVisible } = useSelector((state) => state.toast);
   const dispatch = useDispatch();
   const { t } = useTranslation();
+
+  useEffect(() => {
+    if (isVisible) {
+      const liveRegion = document.getElementById('toast-live-region');
+      if (liveRegion) {
+        liveRegion.textContent = t(text); // Update live region globally
+      }
+    }
+  }, [isVisible, text, t]);
+
   if (!isVisible) {
     return null;
   }
+
   return (
-    <section className="toast" role="status" aria-live="polite">
-      <p>{t(text)}</p>
-      <button
-        className="toast__close"
-        onClick={() => dispatch(hideToast())}
-        aria-label="Close Alert"
-      >
-        <ExitIcon focusable="false" aria-hidden="true" />
-      </button>
-    </section>
+    <>
+      {/* Global ARIA Live Region */}
+      <div
+        id="toast-live-region"
+        aria-live="assertive"
+        style={{ position: 'absolute', left: '-9999px' }}
+      />
+
+      {/* Toast UI */}
+      <section className="toast" role="status">
+        <p>{t(text)}</p>
+        <button
+          className="toast__close"
+          onClick={() => dispatch(hideToast())}
+          aria-label="Close Alert"
+        >
+          <ExitIcon focusable="false" aria-hidden="true" />
+        </button>
+      </section>
+    </>
   );
 }

--- a/client/modules/IDE/components/Toast.jsx
+++ b/client/modules/IDE/components/Toast.jsx
@@ -28,7 +28,7 @@ export default function Toast() {
       {/* Global ARIA Live Region */}
       <div
         id="toast-live-region"
-        aria-live="assertive"
+        aria-live="polite"
         style={{ position: 'absolute', left: '-9999px' }}
       />
 


### PR DESCRIPTION
Fixes #3382

Changes:
1. I updated the time limit for both toast notifications ("Sketch Saved" and "AutoSave Enabled"). Earlier, the "Sketch Saved" notification used to disappear very quickly, within just 2-3 seconds. Now, both notifications remain visible for 10-12 seconds.

2. I added an ARIA live region with the status set to "assertive", ensuring that as soon as a toast notification appears, screen readers announce it immediately.


https://github.com/user-attachments/assets/664f4a3d-4d4f-4395-9764-69513cc9d7c2

This video shows the duration for which the "Sketch Saved" and "AutoSave Enabled" notifications remain visible on the screen.

<img width="639" alt="Screenshot 2025-03-13 at 4 21 19 PM" src="https://github.com/user-attachments/assets/09a70271-c1dc-4ed1-9135-a48382229a41" />

This image shows the announcement made by the screen reader.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
