### PR TITLE
Add issue assignment policy to contributor_docs

### DIFF
--- a/contributor_docs/preparing_a_pull_request.md
+++ b/contributor_docs/preparing_a_pull_request.md
@@ -8,6 +8,7 @@ Pull-requests are easier when your code is up to date!
 Before submitting a pull request, make sure that:
 
 - Your work is related to an issue. **Pull requests that do not have an associated issue will not be accepted.** 
+- **The issue is not already assigned to another contributor.** We follow a "first assigned, first served" approach to avoid duplicated work. If you open a PR for an issue that someone else is already working on, your PR will be closed.
 - Your work adheres to the style guidelines and fits in with the rest of the codebase.
 - You ran the project locally and tested your changes. Pay special attention to any specific areas of the p5.js editor that may be affected by your changes. Does everything still work as before? Great!
 


### PR DESCRIPTION
Fixes #3541  

Changes: Added a clear bullet point to the "Before Submitting a Pull Request" section in `contributor_docs/preparing_a_pull_request.md` that explains the assignment policy.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
