### PR TITLE
integrating discord links to readme and about page

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Stay in touch with Processing Foundation across other platforms:
 - [Instagram](https://www.instagram.com/p5xjs)
 - [Youtube](https://www.youtube.com/@ProcessingFoundation)
 - [X](https://x.com/p5xjs)
-- Discord (invitation link coming soon!)
+- [Discord](https://discord.com/invite/esmGA6H6wm)
 - [Forum](https://discourse.processing.org)
 
 

--- a/client/modules/About/statics/aboutData.js
+++ b/client/modules/About/statics/aboutData.js
@@ -14,7 +14,7 @@ export const ContactSectionLinks = [
   { label: 'About.X', href: 'https://x.com/p5xjs' },
   {
     label: 'About.Discord',
-    href: 'https://discord.gg/SHQ8dH25r9'
+    href: 'https://discord.gg/esmGA6H6wm'
   },
   {
     label: 'About.Forum',
@@ -82,7 +82,7 @@ export const AboutSectionInfo = [
         description: 'About.LinkDescriptions.Forum'
       },
       {
-        url: 'https://discord.com/invite/SHQ8dH25r9',
+        url: 'https://discord.com/invite/esmGA6H6wm',
         title: 'About.DiscordCTA',
         description: 'About.LinkDescriptions.Discord'
       }


### PR DESCRIPTION
Fixes #3613

Changes:

- [p5.js-web-editor readme]: Adding the discord invitation link to the Community Section
- [editor.p5.org/about]: Updating the discord invitation link on the About Page: 
  - "Join the Discord" hyperlink under _Get Involved_ section
  - "Discord" hyperlink of the _Socials_ row of the _Contact_ section

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
