### PR TITLE
Displaying p5.js version in About page

### DIFF
--- a/client/modules/About/pages/About.jsx
+++ b/client/modules/About/pages/About.jsx
@@ -52,7 +52,7 @@ const About = () => {
 
   const p5version = useSelector((state) => {
     const index = state.files.find((file) => file.name === 'index.html');
-    return index?.content.match(/\/p5\.js\/([\d.]+)\//)?.[1];
+    return index?.content.match(/\/p5@([\d.]+)\//)?.[1];
   });
 
   return (


### PR DESCRIPTION
Fixes: https://github.com/processing/p5.js-web-editor/issues/3663

Displaying p5.js version in About page

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
