### PR TITLE
Add 2.0.1 to version picker

### DIFF
--- a/client/modules/IDE/hooks/useP5Version.jsx
+++ b/client/modules/IDE/hooks/useP5Version.jsx
@@ -8,6 +8,7 @@ import PropTypes from 'prop-types';
 // JSON.stringify([...document.querySelectorAll('._132722c7')].map(n => n.innerText), null, 2)
 // TODO: use their API for this to grab these at build time?
 export const p5Versions = [
+  '2.0.1',
   '2.0.0',
   '1.11.5',
   '1.11.4',


### PR DESCRIPTION
We recently [released 2.0.1](https://github.com/processing/p5.js/releases/tag/v2.0.1)! This adds it to the version picker.

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
