### PR TITLE
Improve account section terminology and labels

### DIFF
--- a/client/modules/IDE/components/Header/Nav.jsx
+++ b/client/modules/IDE/components/Header/Nav.jsx
@@ -378,7 +378,7 @@ const AuthenticatedUserMenu = () => {
           {t('Nav.Auth.MyAssets')}
         </MenubarItem>
         <MenubarItem id="account-settings" href="/account">
-          {t('Preferences.Settings')}
+          {t('Nav.Auth.MyAccount')}
         </MenubarItem>
         <MenubarItem id="account-logout" onClick={() => dispatch(logoutUser())}>
           {t('Nav.Auth.LogOut')}

--- a/client/modules/User/components/AccountForm.jsx
+++ b/client/modules/User/components/AccountForm.jsx
@@ -176,7 +176,7 @@ function AccountForm() {
             </Field>
           )}
           <Button type="submit" disabled={submitting || invalid}>
-            {t('AccountForm.SubmitSaveAllSettings')}
+            {t('AccountForm.SaveAccountDetails')}
           </Button>
         </form>
       )}

--- a/client/modules/User/components/AccountForm.unit.test.jsx
+++ b/client/modules/User/components/AccountForm.unit.test.jsx
@@ -61,8 +61,8 @@ describe('<AccountForm />', () => {
   it('handles form submission and calls updateSettings', async () => {
     subject();
 
-    const saveAllSettingsButton = screen.getByRole('button', {
-      name: /save all settings/i
+    const saveAccountDetailsButton = screen.getByRole('button', {
+      name: /save account details/i
     });
 
     const currentPasswordElement = screen.getByLabelText(/current password/i);
@@ -81,7 +81,7 @@ describe('<AccountForm />', () => {
     });
 
     await act(async () => {
-      fireEvent.click(saveAllSettingsButton);
+      fireEvent.click(saveAccountDetailsButton);
     });
 
     await waitFor(() => {
@@ -92,8 +92,8 @@ describe('<AccountForm />', () => {
   it('Save all setting button should get disabled while submitting and enable when not submitting', async () => {
     subject();
 
-    const saveAllSettingsButton = screen.getByRole('button', {
-      name: /save all settings/i
+    const saveAccountDetailsButton = screen.getByRole('button', {
+      name: /save account details/i
     });
 
     const currentPasswordElement = screen.getByLabelText(/current password/i);
@@ -110,12 +110,12 @@ describe('<AccountForm />', () => {
         value: 'newPassword'
       }
     });
-    expect(saveAllSettingsButton).not.toHaveAttribute('disabled');
+    expect(saveAccountDetailsButton).not.toHaveAttribute('disabled');
 
     await act(async () => {
-      fireEvent.click(saveAllSettingsButton);
+      fireEvent.click(saveAccountDetailsButton);
       await waitFor(() => {
-        expect(saveAllSettingsButton).toHaveAttribute('disabled');
+        expect(saveAccountDetailsButton).toHaveAttribute('disabled');
       });
     });
   });

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -367,13 +367,13 @@
     "CurrentPasswordARIA": "Current Password",
     "NewPassword": "New Password",
     "NewPasswordARIA": "New Password",
-    "SubmitSaveAllSettings": "Save All Settings"
+    "SaveAccountDetails": "Save Account Details"
   },
   "AccountView": {
     "SocialLogin": "Social Login",
     "SocialLoginDescription": "Use your GitHub or Google account to log into the p5.js Web Editor.",
     "Title": "p5.js Web Editor | Account Settings",
-    "Settings": "Account Settings",
+    "Settings": "My Account",
     "AccountTab": "Account",
     "AccessTokensTab": "Access Tokens"
   },


### PR DESCRIPTION
Fixes #3505 

Changes:
- Changed MenubarItem label from "Settings" to "My Account"
- Updated AccountView page title and heading to use "My Account"
- Renamed "Save All Settings" button to "Save Account Details"
![Screenshot 2025-06-03 121959](https://github.com/user-attachments/assets/af5f06ff-b6c7-4c52-97a9-f2d198b44e59)
![Screenshot 2025-06-03 123529](https://github.com/user-attachments/assets/8baee73a-3009-4fdc-b843-52acb3ba9862)

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
