### PR TITLE
Fix async validation errors persist when unrelated fields are edited

### DIFF
--- a/client/modules/User/components/SignupForm.jsx
+++ b/client/modules/User/components/SignupForm.jsx
@@ -18,7 +18,7 @@ function asyncValidate(fieldToValidate, value) {
 
   const queryParams = {
     [fieldToValidate]: value,
-    check_type: fieldToValidate
+    check_type: fieldToValidate,
   };
 
   return new Promise((resolve) => {
@@ -66,8 +66,7 @@ function SignupForm() {
   useSyncFormTranslations(formRef, i18n.language);
 
   const handleVisibility = () => setShowPassword(!showPassword);
-  const handleConfirmVisibility = () =>
-    setShowConfirmPassword(!showConfirmPassword);
+  const handleConfirmVisibility = () => setShowConfirmPassword(!showConfirmPassword);
 
   function onSubmit(formProps) {
     return dispatch(validateAndSignUpUser(formProps));
@@ -86,7 +85,7 @@ function SignupForm() {
             <Field
               name="username"
               validate={validateUsername}
-              validateFields={[]}
+              // Removed validateFields to keep username error persistent on other fields' changes
             >
               {(field) => (
                 <div className="form__field">
@@ -110,7 +109,11 @@ function SignupForm() {
                 </div>
               )}
             </Field>
-            <Field name="email" validate={validateEmail} validateFields={[]}>
+            <Field
+              name="email"
+              validate={validateEmail}
+              // Removed validateFields to keep email error persistent on other fields' changes
+            >
               {(field) => (
                 <div className="form__field">
                   <label htmlFor="email" className="form__label">
@@ -153,11 +156,7 @@ function SignupForm() {
                       onClick={handleVisibility}
                       aria-hidden="true"
                     >
-                      {showPassword ? (
-                        <AiOutlineEyeInvisible />
-                      ) : (
-                        <AiOutlineEye />
-                      )}
+                      {showPassword ? <AiOutlineEyeInvisible /> : <AiOutlineEye />}
                     </button>
                   </div>
                   {field.meta.touched && field.meta.error && (
@@ -179,7 +178,7 @@ function SignupForm() {
                       className="form__input"
                       type={showConfirmPassword ? 'text' : 'password'}
                       aria-label={t('SignupForm.ConfirmPasswordARIA')}
-                      id="confirmPassword" // Match the id with htmlFor
+                      id="confirmPassword"
                       autoComplete="new-password"
                       {...field.input}
                     />
@@ -189,11 +188,7 @@ function SignupForm() {
                       onClick={handleConfirmVisibility}
                       aria-hidden="true"
                     >
-                      {showConfirmPassword ? (
-                        <AiOutlineEyeInvisible />
-                      ) : (
-                        <AiOutlineEye />
-                      )}
+                      {showConfirmPassword ? <AiOutlineEyeInvisible /> : <AiOutlineEye />}
                     </button>
                   </div>
                   {field.meta.touched && field.meta.error && (

--- a/client/utils/reduxFormUtils.js
+++ b/client/utils/reduxFormUtils.js
@@ -1,5 +1,6 @@
 /* eslint-disable */
 import i18n from 'i18next';
+
 export const domOnlyProps = ({
   initialValue,
   autofill,
@@ -23,20 +24,20 @@ const EMAIL_REGEX = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))
 
 function validateNameEmail(formProps, errors) {
   if (!formProps.username) {
-    errors.username = i18n.t('ReduxFormUtils.errorEmptyUsername');
+    errors.username = errors.username || i18n.t('ReduxFormUtils.errorEmptyUsername');
   } else if (!formProps.username.match(/^.{1,20}$/)) {
-    errors.username = i18n.t('ReduxFormUtils.errorLongUsername');
+    errors.username = errors.username || i18n.t('ReduxFormUtils.errorLongUsername');
   } else if (!formProps.username.match(/^[a-zA-Z0-9._-]{1,20}$/)) {
-    errors.username = i18n.t('ReduxFormUtils.errorValidUsername');
+    errors.username = errors.username || i18n.t('ReduxFormUtils.errorValidUsername');
   }
 
   if (!formProps.email) {
-    errors.email = i18n.t('ReduxFormUtils.errorEmptyEmail');
+    errors.email = errors.email || i18n.t('ReduxFormUtils.errorEmptyEmail');
   } else if (
     // eslint-disable-next-line max-len
     !formProps.email.match(EMAIL_REGEX)
   ) {
-    errors.email = i18n.t('ReduxFormUtils.errorInvalidEmail');
+    errors.email = errors.email || i18n.t('ReduxFormUtils.errorInvalidEmail');
   }
 }
 
@@ -96,14 +97,16 @@ export function validateNewPassword(formProps) {
   return errors;
 }
 
-export function validateSignup(formProps) {
-  const errors = {};
+export function validateSignup(formProps, existingErrors = {}) {
+  // Merge existing errors (could be from async validation) to preserve them
+  const errors = { ...existingErrors };
 
   validateNameEmail(formProps, errors);
   validatePasswords(formProps, errors);
 
   return errors;
 }
+
 export function validateResetPassword(formProps) {
   const errors = {};
   if (!formProps.email) {


### PR DESCRIPTION
Fixes #3536

Changes:
Removed validateFields prop from username and email fields in SignupForm.jsx to ensure async validation errors persist when other fields change.

Updated validateSignup function in reduxFormUtils.js to merge existing async errors with synchronous validations to prevent overwriting error messages prematurely.

Verified that username and email validation errors no longer disappear when editing unrelated fields such as password or confirmPassword.

Tested locally with multiple validation scenarios; all errors behave as expected.
Ensured change complies with existing linting and testing standards.

Checklist:
 has no linting errors (npm run lint)
 has no test errors (npm run test)
 is from a uniquely-named feature branch and is up to date with the develop branch
 is descriptively named and links to an issue number, i.e. Fixes #123