### PR TITLE
Fixes #3620: Keep cookie consent banner visible until user makes a choice

### DIFF
--- a/client/modules/User/components/CookieConsent.jsx
+++ b/client/modules/User/components/CookieConsent.jsx
@@ -161,7 +161,8 @@ function CookieConsent({ hide }) {
     }
   }, [cookieConsent]);
 
-  if (hide || cookieConsent !== 'none') return null;
+  if (hide || cookieConsent === 'all' || cookieConsent === 'essential')
+    return null;
 
   return (
     <Transition in={inProp} timeout={500}>


### PR DESCRIPTION
Fixes #3620 

The cookie consent banner was disappearing too early.
This update makes sure it only hides after a user actually clicks Allow All or Allow Essential, so it stays visible until a choice is made.