### PR TITLE
fix: typo in "why write tests" section

### DIFF
--- a/contributor_docs/testing.md
+++ b/contributor_docs/testing.md
@@ -107,7 +107,7 @@ You can save a snapshot of what the HTML looks like when the component is render
 - Many of the existing components don't have tests yet, and you could write one :-) You can find a few suggested files to start with [in this section](#Files-to-start-with).
 - They are a good place to start if you're learning the codebase.
 - It benefits all future contributors by allowing them to check their changes for errors.
-- It increases usage: most code with only ever have a single invocation point, but this means that code might not be particularly robust and lead to bugs if a different developer reuses it in a different context. Writing tests increases the usage of the code in question and may improve the long-term durability, along with leading developers to refactor their code to be more usable. [[3]](#References)
+- It increases usage: most code will only ever have a single invocation point, but this means that code might not be particularly robust and lead to bugs if a different developer reuses it in a different context. Writing tests increases the usage of the code in question and may improve the long-term durability, along with leading developers to refactor their code to be more usable. [[3]](#References)
 - Testing lets you check your own work and feel more comfortable submitting PRs.
 - It catches easy-to-miss errors.
 - It is good practice for large projects.


### PR DESCRIPTION
Fixes #3534

Changes: 

- Fixed a single word typo in the "why write tests" section of the testing developer docs
- This was a learning project for the p5.js editor Open Source Internship - I was learning how to make a pull request! 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
