### PR TITLE
Sketch links

### DIFF
--- a/client/modules/About/About.styles.js
+++ b/client/modules/About/About.styles.js
@@ -121,9 +121,11 @@ export const SectionItem = styled.div`
   & a {
     font-weight: 700;
     font-size: ${remSize(16)};
+    text-decoration: underline;
 
     &:hover {
       text-decoration: underline;
+      text-decoration-thickness: 0.1em;
     }
   }
 
@@ -176,6 +178,7 @@ export const ContactHandles = styled.p`
 
   & a {
     color: ${prop('logoColor')};
+    text-decoration: underline;
 
     &:hover {
       text-decoration: underline;
@@ -202,9 +205,11 @@ export const Footer = styled.div`
   & a {
     margin: ${remSize(20)} 9.5% 0 0;
     color: ${prop('logoColor')};
+    text-decoration: underline;
 
     &:hover {
       text-decoration: underline;
+      text-decoration-thickness: 0.1em;
     }
   }
 

--- a/client/modules/IDE/components/CollectionList/CollectionListRow.jsx
+++ b/client/modules/IDE/components/CollectionList/CollectionListRow.jsx
@@ -34,6 +34,12 @@ const SketchsTableRow = styled.tr`
 
   a {
     color: ${prop('primaryTextColor')};
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: underline;
+      text-decoration-thickness: 0.1em;
+    }
   }
 
   &.is-deleted > * {

--- a/client/styles/components/_sketch-list.scss
+++ b/client/styles/components/_sketch-list.scss
@@ -148,8 +148,10 @@
 
 .sketches-table__row a {
   @include themify() {
+    text-decoration: underline;
     color: getThemifyVariable("primary-text-color");
   }
+  
 }
 
 .sketches-table__row.is-deleted > * {
@@ -186,4 +188,5 @@
   @include themify() {
     color: getThemifyVariable("logo-color");
   }
+  text-decoration-thickness: 0.1em;
 }


### PR DESCRIPTION
Progress toward #3550

Changes: Added link underlines to sketches, collections, and about pages. Link underlines become thicker upon hover. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
