### PR TITLE
Fixed i18n Sync: Update Settings and SubmitSaveAllSettings Keys Across Locale Files #3510 

### DIFF
--- a/translations/locales/be/translations.json
+++ b/translations/locales/be/translations.json
@@ -306,7 +306,7 @@
   "AccountForm": {
     "Email": "ই-মেইল",
     "EmailARIA": "ই-মেইল",
-    "Unconfirmed": "অনুমোদিত নয়।",
+    "Unconfirmed": "অনুমোদিত নয়।",
     "EmailSent": "কনফার্মেশন পাঠানো হয়েছে, আপনার ই-মেইল চেক করুন।",
     "Resend": "অনুমোদন ই-মেইল পুনঃপ্রেরণ করুন",
     "UserName": "ব্যবহারকারীর নাম",
@@ -315,13 +315,13 @@
     "CurrentPasswordARIA": "বর্তমান পাসওয়ার্ড",
     "NewPassword": "নতুন পাসওয়ার্ড",
     "NewPasswordARIA": "নতুন পাসওয়ার্ড",
-    "SubmitSaveAllSettings": "সমস্ত সেটিংস সংরক্ষণ করুন"
+    "SaveAccountDetails": "অ্যাকাউন্ট বিবরণ সংরক্ষণ করুন"
   },
   "AccountView": {
     "SocialLogin": "সোশ্যাল লগইন",
     "SocialLoginDescription": "p5.js ওয়েব এডিটরে লগ ইন করতে আপনি আপনার GitHub বা Google অ্যাকাউন্ট ব্যবহার করতে পারেন।",
     "Title": "p5.js ওয়েব এডিটর | অ্যাকাউন্ট সেটিংস",
-    "Settings": "অ্যাকাউন্ট সেটিংস",
+    "Settings": "আমার অ্যাকাউন্ট",
     "AccountTab": "অ্যাকাউন্ট",
     "AccessTokensTab": "অ্যাক্সেস টোকেন"
   },
@@ -533,7 +533,7 @@
     "HeaderName": "স্কেচ",
     "HeaderCreatedAt": "তারিখ তৈরি হয়েছে",
     "HeaderCreatedAt_mobile": "তৈরি হয়েছে",
-"HeaderUpdatedAt": "তারিখ আপডেট হয়েছে",
+    "HeaderUpdatedAt": "তারিখ আপডেট হয়েছে",
     "HeaderUpdatedAt_mobile": "আপডেট",
     "NoSketches": "কোন স্কেচ নেই।"
   },

--- a/translations/locales/de/translations.json
+++ b/translations/locales/de/translations.json
@@ -306,13 +306,13 @@
     "CurrentPasswordARIA": "aktuelles passwort",
     "NewPassword": "Neues Passwort",
     "NewPasswordARIA": "neues passwort",
-    "SubmitSaveAllSettings": "Alle Einstellungen speichern"
+    "SaveAccountDetails": "Kontodaten speichern"
   },
   "AccountView": {
     "SocialLogin": "Social Login",
     "SocialLoginDescription": "Nutze Deinen GitHub oder Google Account um dich beim p5.js Web Editor anzumelden.",
     "Title": "p5.js Web Editor | Account Einstellungen",
-    "Settings": "Account Einstellungen",
+    "Settings": "Mein Konto",
     "AccountTab": "Account",
     "AccessTokensTab": "Zugangstokens"
   },

--- a/translations/locales/hi/translations.json
+++ b/translations/locales/hi/translations.json
@@ -366,7 +366,7 @@
       "SocialLogin": "सामाजिक लॉग इन",
       "SocialLoginDescription": "p5.js वेब संपादक में लॉग इन करने के लिए अपने GitHub या Google खाते का उपयोग करें।",
       "Title": "p5.js वेब संपादक | खाता सेटिंग्स",
-      "Settings": "खाता सेटिंग्स",
+      "Settings": "मेरा खाता",
       "AccountTab": "खाता",
       "AccessTokensTab": "टोकन का उपयोग"
     },

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -308,23 +308,23 @@
     "Email": "Email",
     "EmailARIA": "email",
     "Unconfirmed": "Non confermato.",
-    "EmailSent": "Conferma spedita, controla le tue email.",
-    "Resend": "Rispedisci email di conferma",
-    "Username": "Nome utente",
-    "UserNameARIA": "Nome utente",
+    "EmailSent": "Conferma inviata, controlla la tua email.",
+    "Resend": "Reinvia email di conferma",
+    "UserName": "Nome utente",
+    "UserNameARIA": "nome utente",
     "CurrentPassword": "Password attuale",
-    "CurrentPasswordARIA": "Password attuale",
-    "NewPassword": "Nuova Password",
-    "NewPasswordARIA": "Nuova Password",
-    "SubmitSaveAllSettings": "Salva tutte le impostazioni"
+    "CurrentPasswordARIA": "password attuale",
+    "NewPassword": "Nuova password",
+    "NewPasswordARIA": "nuova password",
+    "SaveAccountDetails": "Salva dettagli account"
   },
   "AccountView": {
-    "SocialLogin": "Accesso ai social",
-    "SocialLoginDescription": "Usa il tuo account GitHub o Google per accedere al redattore web p5.js.",
-    "Title": "p5.js redattore web | Impostazioni account",
-    "Settings": "Impostazioni Account",
+    "SocialLogin": "Social Login",
+    "SocialLoginDescription": "Usa il tuo account GitHub o Google per accedere al Web Editor di p5.js.",
+    "Title": "p5.js Web Editor | Impostazioni Account",
+    "Settings": "Il mio account",
     "AccountTab": "Account",
-    "AccessTokensTab": "Codici di accesso"
+    "AccessTokensTab": "Token di accesso"
   },
   "APIKeyForm": {
     "ConfirmDelete": "Sei sicuro di cancellare {{key_label}}?",

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -311,11 +311,11 @@
     "EmailSent": "Conferma inviata, controlla la tua email.",
     "Resend": "Reinvia email di conferma",
     "UserName": "Nome utente",
-    "UserNameARIA": "nome utente",
+    "UserNameARIA": "Nome utente",
     "CurrentPassword": "Password attuale",
-    "CurrentPasswordARIA": "password attuale",
+    "CurrentPasswordARIA": "Password attuale",
     "NewPassword": "Nuova password",
-    "NewPasswordARIA": "nuova password",
+    "NewPasswordARIA": "Nuova password",
     "SaveAccountDetails": "Salva dettagli account"
   },
   "AccountView": {

--- a/translations/locales/ja/translations.json
+++ b/translations/locales/ja/translations.json
@@ -306,13 +306,13 @@
       "CurrentPasswordARIA": "現在のパスワード",
       "NewPassword": "新しいパスワード",
       "NewPasswordARIA": "新しいパスワード",
-      "SubmitSaveAllSettings": "すべての設定を保存"
+      "SaveAccountDetails": "アカウント情報を保存"
     },
     "AccountView": {
       "SocialLogin": "ソーシャルログイン",
       "SocialLoginDescription": "GitHubやGoogleアカウントを使って、p5.js ウェブエディターにログインできます。",
       "Title": "p5.js ウェブエディター | アカウント設定",
-      "Settings": "アカウント設定",
+      "Settings": "マイアカウント",
       "AccountTab": "アカウント",
       "AccessTokensTab": "アクセストークン"
     },

--- a/translations/locales/ko/translations.json
+++ b/translations/locales/ko/translations.json
@@ -294,13 +294,13 @@
     "CurrentPasswordARIA": "Current Password",
     "NewPassword": "New Password",
     "NewPasswordARIA": "New Password",
-    "SubmitSaveAllSettings": "Save All Settings"
+    "SaveAccountDetails": "Save Account Details"
   },
   "AccountView": {
     "SocialLogin": "Social Login",
     "SocialLoginDescription": "Use your GitHub or Google account to log into the p5.js Web Editor.",
     "Title": "p5.js Web Editor | Account Settings",
-    "Settings": "Account Settings",
+    "Settings": "My Account",
     "AccountTab": "Account",
     "AccessTokensTab": "Access Tokens"
   },
@@ -313,7 +313,7 @@
     "CreateTokenSubmit": "Create",
     "NoTokens": "You have no existing tokens.",
     "NewTokenTitle": "Your new access token",
-    "NewTokenInfo": "Make sure to copy your new personal access token now.\n                  You won’t be able to see it again!",
+    "NewTokenInfo": "Make sure to copy your new personal access token now.\n                  You won't be able to see it again!",
     "ExistingTokensTitle": "Existing tokens"
   },
   "APIKeyList": {

--- a/translations/locales/pt-BR/translations.json
+++ b/translations/locales/pt-BR/translations.json
@@ -306,13 +306,13 @@
     "CurrentPasswordARIA": "Senha Atual",
     "NewPassword": "Nova Senha",
     "NewPasswordARIA": "Nova Senha",
-    "SubmitSaveAllSettings": "Salvar todas as Configurações"
+    "SaveAccountDetails": "Salvar Detalhes da Conta"
   },
   "AccountView": {
     "SocialLogin": "~Login usando redes sociais",
     "SocialLoginDescription": "Use seu GitHub ou sua conta do Google para entrar no Editor de Web p5.js.",
     "Title": "Editor de Web p5.js | Configurações de Conta",
-    "Settings": "Configurações de Conta",
+    "Settings": "Minha Conta",
     "AccountTab": "Conta",
     "AccessTokensTab": "Acessar Tokens"
   },

--- a/translations/locales/sv/translations.json
+++ b/translations/locales/sv/translations.json
@@ -306,13 +306,13 @@
     "CurrentPasswordARIA": "Nuvarande lösenord",
     "NewPassword": "Nytt lösenord",
     "NewPasswordARIA": "Nytt lösenord",
-    "SubmitSaveAllSettings": "Spara alla inställningar"
+    "SaveAccountDetails": "Spara kontouppgifter"
   },
   "AccountView": {
     "SocialLogin": "Social inloggning",
     "SocialLoginDescription": "Använd ditt GitHub- eller Googlekonto för att logga in till p5.js Webb editor.",
     "Title": "p5.js Webb editor | Kontoinställningar",
-    "Settings": "Kontoinställningar",
+    "Settings": "Mitt konto",
     "AccountTab": "Konto",
     "AccessTokensTab": "Tokens för åtkomst"
   },

--- a/translations/locales/tr/translations.json
+++ b/translations/locales/tr/translations.json
@@ -309,13 +309,13 @@
     "CurrentPasswordARIA": "Mevcut Şifre",
     "NewPassword": "Yeni Şifre",
     "NewPasswordARIA": "Yeni Şifre",
-    "SubmitSaveAllSettings": "Tüm Ayarları Kaydet"
+    "SaveAccountDetails": "Hesap Bilgilerini Kaydet"
   },
   "AccountView": {
     "SocialLogin": "Sosyal Giriş",
     "SocialLoginDescription": "GitHub veya Google hesabınızı kullanarak p5.js Web Düzenleyici'ne giriş yapın.",
     "Title": "p5.js Web Düzenleyici | Hesap Ayarları",
-    "Settings": "Hesap Ayarları",
+    "Settings": "Hesabım",
     "AccountTab": "Hesap",
     "AccessTokensTab": "Erişim Anahtarları"
   },

--- a/translations/locales/uk-UA/translations.json
+++ b/translations/locales/uk-UA/translations.json
@@ -308,13 +308,13 @@
     "CurrentPasswordARIA": "Поточний пароль",
     "NewPassword": "Новий пароль",
     "NewPasswordARIA": "Новий пароль",
-    "SubmitSaveAllSettings": "Зберегти всі налаштування"
+    "SaveAccountDetails": "Зберегти дані облікового запису"
   },
   "AccountView": {
     "SocialLogin": "Увійти через соціальну мережу",
     "SocialLoginDescription": "Використовуйте свій обліковий запис GitHub або Google, щоб увійти у p5.js веб-редактор.",
     "Title": "p5.js веб-редактор | Налаштування акаунта",
-    "Settings": "Налаштування акаунта",
+    "Settings": "Мій обліковий запис",
     "AccountTab": "Акаунт",
     "AccessTokensTab": "Ключі"
   },

--- a/translations/locales/ur/translations.json
+++ b/translations/locales/ur/translations.json
@@ -307,13 +307,13 @@
       "CurrentPasswordARIA": "موجودہ خفیہ لفظ",
       "NewPassword": "نیا پاس ورڈ",
       "NewPasswordARIA": "نیا پاس ورڈ",
-      "SubmitSaveAllSettings": "تمام ترتیبات کو محفوظ کریں۔"
+      "SaveAccountDetails": "اکاؤنٹ کی تفصیلات محفوظ کریں"
     },
     "AccountView": {
       "SocialLogin": "سماجی لاگ ان",
       "SocialLoginDescription": "p5.js ویب ایڈیٹر میں لاگ ان کرنے کے لیے اپنا GitHub یا Google اکاؤنٹ استعمال کریں۔",
       "Title": "p5.js ویب ایڈیٹر | ",
-      "Settings": "اکاؤنٹ کی ترتیبات",
+      "Settings": "میرا اکاؤنٹ",
       "AccountTab": "کھاتہ",
       "AccessTokensTab": "ٹوکنز تک رسائی حاصل کریں۔"
     },

--- a/translations/locales/zh-CN/translations.json
+++ b/translations/locales/zh-CN/translations.json
@@ -309,13 +309,13 @@
     "CurrentPasswordARIA": "当前密码",
     "NewPassword": "新密码",
     "NewPasswordARIA": "新密码",
-    "SubmitSaveAllSettings": "保存所有设置"
+    "SaveAccountDetails": "保存账户信息"
   },
   "AccountView": {
     "SocialLogin": "第三方登陆",
     "SocialLoginDescription": "使用您的 GitHub 或谷歌账号登陆 p5.js 在线编辑器。",
     "Title": "p5.js 在线编辑器 ｜ 账号设置",
-    "Settings": "账号设置",
+    "Settings": "我的账号",
     "AccountTab": "账号",
     "AccessTokensTab": "访问令牌"
   },

--- a/translations/locales/zh-TW/translations.json
+++ b/translations/locales/zh-TW/translations.json
@@ -309,13 +309,13 @@
     "CurrentPasswordARIA": "目前密碼",
     "NewPassword": "新密碼",
     "NewPasswordARIA": "新密碼",
-    "SubmitSaveAllSettings": "儲存所有設定"
+    "SaveAccountDetails": "儲存帳戶資料"
   },
   "AccountView": {
     "SocialLogin": "以社群帳號登入",
     "SocialLoginDescription": "使用你的 GitHub 或 Google 帳號登入 p5.js 網頁編輯器.",
     "Title": "p5.js 網頁編輯器 | 帳號設定",
-    "Settings": "帳號設定",
+    "Settings": "我的帳號",
     "AccountTab": "帳號",
     "AccessTokensTab": "存取權杖"
   },


### PR DESCRIPTION
Fixes #3510 

Changes:
I have now updated all the locale files to use the new keys and translations. Here's a summary of the changes made:
Replaced "SubmitSaveAllSettings" with "SaveAccountDetails" in all locale files
Updated "Settings" to "My Account" (or its translation) in the AccountView section of all locale files
The translations are now consistent across all languages and match the English version. The UI should now display the correct text in all supported languages.

I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] has no test errors (`npm run test`)
* [X] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`

