### PR TITLE
Include p5.js 2.0.5 in the version picker

### DIFF
--- a/common/p5Versions.js
+++ b/common/p5Versions.js
@@ -5,6 +5,7 @@ export const currentP5Version = '1.11.10'; // Don't update to 2.x until 2026
 // JSON.stringify([...document.querySelectorAll('._132722c7')].map(n => n.innerText), null, 2)
 // TODO: use their API for this to grab these at build time?
 export const p5Versions = [
+  '2.0.5',
   '2.0.4',
   '2.0.3',
   '2.0.2',


### PR DESCRIPTION
We recently [released p5.js 2.0.5](https://github.com/processing/p5.js/releases/tag/v2.0.5)! This adds it to the version picker.

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`