### PR TITLE
BUG: fix z-index of popup

### DIFF
--- a/client/modules/User/components/CookieConsent.jsx
+++ b/client/modules/User/components/CookieConsent.jsx
@@ -24,7 +24,7 @@ const CookieConsentContainer = styled.div`
   }};
   left: 0;
   right: 0;
-  z-index: 9999;
+  z-index: 999999999;
   @media print {
     display: none;
   }


### PR DESCRIPTION
Fixes #3620

Changes: update z-index of cookies popup

<img width="1919" height="877" alt="image" src="https://github.com/user-attachments/assets/615d6e8c-bd1b-4f87-ad79-6fdbd94534f4" />


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`

