### PR TITLE
temporarily point to 1.11.3, add 1.11.5

### DIFF
--- a/client/modules/IDE/hooks/useP5Version.jsx
+++ b/client/modules/IDE/hooks/useP5Version.jsx
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
 // TODO: use their API for this to grab these at build time?
 export const p5Versions = [
   '2.0.0',
+  '1.11.5',
   '1.11.4',
   '1.11.3',
   '1.11.2',
@@ -135,7 +136,7 @@ export const p5Versions = [
   '0.2.1'
 ];
 
-export const currentP5Version = '1.11.4'; // Don't update to 2.x until 2026
+export const currentP5Version = '1.11.3'; // Don't update to 2.x until 2026
 
 export const p5SoundURLOld = `https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/addons/p5.sound.min.js`;
 export const p5SoundURL =

--- a/server/domain-objects/createDefaultFiles.js
+++ b/server/domain-objects/createDefaultFiles.js
@@ -9,8 +9,8 @@ function draw() {
 export const defaultHTML = `<!DOCTYPE html>
 <html lang="en">
   <head>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.4/p5.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.4/addons/p5.sound.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/addons/p5.sound.min.js"></script>
     <link rel="stylesheet" type="text/css" href="style.css">
     <meta charset="utf-8" />
 


### PR DESCRIPTION
Changes:
- Adds in p5.js version `1.11.5` in the `usep5Version` hook
- Temporarily points to version `1.11.3` since the current version, `1.11.4`, is breaking the default sketch

Hi @ksen0! I'm noticing that the minified files for the p5.js version [`1.11.4`](https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.4/p5.js) and [`1.11.5`](https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.5/p5.js) on the p5.js editor `index.html` file are pointing to dead links, so I'm going to temporarily revert it to `1.11.3` for now just to have the default sketches running!

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
