### PR TITLE
Fixing "welcome" translation for "pt-BR"

### DIFF
--- a/translations/locales/pt-BR/translations.json
+++ b/translations/locales/pt-BR/translations.json
@@ -36,7 +36,7 @@
     "LoginOr": "ou",
     "SignUp": "Registrar-se",
     "Auth": {
-      "Welcome": "Bem Vinda(o)",
+      "Welcome": "Bem-vinda(o)",
       "Hello": "Olá",
       "MyAccount": "Minha Conta",
       "My": "Meu",


### PR DESCRIPTION
Unrelated to an open issue, I have fixed a "pt-BR" incorrect translation.

Even though the translation was incorrect and was fixed, I searched the codebase for uses of `Nav.Auth.Welcome` and found no references to it.

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named
