### PR TITLE
Address Broken Collection Sketch Links

### DIFF
--- a/client/modules/User/components/CollectionItemRow.jsx
+++ b/client/modules/User/components/CollectionItemRow.jsx
@@ -19,14 +19,14 @@ const CollectionItemRow = ({ collection, item, isOwner }) => {
         t('Collection.DeleteFromCollection', { name_sketch: name })
       )
     ) {
-      dispatch(removeFromCollection(collection.id, item.projectId));
+      dispatch(removeFromCollection(collection.id, item.project.id));
     }
   };
 
   const name = projectIsDeleted ? (
     <span>{t('Collection.SketchDeleted')}</span>
   ) : (
-    <Link to={`/${item.project.user.username}/sketches/${item.projectId}`}>
+    <Link to={`/${item.project.user.username}/sketches/${item.project.id}`}>
       {item.project.name}
     </Link>
   );
@@ -64,7 +64,6 @@ CollectionItemRow.propTypes = {
   }).isRequired,
   item: PropTypes.shape({
     createdAt: PropTypes.string.isRequired,
-    projectId: PropTypes.string.isRequired,
     isDeleted: PropTypes.bool.isRequired,
     project: PropTypes.shape({
       id: PropTypes.string.isRequired,


### PR DESCRIPTION
Fixes #3561 

After upgrading `node` and `mongoose`, `Collection` items that use `.populate()` no longer consistently provide the `projectId` field as before. In these queries, `mongoose` now seems to favor returning a full `project` object with its own `id` instead of `projectId`, resulting in `item.projectId` breaking. 

Changes:
- Updates `item.projectId` to use the `id` from the `project` object instead to fix the missing sketch ids in the collection list URLs

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
