### PR TITLE
Update p5Versions.js to include 2.0.4 and 1.11.9

### DIFF
--- a/common/p5Versions.js
+++ b/common/p5Versions.js
@@ -5,10 +5,12 @@ export const currentP5Version = '1.11.8'; // Don't update to 2.x until 2026
 // JSON.stringify([...document.querySelectorAll('._132722c7')].map(n => n.innerText), null, 2)
 // TODO: use their API for this to grab these at build time?
 export const p5Versions = [
+  '2.0.4',
   '2.0.3',
   '2.0.2',
   '2.0.1',
   '2.0.0',
+  '1.11.9',
   '1.11.8',
   '1.11.7',
   '1.11.6',


### PR DESCRIPTION
We recently [released p5.js 2.0.4](https://github.com/processing/p5.js/releases/tag/v2.0.4)! This adds it to the version picker.

1.11.9 has been released earlier but is also added here.

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`