### PR TITLE
Added translation for Library Management

### DIFF
--- a/translations/locales/es-419/translations.json
+++ b/translations/locales/es-419/translations.json
@@ -138,6 +138,7 @@
     "Settings": "Configuración",
     "GeneralSettings": "Configuración general",
     "Accessibility": "Accesibilidad",
+    "LibraryManagement": "Gestión de biblioteca",
     "Theme": "Modo de visualización",
     "LightTheme": "Claro",
     "LightThemeARIA": "Modo de visualización claro activado",
@@ -174,7 +175,13 @@
     "PlainText": "Texto sin formato",
     "TextOutputARIA": "Salida de texto activado",
     "TableText": "Tablero de texto",
-    "TableOutputARIA": "Salida de tablero activado"
+    "TableOutputARIA": "Salida de tablero activado",
+    "LibraryVersion": "p5.js Versión",
+    "LibraryVersionInfo": "Aquí hay una [nueva versión 2.0](https://github.com/processing/p5.js/releases/) ¡Ya está disponible la versión p5.js! Se convertirá en la predeterminada en agosto de 2026, así que aprovecha este tiempo para probarla y reportar errores. ¿Te interesa migrar tus bocetos de la versión 1.x a la 2.0? Mira el [recursos de compatibilidad y transición.](https://github.com/processing/p5.js-compatibility)",
+    "SoundAddon": "p5.sound.js Add-on Biblioteca",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on Biblioteca — Precarga",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on Biblioteca — formas",
+    "DataAddon": "p5.js 1.x Compatibility Add-on Biblioteca — Estructuras de datos"
   },
   "KeyboardShortcuts": {
     "Title": " Atajos de teclado",


### PR DESCRIPTION
Progress Towards #3478 

Changes: Added Spanish translation for Library Management preferences

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
