### PR TITLE
Add tooltip for "Upload File" button when user is not authenticated

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -343,16 +343,20 @@ const FileNode = ({
                       {t('FileNode.AddFile')}
                     </button>
                   </li>
-                  {authenticated && (
-                    <li>
-                      <button
-                        aria-label={t('FileNode.UploadFileARIA')}
-                        onClick={handleClickUploadFile}
-                      >
-                        {t('FileNode.UploadFile')}
-                      </button>
-                    </li>
-                  )}
+                  <li>
+                    <button
+                      disabled={!authenticated}
+                      className={!authenticated ? 'tooltipped-login' : ''}
+                      aria-label={
+                        !authenticated
+                          ? t('FileNode.UploadFileRequiresLogin')
+                          : t('FileNode.UploadFileARIA')
+                      }
+                      onClick={handleClickUploadFile}
+                    >
+                      {t('FileNode.UploadFile')}
+                    </button>
+                  </li>
                 </>
               )}
               <li>

--- a/client/modules/IDE/components/Sidebar.jsx
+++ b/client/modules/IDE/components/Sidebar.jsx
@@ -124,19 +124,23 @@ export default function SideBar() {
                     {t('Sidebar.AddFile')}
                   </button>
                 </li>
-                {isAuthenticated && (
-                  <li>
-                    <button
-                      aria-label={t('Sidebar.UploadFileARIA')}
-                      onClick={() => {
-                        dispatch(openUploadFileModal(rootFile.id));
-                        setTimeout(() => dispatch(closeProjectOptions()), 300);
-                      }}
-                    >
-                      {t('Sidebar.UploadFile')}
-                    </button>
-                  </li>
-                )}
+                <li>
+                  <button
+                    disabled={!isAuthenticated}
+                    className={!isAuthenticated ? 'tooltipped-login' : ''}
+                    aria-label={
+                      !isAuthenticated
+                        ? t('Sidebar.UploadFileRequiresLogin')
+                        : t('Sidebar.UploadFileARIA')
+                    }
+                    onClick={() => {
+                      dispatch(openUploadFileModal(rootFile.id));
+                      setTimeout(() => dispatch(closeProjectOptions()), 300);
+                    }}
+                  >
+                    {t('Sidebar.UploadFile')}
+                  </button>
+                </li>
               </ul>
             )}
           </div>

--- a/client/styles/components/_sidebar.scss
+++ b/client/styles/components/_sidebar.scss
@@ -322,7 +322,6 @@
 .sidebar__file-item--closed .file-item__children {
   display: none;
 }
-
 .sidebar__project-options {
   @extend %dropdown-open-right;
   display: none;
@@ -332,3 +331,48 @@
     display: flex;
   }
 }
+
+// Custom tooltip for upload file when login is required
+.tooltipped-login {
+  position: relative;
+  
+  &::before,
+  &::after {
+    position: absolute;
+    z-index: 1000000;
+    display: none;
+    pointer-events: none;
+  }
+  
+  &::after {
+    padding: 5px 8px;
+    font-size: #{math.div(12, $base-font-size)}rem;
+    font-family: Montserrat, sans-serif;
+    content: attr(aria-label);
+    border-radius: 3px;
+    background-color: white !important;
+    color: black !important;
+    text-align: center;
+    white-space: pre;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+  }
+  
+  &::before {
+    display: none;
+  }
+  
+  &:hover::after,
+  &:active::after,
+  &:focus::after {
+    display: inline-block;
+    text-decoration: none;
+  }
+  
+  &::after {
+    bottom: -35px;
+    right: auto;
+    left: 5px;
+    transform: none;
+  }
+}
+

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -268,7 +268,8 @@
     "AddFile": "Create file",
     "AddFileARIA": "add file",
     "UploadFile": "Upload file",
-    "UploadFileARIA": "upload file"
+    "UploadFileARIA": "upload file",
+    "UploadFileRequiresLogin": "You must log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "Open folder contents",
@@ -280,6 +281,7 @@
     "AddFileARIA": "add file",
     "UploadFile": "Upload file",
     "UploadFileARIA": "upload file",
+    "UploadFileRequiresLogin": "You must log in to upload files",
     "Rename": "Rename",
     "Delete": "Delete"
   },


### PR DESCRIPTION
Fixes #3079

Changes:

- Added a tooltip to the "Upload File" button to inform users that authentication is required before uploading.
- This enhances the user experience by providing guidance instead of leaving the button inactive without explanation.

<img width="1250" alt="Screenshot 2025-05-27 at 12 45 46 AM" src="https://github.com/user-attachments/assets/52c3fda7-abca-4715-97ab-22fe118dc2d3" />

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #3079`
