### PR TITLE
Fix background color issue on hover for sketch name by username #2676

### DIFF
--- a/client/modules/IDE/components/Header/Toolbar.jsx
+++ b/client/modules/IDE/components/Header/Toolbar.jsx
@@ -61,7 +61,6 @@ const Toolbar = (props) => {
       </button>
       <button
         className={playButtonClass}
-        id="play-sketch"
         onClick={() => {
           props.syncFileContent();
           dispatch(startSketch());
@@ -104,7 +103,10 @@ const Toolbar = (props) => {
             return (
               <p className="toolbar__project-project.owner">
                 {t('Toolbar.By')}{' '}
-                <Link to={`/${project.owner.username}/sketches`}>
+                <Link
+                  className="toolbar__username"
+                  to={`/${project.owner.username}/sketches`}
+                >
                   {project.owner.username}
                 </Link>
               </p>

--- a/client/styles/components/_toolbar.scss
+++ b/client/styles/components/_toolbar.scss
@@ -126,6 +126,23 @@
 	}
 }
 
+.toolbar__username {
+	cursor: pointer;
+	@include themify() {
+	  color: getThemifyVariable('secondary-text-color');
+	  
+	  &:hover {
+		// Default hover color for light/dark theme
+		color: $p5-light-pink;
+  
+		// If the logo color is yellow, override the hover color
+		@if (getThemifyVariable('logo-color') == $yellow) {
+		  color: $yellow;
+		}
+	  }
+	}
+  }
+
 .toolbar__autorefresh-label {
 	cursor: pointer;
 	@include themify() {


### PR DESCRIPTION
Fixes #2676 

Changes:
1. I have updated the classname and the SCSS file to resolve this issue.

Here is a video with the required changes :

https://github.com/user-attachments/assets/1deffb41-c223-4d34-9bee-b03423d7abda



I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
