### PR TITLE
Added "Create folder" keyboard shortcut

### DIFF
--- a/client/common/useKeyDownHandlers.js
+++ b/client/common/useKeyDownHandlers.js
@@ -32,18 +32,19 @@ export default function useKeyDownHandlers(keyHandlers) {
     if (!e.key) return;
     const isMac = navigator.userAgent.toLowerCase().indexOf('mac') !== -1;
     const isCtrl = isMac ? e.metaKey : e.ctrlKey;
-    if (e.shiftKey && isCtrl && e.altKey && e.code === 'KeyN') {
+
+    if (isCtrl && e.shiftKey && e.altKey && e.code === 'KeyN') {
       // specifically for creating a new folder
       handlers.current[`ctrl-alt-shift-n`]?.(e);
+    } else if (isCtrl && e.altKey && e.code === 'KeyN') {
+      // specifically for creating a new file
+      handlers.current[`ctrl-alt-n`]?.(e);
     } else if (e.shiftKey && isCtrl) {
       handlers.current[
         `ctrl-shift-${
           /^\d+$/.test(e.code.at(-1)) ? e.code.at(-1) : e.key.toLowerCase()
         }`
       ]?.(e);
-    } else if (isCtrl && e.altKey && e.code === 'KeyN') {
-      // specifically for creating a new file
-      handlers.current[`ctrl-alt-n`]?.(e);
     } else if (isCtrl) {
       handlers.current[`ctrl-${e.key.toLowerCase()}`]?.(e);
     }

--- a/client/common/useKeyDownHandlers.js
+++ b/client/common/useKeyDownHandlers.js
@@ -32,7 +32,10 @@ export default function useKeyDownHandlers(keyHandlers) {
     if (!e.key) return;
     const isMac = navigator.userAgent.toLowerCase().indexOf('mac') !== -1;
     const isCtrl = isMac ? e.metaKey : e.ctrlKey;
-    if (e.shiftKey && isCtrl) {
+    if (e.shiftKey && isCtrl && e.altKey && e.code === 'KeyN') {
+      // specifically for creating a new folder
+      handlers.current[`ctrl-alt-shift-n`]?.(e);
+    } else if (e.shiftKey && isCtrl) {
       handlers.current[
         `ctrl-shift-${
           /^\d+$/.test(e.code.at(-1)) ? e.code.at(-1) : e.key.toLowerCase()

--- a/client/modules/IDE/components/Header/Nav.jsx
+++ b/client/modules/IDE/components/Header/Nav.jsx
@@ -139,6 +139,8 @@ const ProjectMenu = () => {
     metaKey === 'Ctrl' ? `${metaKeyName}+H` : `${metaKeyName}+⌥+F`;
   const newFileCommand =
     metaKey === 'Ctrl' ? `${metaKeyName}+Alt+N` : `${metaKeyName}+⌥+N`;
+  const newFolderCommand =
+    metaKey === 'Ctrl' ? `${metaKeyName}+Alt+Shift+N` : `${metaKeyName}+⌥+⇧+N`;
 
   return (
     <ul className="nav__items-left" role="menubar">
@@ -230,6 +232,7 @@ const ProjectMenu = () => {
         </MenubarItem>
         <MenubarItem onClick={() => dispatch(newFolder(rootFile.id))}>
           {t('Nav.Sketch.AddFolder')}
+          <span className="nav__keyboard-shortcut">{newFolderCommand}</span>
         </MenubarItem>
         <MenubarItem onClick={() => dispatch(startSketch())}>
           {t('Nav.Sketch.Run')}

--- a/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
+++ b/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
@@ -653,6 +653,11 @@ exports[`Nav renders editor version for desktop 1`] = `
                 role="menuitem"
               >
                 Add Folder
+                <span
+                  class="nav__keyboard-shortcut"
+                >
+                  Ctrl+Alt+Shift+N
+                </span>
               </button>
             </li>
             <li

--- a/client/modules/IDE/components/IDEKeyHandlers.jsx
+++ b/client/modules/IDE/components/IDEKeyHandlers.jsx
@@ -9,7 +9,8 @@ import {
   showErrorModal,
   startSketch,
   stopSketch,
-  newFile
+  newFile,
+  newFolder
 } from '../actions/ide';
 import { setAllAccessibleOutput } from '../actions/preferences';
 import { cloneProject, saveProject } from '../actions/project';
@@ -81,6 +82,11 @@ export const useIDEKeyHandlers = ({ getContent }) => {
       e.preventDefault();
       e.stopPropagation();
       dispatch(newFile(rootFile.id));
+    },
+    'ctrl-alt-shift-n': (e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      dispatch(newFolder(rootFile.id));
     },
     'ctrl-`': (e) => {
       e.preventDefault();

--- a/client/modules/IDE/components/KeyboardShortcutModal.jsx
+++ b/client/modules/IDE/components/KeyboardShortcutModal.jsx
@@ -8,6 +8,10 @@ function KeyboardShortcutModal() {
     metaKey === 'Ctrl' ? `${metaKeyName} + H` : `${metaKeyName} + ⌥ + F`;
   const newFileCommand =
     metaKey === 'Ctrl' ? `${metaKeyName} + Alt + N` : `${metaKeyName} + ⌥ + N`;
+  const newFolderCommand =
+    metaKey === 'Ctrl'
+      ? `${metaKeyName} + Alt + Shift + N`
+      : `${metaKeyName} + ⌥ + ⇧ + N`;
   return (
     <div className="keyboard-shortcuts">
       <h3 className="keyboard-shortcuts__title">
@@ -74,6 +78,10 @@ function KeyboardShortcutModal() {
         <li className="keyboard-shortcut-item">
           <span className="keyboard-shortcut__command">{newFileCommand}</span>
           <span>{t('KeyboardShortcuts.CodeEditing.CreateNewFile')}</span>
+        </li>
+        <li className="keyboard-shortcut-item">
+          <span className="keyboard-shortcut__command">{newFolderCommand}</span>
+          <span>{t('KeyboardShortcuts.CodeEditing.CreateNewFolder')}</span>
         </li>
       </ul>
       <h3 className="keyboard-shortcuts__title">

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -249,7 +249,8 @@
       "FindPreviousTextMatch": "Find Previous Text Match",
       "CodeEditing": "Code Editing",
       "ColorPicker": "Show Inline Color Picker",
-      "CreateNewFile": "Create New File"
+      "CreateNewFile": "Create New File",
+      "CreateNewFolder": "Create New Folder"
     },
     "General": "General",
     "GeneralSelection": {


### PR DESCRIPTION
Fixes #3383, #3376

Changes:

- Added a keyboard shortcut for creating a new folder: Ctrl/Cmd + Alt/Option + Shift + N.
- This follows common conventions in development environments and avoids conflicts with existing shortcuts used by the editor or browsers.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #3383, #3376`
