### PR TITLE
Fixing mobile menu translations

### DIFF
--- a/client/modules/IDE/components/Header/MobileNav.jsx
+++ b/client/modules/IDE/components/Header/MobileNav.jsx
@@ -437,17 +437,16 @@ const MoreMenu = () => {
           <MobileMenuItem onClick={() => dispatch(newFolder(rootFile.id))}>
             {t('Nav.Sketch.AddFolder')}
           </MobileMenuItem>
-          {/* TODO: Add Translations */}
-          <b>Settings</b>
+          <b>{t('MobilePreferences.Settings')}</b>
           <MobileMenuItem
             onClick={() => {
               dispatch(openPreferences());
             }}
           >
-            Preferences
+            {t('MobilePreferences.Preferences')}
           </MobileMenuItem>
           <MobileMenuItem onClick={() => setIsLanguageModalVisible(true)}>
-            Language
+            {t('MobilePreferences.Language')}
           </MobileMenuItem>
           <b>{t('Nav.Help.Title')}</b>
           <MobileMenuItem onClick={() => dispatch(showKeyboardShortcutModal())}>

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -644,7 +644,9 @@
     "UsedScreenReader": "Used with screen reader",
     "PlainText": "Plain-text",
     "TableText": "Table-text",
-    "Sound": "Sound"
+    "Sound": "Sound",
+    "Preferences": "Preferences",
+    "Language": "Language"
   },
   "PreferenceCreators": {
     "On": "On",

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -122,7 +122,7 @@
     "EmailAddress": "hello@p5js.org",
     "Socials": "Socials",
     "LinkDescriptions": {
-      "Home": "Learn more about p5.js and our community.", 
+      "Home": "Learn more about p5.js and our community.",
       "Examples": "Explore the possibilities of p5.js with short examples.",
       "CodeOfConduct": "Read our Community State and Code of Conduct.",
       "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
@@ -143,7 +143,7 @@
     "SettingsSaved": "Settings saved.",
     "EmptyCurrentPass": "Current password field is empty",
     "IncorrectCurrentPass": "Current password is incorrect",
-    "DefaultError":"Something went wrong",
+    "DefaultError": "Something went wrong",
     "UserNotFound": "User not found",
     "NetworkError": "Network error"
   },
@@ -295,9 +295,9 @@
     "SubmitFeedback": "Submit Feedback",
     "SubmitFeedbackARIA": "submit-feedback",
     "AddCollectionTitle": "Add to collection",
-    "AddCollectionARIA":"add to collection",
+    "AddCollectionARIA": "add to collection",
     "ShareTitle": "Share",
-    "ShareARIA":"share"
+    "ShareARIA": "share"
   },
   "NewFileModal": {
     "Title": "Create File",
@@ -342,7 +342,7 @@
     "errorShortPassword": "Password must be at least 6 characters",
     "errorConfirmPassword": "Please confirm your password",
     "errorNewPassword": "Please enter a new password or leave the current password empty.",
-    "errorNewPasswordRepeat":"Your New Password must differ from the current one.",
+    "errorNewPasswordRepeat": "Your New Password must differ from the current one.",
     "errorEmptyUsername": "Please enter a username.",
     "errorLongUsername": "Username must be less than 20 characters.",
     "errorValidUsername": "Username must only consist of numbers, letters, periods, dashes, and underscores."
@@ -498,7 +498,7 @@
     "Description": "description",
     "NumSketches": "{{count}} sketch",
     "NumSketches_plural": "{{count}} sketches",
-    "By":"Collection by ",
+    "By": "Collection by ",
     "NoSketches": "No sketches in collection",
     "TableSummary": "table containing all collections",
     "HeaderName": "Name",
@@ -562,7 +562,7 @@
   "Overlay": {
     "AriaLabel": "Close {{title}} overlay"
   },
-  "QuickAddList":{
+  "QuickAddList": {
     "ButtonRemoveARIA": "Remove from collection",
     "ButtonAddToCollectionARIA": "Add to collection",
     "View": "View"

--- a/translations/locales/pt-BR/translations.json
+++ b/translations/locales/pt-BR/translations.json
@@ -589,6 +589,11 @@
     "EditSketchARIA": "Editar esboço",
     "ByUser": "por"
   },
+  "MobilePreferences": {
+    "Settings": "Configurações",
+    "Preferences": "Preferências",
+    "Language": "Idioma"
+  },
   "PreferenceCreators": {
     "On": "Ligado",
     "Off": "Desligado"


### PR DESCRIPTION
Fixing mobile menu translations. It also adds missing and removes additional spaces in/from `en-US` locale (using Prettier).

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
