### PR TITLE
made changes in the spelling

### DIFF
--- a/contributor_docs/README.md
+++ b/contributor_docs/README.md
@@ -1,4 +1,4 @@
-# Contributor Documentatation
+# Contributor Documentation
 This folder contains guides for contributing to the p5.js Web Editor. You don't need to know everything to get started—explore at your own pace! To begin, we highly recommend starting with the [Contribution Guide](https://github.com/processing/p5.js-web-editor/blob/develop/.github/CONTRIBUTING.md)!
 
 These guides aren't exhaustive, and do not cover all the possible ways you can contribute to a project. If you have an idea for how you'd like to help and don't see a guide for it here, you're welcome to add it to the "Documents to Create" list below by opening an issue!


### PR DESCRIPTION
Fixes #3584 

Changes: Updating the spelling of 'Contributor Documentation' title.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
