### PR TITLE
Enhanced AutoComplete Hinter

### DIFF
--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -454,10 +454,30 @@ class Editor extends React.Component {
             .search(token.string)
             .filter((h) => h.item.text[0] === token.string[0]);
 
+          if (hints.length === 0) {
+            return {
+              list: [
+                {
+                  text: 'No results found',
+                  render: (element) => {
+                    element.textContent = 'No results found';
+                    element.style.backgroundColor = 'grey'; // White background
+                    element.style.color = 'white'; // Black text
+                    element.style.padding = '5px 10px'; // Add padding
+                    element.style.fontSize = '14px'; // Adjust font size
+                  }
+                }
+              ],
+              from: CodeMirror.Pos(c.line, token.start),
+              to: CodeMirror.Pos(c.line, c.ch),
+              selectedHint: 0
+            };
+          }
           return {
             list: hints,
             from: CodeMirror.Pos(c.line, token.start),
-            to: CodeMirror.Pos(c.line, c.ch)
+            to: CodeMirror.Pos(c.line, c.ch),
+            selectedHint: 0
           };
         },
         hintOptions

--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -461,10 +461,10 @@ class Editor extends React.Component {
                   text: 'No results found',
                   render: (element) => {
                     element.textContent = 'No results found';
-                    element.style.backgroundColor = 'grey'; // White background
-                    element.style.color = 'white'; // Black text
-                    element.style.padding = '5px 10px'; // Add padding
-                    element.style.fontSize = '14px'; // Adjust font size
+                    element.style.backgroundColor = 'grey';
+                    element.style.color = 'white';
+                    element.style.padding = '5px 10px';
+                    element.style.fontSize = '14px';
                   }
                 }
               ],


### PR DESCRIPTION
Fixes #3078 

Changes:

1. In this PR, I have enhanced the autocomplete hinter feature. Previously, when no hints were available, it displayed an empty list. Now, I have ensured that the "No results found" message is displayed correctly when no hints are available.

<img width="1502" alt="Screenshot 2025-03-18 at 12 01 26 AM" src="https://github.com/user-attachments/assets/3026220c-0a7e-4698-b03a-bb9fc0418f6d" />
This image shows the Correct implementation of the "No Results Found".

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
