### PR TITLE
Added RTF Copy and Cut Feature

### DIFF
--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -184,21 +184,22 @@ class Editor extends React.Component {
       [`${metaKey}-.`]: 'toggleComment' // Note: most adblockers use the shortcut ctrl+.
     });
 
-
     const rtfCopy = (_cm, e) => {
       e.preventDefault();
       const plaintext = _cm.doc.getSelection();
       const selectedElementsArr = document.getElementsByClassName(
         'CodeMirror-selectedtext'
       );
-
       let richText = plaintext[0] === '\n' ? '</br>' : '';
       let plaintextcounter = plaintext[0] === '\n' ? 1 : 0;
       for (let i = 0; i < selectedElementsArr.length; i += 1) {
-        const { color, fontWeight, fontSize } = window.getComputedStyle(
-          selectedElementsArr[i]
-        );
-        const cssToken = `color: ${color}; font-weight: ${fontWeight}; font-size: ${fontSize}`;
+        const {
+          color,
+          fontWeight,
+          fontSize,
+          fontFamily
+        } = window.getComputedStyle(selectedElementsArr[i]);
+        const cssToken = `color: ${color}; font-weight: ${fontWeight}; font-size: ${fontSize}; font-family: ${fontFamily}`;
         richText += `<span style='${cssToken}'>${selectedElementsArr[i].textContent}</span>`;
         plaintextcounter += selectedElementsArr[i].textContent.length;
         while (
@@ -237,7 +238,6 @@ class Editor extends React.Component {
     if (this._cm) {
       this._cm.on('keyup', this.handleKeyUp);
     }
-
 
     this._cm.on('copy', rtfCopy);
     this._cm.on('cut', (_em, e) => {

--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -184,6 +184,40 @@ class Editor extends React.Component {
       [`${metaKey}-.`]: 'toggleComment' // Note: most adblockers use the shortcut ctrl+.
     });
 
+
+    const rtfCopy = (_cm, e) => {
+      e.preventDefault();
+      const plaintext = _cm.doc.getSelection();
+      const selectedElementsArr = document.getElementsByClassName(
+        'CodeMirror-selectedtext'
+      );
+
+      let richText = plaintext[0] === '\n' ? '</br>' : '';
+      let plaintextcounter = plaintext[0] === '\n' ? 1 : 0;
+      for (let i = 0; i < selectedElementsArr.length; i += 1) {
+        const { color, fontWeight, fontSize } = window.getComputedStyle(
+          selectedElementsArr[i]
+        );
+        const cssToken = `color: ${color}; font-weight: ${fontWeight}; font-size: ${fontSize}`;
+        richText += `<span style='${cssToken}'>${selectedElementsArr[i].textContent}</span>`;
+        plaintextcounter += selectedElementsArr[i].textContent.length;
+        while (
+          plaintextcounter < plaintext.length &&
+          plaintext[plaintextcounter] === '\n'
+        ) {
+          richText += '<br/>';
+          plaintextcounter += 1;
+        }
+      }
+
+      try {
+        e.clipboardData.setData('text/html', richText);
+        e.clipboardData.setData('text/plain', plaintext);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+
     this.initializeDocuments(this.props.files);
     this._cm.swapDoc(this._docs[this.props.file.id]);
 
@@ -204,6 +238,12 @@ class Editor extends React.Component {
       this._cm.on('keyup', this.handleKeyUp);
     }
 
+
+    this._cm.on('copy', rtfCopy);
+    this._cm.on('cut', (_em, e) => {
+      rtfCopy(_em, e);
+      _em.replaceSelection('');
+    });
 
     this._cm.on('keydown', (_cm, e) => {
       // Show hint

--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -204,6 +204,7 @@ class Editor extends React.Component {
       this._cm.on('keyup', this.handleKeyUp);
     }
 
+
     this._cm.on('keydown', (_cm, e) => {
       // Show hint
       const mode = this._cm.getOption('mode');


### PR DESCRIPTION
Fixes #445 

### Changes Made:

Added event listeners for copy and cut to support RTF (Rich Text Format) when copying text.
Implemented functionality based on a previous PR, but now utilizing the Copy and Cut events provided by CodeMirror.

### Functionality:

The implemented solution works with:
✅ Keyboard Shortcuts: Ctrl + C (Copy) and Ctrl + X (Cut).
✅ Copy option via Context Menu.


I have verified that this pull request:

* [✅] has no linting errors (`npm run lint`)
* [✅] has no test errors (`npm run test`)
* [✅] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [✅] is descriptively named and links to an issue number, i.e. `Fixes #445 `

This is my first contribution to Open Source, and I appreciate any feedback or suggestions for improvement.