### PR TITLE
Fix:  About page has wrong copy for forum and Discord

### DIFF
--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -124,14 +124,14 @@
     "LinkDescriptions": {
       "Home": "Learn more about p5.js and our community.",
       "Examples": "Explore the possibilities of p5.js with short examples.",
-      "CodeOfConduct": "Read our Community State and Code of Conduct.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
       "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
       "Reference": "Find easy explanations for every piece of p5.js code.",
       "Donate": "Support this work with a donation to the Processing Foundation.",
       "Contribute": "Contribute to the open-source p5.js Editor on Github.",
       "Report": "Report broken or incorrect behavior with the p5.js Editor.",
-      "Forum": "Expand the possibilities of p5.js with community-created libraries.",
-      "Discord": "Expand the possibilities of p5.js with community-created libraries."
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
     }
   },
   "Toast": {


### PR DESCRIPTION
Fixes #3649 

Changes:
Changes the Description of Discord , Code of Conduct ,Join the Forum Section 
as mentioned in the issue 

<img width="1007" height="308" alt="Screenshot 2025-09-21 at 2 18 01 PM" src="https://github.com/user-attachments/assets/93bd1cd0-fbfc-403e-a935-42f8715e7ffe" />

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`) 
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
