### PR TITLE
[Fixes #3566] Added hover pseudo class to preview console down arrow (collapse/expand)

### DIFF
--- a/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
+++ b/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
@@ -335,7 +335,7 @@ exports[`Nav renders dashboard version for mobile 1`] = `
           >
             <test-file-stub
               aria-hidden="true"
-              classname="icons__StyledIcon-sc-xmer15-0 cLOsBq"
+              classname="icons__StyledIcon-sc-xmer15-0 kjSZIe"
               focusable="false"
             />
           </button>
@@ -351,7 +351,7 @@ exports[`Nav renders dashboard version for mobile 1`] = `
         >
           <test-file-stub
             aria-hidden="true"
-            classname="icons__StyledIcon-sc-xmer15-0 cLOsBq"
+            classname="icons__StyledIcon-sc-xmer15-0 kjSZIe"
             focusable="false"
           />
         </button>

--- a/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
+++ b/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
@@ -335,7 +335,7 @@ exports[`Nav renders dashboard version for mobile 1`] = `
           >
             <test-file-stub
               aria-hidden="true"
-              classname="icons__StyledIcon-sc-xmer15-0 kjSZIe"
+              classname="icons__StyledIcon-sc-xmer15-0 cLOsBq"
               focusable="false"
             />
           </button>
@@ -351,7 +351,7 @@ exports[`Nav renders dashboard version for mobile 1`] = `
         >
           <test-file-stub
             aria-hidden="true"
-            classname="icons__StyledIcon-sc-xmer15-0 kjSZIe"
+            classname="icons__StyledIcon-sc-xmer15-0 cLOsBq"
             focusable="false"
           />
         </button>
@@ -930,7 +930,7 @@ exports[`Nav renders editor version for mobile 1`] = `
           >
             <test-file-stub
               aria-hidden="true"
-              classname="icons__StyledIcon-sc-xmer15-0 kjSZIe"
+              classname="icons__StyledIcon-sc-xmer15-0 cLOsBq"
               focusable="false"
             />
           </button>
@@ -946,7 +946,7 @@ exports[`Nav renders editor version for mobile 1`] = `
         >
           <test-file-stub
             aria-hidden="true"
-            classname="icons__StyledIcon-sc-xmer15-0 kjSZIe"
+            classname="icons__StyledIcon-sc-xmer15-0 cLOsBq"
             focusable="false"
           />
         </button>

--- a/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
+++ b/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
@@ -930,7 +930,7 @@ exports[`Nav renders editor version for mobile 1`] = `
           >
             <test-file-stub
               aria-hidden="true"
-              classname="icons__StyledIcon-sc-xmer15-0 cLOsBq"
+              classname="icons__StyledIcon-sc-xmer15-0 kjSZIe"
               focusable="false"
             />
           </button>
@@ -946,7 +946,7 @@ exports[`Nav renders editor version for mobile 1`] = `
         >
           <test-file-stub
             aria-hidden="true"
-            classname="icons__StyledIcon-sc-xmer15-0 cLOsBq"
+            classname="icons__StyledIcon-sc-xmer15-0 kjSZIe"
             focusable="false"
           />
         </button>

--- a/client/styles/components/_console.scss
+++ b/client/styles/components/_console.scss
@@ -57,6 +57,13 @@
 		& path {
 			fill: getThemifyVariable('secondary-text-color');
 		}
+		&:hover {
+			& g,
+			& polygon,
+			& path {
+				fill: getThemifyVariable('logo-color');
+			}
+		}
 	}
 	.preview-console--collapsed & {
 		display: none;
@@ -71,6 +78,13 @@
 		& polygon,
 		& path {
 			fill: getThemifyVariable('secondary-text-color');
+		}
+		&:hover {
+			& g,
+			& polygon,
+			& path {
+				fill: getThemifyVariable('logo-color');
+			}
 		}
 	}
 	display: none;


### PR DESCRIPTION
Fixes #3566

Changes:

I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] has no test errors (`npm run test`)
* [X] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`
