### PR TITLE
fixing Search Auto-Update After Content Changes Dynamically

### DIFF
--- a/client/utils/codemirror-search.js
+++ b/client/utils/codemirror-search.js
@@ -515,6 +515,12 @@ function doSearch(cm, rev, persistent, immediate, ignoreQuery) {
       startSearch(cm, state, q);
       findNext(cm, rev);
     }
+    cm.on('change', function () {
+      var state = getSearchState(cm);
+      if (state.query) {
+        startSearch(cm, state, state.queryText);
+      }
+    });
   } else {
     dialog(cm, queryDialog, 'Search for:', q, function (query) {
       if (query && !state.query)


### PR DESCRIPTION
This PR fixes an issue where the search match counter does not update dynamically when content is modified.

Fixes #3405 

Changes:
Add a change event listener to detect content modifications and restart the search

https://github.com/user-attachments/assets/b3b4b4f1-a121-436e-bce5-7b210b584134



* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
