### PR TITLE
Fix close button active box misalignment

### DIFF
--- a/client/styles/components/_overlay.scss
+++ b/client/styles/components/_overlay.scss
@@ -62,6 +62,10 @@
 .overlay__close-button {
   @include icon();
   padding: #{math.div(3, $base-font-size)}rem 0 #{math.div(3, $base-font-size)}rem #{math.div(10, $base-font-size)}rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 8px;
 }
 
 /* Fixed height overlay */


### PR DESCRIPTION
Fixes #3434 

Changes:

- Add the css in `client/styles/components/_overlay.scss` to center the `svg` inside button

| Before | After |
|--------|--------|
|  ![before](https://github.com/user-attachments/assets/d43a3939-15e3-4892-ac0b-1988df82d9a4) | ![after](https://github.com/user-attachments/assets/043f7a15-9c29-42ba-a847-d0b23012aa4c) | 

This also ensures that the all other places (such as share overlay) where close button is used is also fixed.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
