### PR TITLE
Add margin-left to sort button in sketches page

### DIFF
--- a/client/styles/components/_sketch-list.scss
+++ b/client/styles/components/_sketch-list.scss
@@ -101,6 +101,7 @@
   }
 
   & svg {
+    margin-left: #{math.div(5, $base-font-size)}rem;
     @include themify() {
       fill: getThemifyVariable("inactive-text-color");
     }


### PR DESCRIPTION
Fixes #3432

Changes:
Added `margin-left: #{math.div(5, $base-font-size)}rem;` to `.sketch-list__sort-button svg` in _sketch-list.scss for better spacing of the sort button on the 'Sketches' page.

<img width="1027" alt="sort-button" src="https://github.com/user-attachments/assets/964ac20d-9d0b-4626-8cb1-276b59f17fbe" />

\
This ensures consistency with the existing code in _nav.scss, where the same margin is applied to `.nav__item-header-triangle` on the 'Editor' page.
\
I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [X] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`
