### PR TITLE
[#3434] Remove left padding on overlay close button

### DIFF
--- a/client/styles/components/_overlay.scss
+++ b/client/styles/components/_overlay.scss
@@ -61,7 +61,7 @@
 
 .overlay__close-button {
   @include icon();
-  padding: #{math.div(3, $base-font-size)}rem 0 #{math.div(3, $base-font-size)}rem #{math.div(10, $base-font-size)}rem;
+  padding: #{math.div(3, $base-font-size)}rem 0 #{math.div(3, $base-font-size)}rem;
 }
 
 /* Fixed height overlay */


### PR DESCRIPTION
Adjusted the CSS to remove the extra left padding on the close button. This ensures that the active box is centered around the 'X' when clicked.

- Removed left padding value from the padding property
- Verified alignment in both desktop and responsive view

Fixes #3434  

Changes:

I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] has no test errors (`npm run test`)
* [X] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`
