### PR TITLE
Update p5Versions.js to include 1.11.10

### DIFF
--- a/common/p5Versions.js
+++ b/common/p5Versions.js
@@ -1,4 +1,4 @@
-export const currentP5Version = '1.11.8'; // Don't update to 2.x until 2026
+export const currentP5Version = '1.11.10'; // Don't update to 2.x until 2026
 
 // Generated from https://www.npmjs.com/package/p5?activeTab=versions
 // Run this in the console:
@@ -10,6 +10,7 @@ export const p5Versions = [
   '2.0.2',
   '2.0.1',
   '2.0.0',
+  '1.11.10',
   '1.11.9',
   '1.11.8',
   '1.11.7',


### PR DESCRIPTION
We recently [released p5.js 1.11.10](https://github.com/processing/p5.js/releases/tag/v1.11.10)! This adds it to the version picker.

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
