### PR TITLE
[#3691] Add mobile visibility toggle to sketches dropdown

### DIFF
--- a/client/modules/IDE/components/SketchListRowBase.jsx
+++ b/client/modules/IDE/components/SketchListRowBase.jsx
@@ -96,6 +96,14 @@ const SketchListRowBase = ({
     [changeVisibility]
   );
 
+  const isPublic =
+    typeof sketch.visibility === 'string' &&
+    sketch.visibility.toLowerCase() === 'public';
+  const toggleVisibilityFromMenu = () => {
+    const toggle = isPublic ? 'Private' : 'Public';
+    handleVisibilityChange(sketch.id, sketch.name, toggle);
+  };
+
   const userIsOwner = user.username === username;
 
   let url = `/${username}/sketches/${sketch.id}`;
@@ -147,6 +155,14 @@ const SketchListRowBase = ({
           </MenuItem>
           <MenuItem hideIf={!user.authenticated} onClick={onAddToCollection}>
             {t('SketchList.DropdownAddToCollection')}
+          </MenuItem>
+          <MenuItem
+            hideIf={!userIsOwner || !mobile}
+            onClick={toggleVisibilityFromMenu}
+          >
+            {isPublic
+              ? t('SketchList.MakePrivate', 'Make Private')
+              : t('SketchList.MakePublic', 'Make Public')}
           </MenuItem>
           {/* <MenuItem onClick={handleSketchShare}>
             {t('SketchList.DropdownShare')}


### PR DESCRIPTION
Fixes #3691 

Changes:
Added a mobile-only visibility toggle in the /sketches dropdown menu, allowing users to switch between public and private sketches on smaller screens.
Updated SketchListRowBase.jsx to reuse the existing changeVisibility logic for consistency.
Verified responsive behavior and correct state updates across desktop and mobile views.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #3691`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
