### PR TITLE
temp esc editor key, update open/close file menu aria label

### DIFF
--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -169,6 +169,9 @@ class Editor extends React.Component {
       },
       Enter: 'emmetInsertLineBreak',
       Esc: 'emmetResetAbbreviation',
+      [`Shift-${metaKey}-E`]: (cm) => {
+        cm.getInputField().blur();
+      },
       [`Shift-Tab`]: false,
       [`${metaKey}-Enter`]: () => null,
       [`Shift-${metaKey}-Enter`]: () => null,
@@ -552,7 +555,7 @@ class Editor extends React.Component {
             <section className={editorSectionClass}>
               <div className="editor__header">
                 <button
-                  aria-label={this.props.t('Editor.OpenSketchARIA')}
+                  aria-label={this.props.t('Editor.CloseSketchARIA')}
                   className="sidebar__contract"
                   onClick={() => {
                     this.props.collapseSidebar();
@@ -562,7 +565,7 @@ class Editor extends React.Component {
                   <LeftArrowIcon focusable="false" aria-hidden="true" />
                 </button>
                 <button
-                  aria-label={this.props.t('Editor.CloseSketchARIA')}
+                  aria-label={this.props.t('Editor.OpenSketchARIA')}
                   className="sidebar__expand"
                   onClick={this.props.expandSidebar}
                 >


### PR DESCRIPTION
Changes:
- Switches the aria labels for the Open/Close File menu button to address: "Open/close sketch files navigation has opposite labels. Labelled 'open' when it's open and 'close' when it's closed."
- Adds a temporary key `Shift-Metakey-E` to escape the keyboard trap in the CodeMirror editor. Will be removed once upgraded to Codemirror 6, which should have `Esc-Tab` do this as default. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
