### PR TITLE
About page lower area theme set

### DIFF
--- a/client/modules/About/About.styles.js
+++ b/client/modules/About/About.styles.js
@@ -2,13 +2,15 @@ import styled from 'styled-components';
 import { remSize, prop } from '../../theme';
 
 export const AboutPageContent = styled.div`
-  margin: ${remSize(42)} ${remSize(295)};
+  padding: ${remSize(42)} ${remSize(295)};
+  background-color: ${prop('sectionBackground')};
 
   @media (max-width: 1279px) {
     margin: ${remSize(20)};
     width: 95%;
     overflow: hidden auto;
     flex-direction: column;
+    background-color: ${prop('sectionBackground')};
   }
 `;
 
@@ -82,6 +84,7 @@ export const IntroDescription = styled.div`
 
 export const Section = styled.div`
   margin: ${remSize(50)} 0;
+  background-color: ${prop('sectionBackground')};
 
   & h2 {
     font-size: ${remSize(24)};

--- a/client/theme.js
+++ b/client/theme.js
@@ -80,6 +80,7 @@ const baseThemes = {
     searchBackgroundColor: grays.lightest,
     tableRowStripeColor: grays.mediumLight,
     notification: colors.dodgerblue,
+    sectionBackground: grays.lightest,
 
     Button: {
       primary: {
@@ -172,6 +173,7 @@ const baseThemes = {
     searchBackgroundColor: grays.darker,
     tableRowStripeColor: grays.dark,
     notification: colors.processingBlueLight,
+    sectionBackground: grays.darker,
 
     Button: {
       primary: {
@@ -260,6 +262,7 @@ export default {
     inactiveTextColor: grays.light,
     logoColor: colors.yellow,
     notification: colors.p5ContrastYellow,
+    sectionBackground: grays.darkest,
 
     Button: {
       primary: {


### PR DESCRIPTION
The about page lower area was not supporting dark and light theme as you can see in the demo video of bug. Then I fixed the bug by using and assigning dynamic color property and using padding instead of margin. Please have a look on fixed bug video for proper guide.

Fixes #3563 

# Original Bug Demo:

https://github.com/user-attachments/assets/f1109a9c-9c31-4ad6-85f0-9102aa78b93e

# Bug Fix Demo:

https://github.com/user-attachments/assets/e3e105eb-e6b3-4c3a-8589-a58f59aab5b5



