### PR TITLE
added link for Preparing an Issue Guide at 2 places

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -53,7 +53,7 @@ Issues with these labels are a great place to start!
 - [Need Steps to Reproduce](https://github.com/processing/p5.js-web-editor/labels/Needs%20Steps%20to%20Reproduce)
 - [Ready for Work](https://github.com/processing/p5.js-web-editor/labels/Ready%20for%20Work)
 
-A breakdown of what each label means can be found in the [Preparing an Issue Guide](#preparing-an-issue). 
+A breakdown of what each label means can be found in the [Preparing an Issue Guide](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/preparing_an_issue.md). 
 
 When approaching these issues, know that it's okay to not know how to fix an issue! Feel free to ask questions about to approach the problem. We are all here to learn and make something awesome. Someone from the community will help you out, and asking questions is a great way to learn about the p5.js editor, its file structure, and development process.
 
@@ -83,7 +83,7 @@ Before submitting a pull request, make sure that:
 ---
 
 ## Ideas for Getting Started
-* Use the [p5.js Editor](https://editor.p5js.org)! Find a bug? Think of something you think would add to the project? Reference the [Preparing an Issue Guide](#preparing-an-issue) and open an issue.
+* Use the [p5.js Editor](https://editor.p5js.org)! Find a bug? Think of something you think would add to the project? Reference the [Preparing an Issue Guide](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/preparing_an_issue.md) and open an issue.
 * Expand an existing issue. Sometimes issues are missing steps to reproduce, or need suggestions for potential solutions. Sometimes they need another voice saying, "this is really important!"
 * Try getting the project running locally on your computer by following the [installation steps](./../contributor_docs/installation.md).
 * Look through the documentation in the [developer docs](../contributor_docs/) and the [development guide](./../contributor_docs/development.md). Is there anything that could be expanded? Is there anything missing?


### PR DESCRIPTION
Fixes #3502 

Changes: fixed broken link of `Preparing an Issue` in  [working-within-the-codebase](https://github.com/processing/p5.js-web-editor/blob/develop/.github/CONTRIBUTING.md#working-within-the-codebase) and [ideas-for-getting-started](https://github.com/processing/p5.js-web-editor/blob/develop/.github/CONTRIBUTING.md#ideas-for-getting-started), added link to [Preparing An Issue](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/preparing_an_issue.md)

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
