### PR TITLE
Enhance hover effect on console Clear button  #2592

### DIFF
--- a/client/styles/components/_console.scss
+++ b/client/styles/components/_console.scss
@@ -86,19 +86,23 @@
 
 .preview-console__clear {
 	@include themify() {
-		@extend %link;
-		color: getThemifyVariable('secondary-text-color');
-		&:hover {
-			color: $p5-light-pink; // Use the pink color directly for hover
+	  @extend %link;
+	  color: getThemifyVariable('secondary-text-color');
+	  &:hover {
+		color: $p5-light-pink; 
+  
+		@if (getThemifyVariable('logo-color') == $yellow) {
+		  color: $yellow; 
 		}
+	  }
 	}
 	background: transparent;
 	border: none;
 	padding-right: #{math.div(10, $base-font-size)}rem;
 	.preview-console--collapsed & {
-		display: none;
+	  display: none;
 	}
-}
+  }
 
 .preview-console__body {
 	display: flex;

--- a/client/styles/components/_console.scss
+++ b/client/styles/components/_console.scss
@@ -86,17 +86,20 @@
 
 .preview-console__clear {
 	@include themify() {
-	@extend %link;
-	color: getThemifyVariable('secondary-text-color');
-	&:hover {
-	    color: getThemifyVariable('logo-color');
-	  }
+		@extend %link;
+		color: getThemifyVariable('secondary-text-color');
+
+		&:hover {
+			color: getThemifyVariable('logo-color');
+		}
 	}
+
 	background: transparent;
 	border: none;
 	padding-right: #{math.div(10, $base-font-size)}rem;
+
 	.preview-console--collapsed & {
-	display: none;
+		display: none;
 	}
 }
 

--- a/client/styles/components/_console.scss
+++ b/client/styles/components/_console.scss
@@ -88,16 +88,13 @@
 	@include themify() {
 		@extend %link;
 		color: getThemifyVariable('secondary-text-color');
-
 		&:hover {
 			color: getThemifyVariable('logo-color');
 		}
 	}
-
 	background: transparent;
 	border: none;
 	padding-right: #{math.div(10, $base-font-size)}rem;
-
 	.preview-console--collapsed & {
 		display: none;
 	}

--- a/client/styles/components/_console.scss
+++ b/client/styles/components/_console.scss
@@ -89,7 +89,7 @@
 		@extend %link;
 		color: getThemifyVariable('secondary-text-color');
 		&:hover {
-			color: getThemifyVariable('heavy-text-color');
+			color: $p5-light-pink; // Use the pink color directly for hover
 		}
 	}
 	background: transparent;

--- a/client/styles/components/_console.scss
+++ b/client/styles/components/_console.scss
@@ -86,10 +86,10 @@
 
 .preview-console__clear {
 	@include themify() {
-	  @extend %link;
-	  color: getThemifyVariable('secondary-text-color');
-	  &:hover {
-		color: getThemifyVariable('logo-color');
+	@extend %link;
+	color: getThemifyVariable('secondary-text-color');
+	&:hover {
+	    color: getThemifyVariable('logo-color');
 	  }
 	}
 	background: transparent;

--- a/client/styles/components/_console.scss
+++ b/client/styles/components/_console.scss
@@ -89,20 +89,16 @@
 	  @extend %link;
 	  color: getThemifyVariable('secondary-text-color');
 	  &:hover {
-		color: $p5-light-pink; 
-  
-		@if (getThemifyVariable('logo-color') == $yellow) {
-		  color: $yellow; 
-		}
+		color: getThemifyVariable('logo-color');
 	  }
 	}
 	background: transparent;
 	border: none;
 	padding-right: #{math.div(10, $base-font-size)}rem;
 	.preview-console--collapsed & {
-	  display: none;
+	display: none;
 	}
-  }
+}
 
 .preview-console__body {
 	display: flex;


### PR DESCRIPTION
Fixes #2592 

Changes:

1. Updated the colour of the hover effect for the Clear button in the console in _console.scss file.
2. The colour is mentioned in the theme file for all the 3 (Light , Dark and High contrast themes).

For Light Mode :
<img width="1504" alt="Light mode" src="https://github.com/user-attachments/assets/998a1b71-7c3e-47ce-8587-be4d4ac83034" />

For Dark Mode : 
<img width="1500" alt="Dark mode" src="https://github.com/user-attachments/assets/2aeb9c58-8120-46cd-9969-6de24d536061" />

For High-Contrast Mode : 
<img width="1505" alt="High-Contrast Mode" src="https://github.com/user-attachments/assets/119761d8-d40e-4c80-9491-203b1a002358" />


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

