### PR TITLE
fix: white background when content overflows viewport

### DIFF
--- a/client/components/RootPage.tsx
+++ b/client/components/RootPage.tsx
@@ -7,7 +7,7 @@ interface RootPageProps {
 
 export const RootPage = styled.div<RootPageProps>`
   min-height: 100vh;
-  height: ${({ fixedHeight }) => fixedHeight || '100vh'};
+  height: ${({ fixedHeight }) => fixedHeight || 'auto'};
   display: flex;
   justify-content: flex-start;
   flex-direction: column;


### PR DESCRIPTION
Fixes #3563 

Changes: Changed the height property to allow the container to grow with content while maintaining `min-height: 100vh`.

Pages verified after this change: 

- `/about`, 
- `/signup`, 
- `/terms-of-use`, 
- `/privacy-policy`, 
- `/code-of-conduct`

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
