### PR TITLE
Use jsdelivr as a CDN to fix broken links

### DIFF
--- a/client/modules/IDE/hooks/useP5Version.jsx
+++ b/client/modules/IDE/hooks/useP5Version.jsx
@@ -136,7 +136,7 @@ export const p5Versions = [
   '0.2.1'
 ];
 
-export const currentP5Version = '1.11.3'; // Don't update to 2.x until 2026
+export const currentP5Version = '1.11.5'; // Don't update to 2.x until 2026
 
 export const p5SoundURLOld = `https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/addons/p5.sound.min.js`;
 export const p5SoundURL =
@@ -147,7 +147,7 @@ export const p5ShapesAddonURL =
   'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/shapes.js';
 export const p5DataAddonURL =
   'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/data.js';
-export const p5URL = `https://cdnjs.cloudflare.com/ajax/libs/p5.js/${currentP5Version}/p5.js`;
+export const p5URL = `https://cdn.jsdelivr.net/npm/p5@${currentP5Version}/lib/p5.js`;
 
 const P5VersionContext = React.createContext({});
 

--- a/server/domain-objects/createDefaultFiles.js
+++ b/server/domain-objects/createDefaultFiles.js
@@ -9,7 +9,7 @@ function draw() {
 export const defaultHTML = `<!DOCTYPE html>
 <html lang="en">
   <head>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/p5.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/p5@1.11.5/lib/p5.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.3/addons/p5.sound.min.js"></script>
     <link rel="stylesheet" type="text/css" href="style.css">
     <meta charset="utf-8" />


### PR DESCRIPTION
In https://github.com/processing/p5.js-web-editor/pull/3457 we noticed that some CDN links were broken, and changed the version back to 1.11.3.

It seems that this is a cloudflare CDN issue, with them not updating especially quickly when we release a new version. In the past we [switched to jsdelivr as our CDN on the p5.js website](https://github.com/processing/p5.js-website/pull/579) as they seem to update much more quickly. I had started using jsdelivr URLs in the version picker here too, but only when you start to change the version -- the default was using Cloudflare as before. So a possible solution is to just use jsdelivr as the default.

Changes:
- Bumps default version back to 1.11.5
- Makes the initial sketch use jsdelivr instead of cloudflare cdnjs
  - We still detect cloudflare CDN links, we just don't use them when you switch versions

The p5 version in the default sketch seems to work now!

![image](https://github.com/user-attachments/assets/28995b68-86d4-4d8e-adfc-ae4af504cb1f)


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
