### PR TITLE
Extracting english texts from source code and replacing by translation entries for the recent "sketch visibility" feature, for both en-US and pt-BR locales

### DIFF
--- a/client/modules/IDE/components/SketchList.jsx
+++ b/client/modules/IDE/components/SketchList.jsx
@@ -148,7 +148,8 @@ const SketchList = ({
                   context: mobile ? 'mobile' : ''
                 })
               )}
-              {userIsOwner && renderFieldHeader('visibility', 'Visibility')}
+              {userIsOwner &&
+                renderFieldHeader('visibility', t('Visibility.Label'))}
               <th scope="col"></th>
             </tr>
           </thead>

--- a/client/modules/User/components/VisibilityDropdown.jsx
+++ b/client/modules/User/components/VisibilityDropdown.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
 import LockIcon from '../../../images/lock.svg';
 import EarthIcon from '../../../images/earth.svg';
 import CheckmarkIcon from '../../../images/checkmark.svg';
@@ -8,18 +9,20 @@ const VisibilityDropdown = ({ sketch, onVisibilityChange, location }) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef(null);
 
+  const { t } = useTranslation();
+
   const visibilityOptions = [
     {
       value: 'Public',
-      label: 'Public',
+      label: t('Visibility.Public.Label'),
       icon: <EarthIcon className="visibility-icon" />,
-      description: 'Anyone can see this sketch'
+      description: t('Visibility.Public.Description')
     },
     {
       value: 'Private',
-      label: 'Private',
+      label: t('Visibility.Private.Label'),
       icon: <LockIcon className="visibility-icon" />,
-      description: 'Only you can see this sketch'
+      description: t('Visibility.Private.Description')
     }
   ];
 

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -675,5 +675,16 @@
   },
   "SkipLink": {
     "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    }
   }
 }

--- a/translations/locales/pt-BR/translations.json
+++ b/translations/locales/pt-BR/translations.json
@@ -606,5 +606,16 @@
   },
   "SkipLink": {
     "PlaySketch": "Pule para reproduzir o esboço"
+  },
+  "Visibility": {
+    "Label": "Visibilidade",
+    "Public": {
+      "Description": "Qualquer um pode ver este esboço.",
+      "Label": "Público"
+    },
+    "Private": {
+      "Description": "Apenas você pode ver este esboço.",
+      "Label": "Privado"
+    }
   }
 }


### PR DESCRIPTION
Extracting english texts from source code and replacing by translation entries for the recent "sketch visibility" feature, for both en-US and pt-BR locales.

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
