### PR TITLE
Fix: Use Title Case for Settings Modal Tab Titles

### DIFF
--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -169,7 +169,7 @@
   },
   "Preferences": {
     "Settings": "Settings",
-    "GeneralSettings": "General settings",
+    "GeneralSettings": "General Settings",
     "Accessibility": "Accessibility",
     "Theme": "Theme",
     "LightTheme": "Light",


### PR DESCRIPTION
Fixes #3415

Updated tab titles in the settings modal to follow title case.

Changed from "General settings" → "General Settings".