### PR TITLE
pr05 Typescript Migration #17: Add typecheck to ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,12 @@ jobs:
     name: Test and lint code base
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js
-      uses: actions/setup-node@v1
-      with:
-        node-version: '18.20.x'
-    - run: npm install
-    - run: npm run test
-    - run: npm run lint
-
-
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '18.20.x'
+      - run: npm install
+      - run: npm run test
+      - run: npm run typecheck
+      - run: npm run lint

--- a/server/routes/passport.routes.ts
+++ b/server/routes/passport.routes.ts
@@ -1,5 +1,6 @@
 import { Router, Request, Response, NextFunction } from 'express';
 import passport from 'passport';
+import { UserDocument } from '../types';
 
 const router = Router();
 
@@ -11,7 +12,7 @@ const authenticateOAuth = (service: string) => (
   passport.authenticate(
     service,
     { failureRedirect: '/login' },
-    (err: unknown, user: unknown) => {
+    (err: unknown, user: UserDocument) => {
       if (err) {
         // use query string param to show error;
         res.redirect(`/account?error=${service}`);


### PR DESCRIPTION
Fixes #issue-number

- https://github.com/processing/p5.js-web-editor/pull/3661 resulted in a typeerror that was uncaught on CI as we did have typecheck on CI yet
- It was on the precommit hook but may have been bypassed

<img width="763" height="169" alt="Screenshot 2025-10-24 at 16 35 44" src="https://github.com/user-attachments/assets/2e57f2ca-d871-4423-99cc-3c14ac8feca2" />

- Update to add `typecheck` to CI

Changes:

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
