### PR TITLE
Enables URL parsing of p5.js version and add-on libraries

### DIFF
--- a/client/modules/IDE/components/Preferences/index.jsx
+++ b/client/modules/IDE/components/Preferences/index.jsx
@@ -21,12 +21,8 @@ import {
   setLinewrap,
   setPreferencesTab
 } from '../../actions/preferences';
-import {
-  majorVersion,
-  p5SoundURL,
-  p5URL,
-  useP5Version
-} from '../../hooks/useP5Version';
+import { majorVersion, p5URL, useP5Version } from '../../hooks/useP5Version';
+import p5SoundURL from '../../../../../common/p5URLs';
 import VersionPicker from '../VersionPicker';
 import { updateFileContent } from '../../actions/files';
 import { CmControllerContext } from '../../pages/IDEView';

--- a/client/modules/IDE/hooks/useP5Version.jsx
+++ b/client/modules/IDE/hooks/useP5Version.jsx
@@ -3,24 +3,22 @@ import React, { useContext, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { currentP5Version, p5Versions } from '../../../../common/p5Versions';
+import {
+  p5SoundURLOldTemplate,
+  p5SoundURL,
+  p5PreloadAddonURL,
+  p5ShapesAddonURL,
+  p5DataAddonURL,
+  p5URLTemplate
+} from '../../../../common/p5URLs';
 
 export const majorVersion = (version) => version.split('.')[0];
 
-export const p5SoundURLOldTemplate =
-  'https://cdnjs.cloudflare.com/ajax/libs/p5.js/$VERSION/addons/p5.sound.min.js';
 export const p5SoundURLOld = p5SoundURLOldTemplate.replace(
   '$VERSION',
   currentP5Version
 );
-export const p5SoundURL =
-  'https://cdn.jsdelivr.net/npm/p5.sound@0.2.0/dist/p5.sound.min.js';
-export const p5PreloadAddonURL =
-  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/preload.js';
-export const p5ShapesAddonURL =
-  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/shapes.js';
-export const p5DataAddonURL =
-  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/data.js';
-export const p5URL = `https://cdn.jsdelivr.net/npm/p5@${currentP5Version}/lib/p5.js`;
+export const p5URL = p5URLTemplate.replace('$VERSION', currentP5Version);
 
 const P5VersionContext = React.createContext({});
 

--- a/client/modules/IDE/reducers/files.js
+++ b/client/modules/IDE/reducers/files.js
@@ -32,7 +32,7 @@ export const initialState = () => {
     },
     {
       name: 'index.html',
-      content: defaultHTML,
+      content: defaultHTML(),
       id: b,
       _id: b,
       fileType: 'file',

--- a/client/modules/IDE/reducers/files.js
+++ b/client/modules/IDE/reducers/files.js
@@ -5,12 +5,14 @@ import {
   defaultCSS,
   defaultHTML
 } from '../../../../server/domain-objects/createDefaultFiles';
+import { parseUrlParams } from '../../../utils/parseURLParams';
 
 export const initialState = () => {
   const a = objectID().toHexString();
   const b = objectID().toHexString();
   const c = objectID().toHexString();
   const r = objectID().toHexString();
+  const params = parseUrlParams(window.location.href);
   return [
     {
       name: 'root',
@@ -32,7 +34,7 @@ export const initialState = () => {
     },
     {
       name: 'index.html',
-      content: defaultHTML(),
+      content: defaultHTML(params),
       id: b,
       _id: b,
       fileType: 'file',

--- a/client/utils/parseURLParams.js
+++ b/client/utils/parseURLParams.js
@@ -1,0 +1,62 @@
+import { p5Versions, currentP5Version } from "../../common/p5Versions";
+
+// One centralized parser
+export function parseUrlParams(url) {
+  const params = new URLSearchParams(new URL(url, 'https://dummy.origin').search);
+
+  return {
+    version: validateVersion(params.get('version')), // string
+    sound: validateSound(params.get('sound')), // bool
+    preload: validatePreload(params.get('preload')), // bool
+    shapes: validateShapes(params.get('shapes')), // bool
+    data: validateData(params.get('data')) // bool
+    // Easy to add more params here
+  };
+}
+
+function validateVersion(version) {
+    if (!version) {
+        return currentP5Version;
+    }
+
+    // if valid return version
+
+    return currentP5Version;
+}
+function validateSound(sound) {
+    return;
+
+    // on, true, 1 == on
+    // off, false, 0 == off
+
+    // default if none triggered
+
+}
+function validatePreload(preload) {
+    return;
+
+    // on, true, 1 == on
+    // off, false, 0 == off
+    
+    // default if none triggered
+
+}
+function validateShapes(shapes) {
+    return;
+
+    // on, true, 1 == on
+    // off, false, 0 == off
+    
+    // default if none triggered
+
+
+}
+function validateData(data) {
+    return;
+
+    // on, true, 1 == on
+    // off, false, 0 == off
+    
+    // default if none triggered
+
+}

--- a/client/utils/parseURLParams.js
+++ b/client/utils/parseURLParams.js
@@ -1,62 +1,80 @@
-import { p5Versions, currentP5Version } from "../../common/p5Versions";
+import { p5Versions, currentP5Version } from '../../common/p5Versions';
+
+const DEFAULTS = {
+  sound: true,
+  preload: false,
+  shapes: false,
+  data: false
+};
 
 // One centralized parser
 export function parseUrlParams(url) {
-  const params = new URLSearchParams(new URL(url, 'https://dummy.origin').search);
+  const params = new URLSearchParams(
+    new URL(url, 'https://dummy.origin').search
+  );
 
   return {
     version: validateVersion(params.get('version')), // string
-    sound: validateSound(params.get('sound')), // bool
-    preload: validatePreload(params.get('preload')), // bool
-    shapes: validateShapes(params.get('shapes')), // bool
-    data: validateData(params.get('data')) // bool
+    sound: validateBool(params.get('sound'), DEFAULTS.sound), // bool
+    preload: validateBool(params.get('preload'), DEFAULTS.preload), // bool
+    shapes: validateBool(params.get('shapes'), DEFAULTS.shapes), // bool
+    data: validateBool(params.get('data'), DEFAULTS.data) // bool
     // Easy to add more params here
   };
 }
 
 function validateVersion(version) {
-    if (!version) {
-        return currentP5Version;
-    }
-
-    // if valid return version
-
+  if (!version) {
     return currentP5Version;
+  }
+  const v = String(version).trim();
+  if (v.toLowerCase() === 'latest') {
+    const newest = getNewestVersion(p5Versions);
+    return newest ?? currentP5Version; //The ?? operator means: “if newest is null or undefined, use currentP5Version
+  }
+  if (v.toLowerCase() === 'current') return currentP5Version;
+  if (p5Versions.includes(v)) return v;
+  const normalized = v.replace(/^v/i, '');
+  if (p5Versions.includes(normalized)) return normalized;
+  //This line strips that leading v using a regular expression ^v (meaning “v at the start”) and then rechecks.
+
+  // if valid return version
+  return currentP5Version;
 }
-function validateSound(sound) {
-    return;
 
-    // on, true, 1 == on
-    // off, false, 0 == off
-
-    // default if none triggered
-
+//picks highest version number from array
+function getNewestVersion(list) {
+  // Defensive copy + semver sort (major.minor.patch)
+  const parts = (s) => s.split('.').map((n) => parseInt(n, 10) || 0);
+  return [...list].sort((a, b) => {
+    const [am, an, ap] = parts(a);
+    const [bm, bn, bp] = parts(b);
+    if (am !== bm) return bm - am;
+    if (an !== bn) return bn - an;
+    return bp - ap;
+  })[0];
 }
-function validatePreload(preload) {
-    return;
 
-    // on, true, 1 == on
-    // off, false, 0 == off
-    
-    // default if none triggered
+function validateBool(value, defaultValue) {
+  if (value) return defaultValue; // param absent
+  //if (value === '') return true; // bare flag: ?flag
 
+  const v = String(value).trim().toLowerCase();
+
+  const TRUTHY = new Set(['on', 'true', '1', 'yes', 'y', 'enable', 'enabled']);
+  const FALSY = new Set([
+    'off',
+    'false',
+    '0',
+    //'no',
+    //'n',
+    //'disable',
+    //'disabled'
+  ]);
+
+  if (TRUTHY.has(v)) return true;
+  if (FALSY.has(v)) return false;
+
+  return defaultValue; // unrecognized → fall back safely
 }
-function validateShapes(shapes) {
-    return;
 
-    // on, true, 1 == on
-    // off, false, 0 == off
-    
-    // default if none triggered
-
-
-}
-function validateData(data) {
-    return;
-
-    // on, true, 1 == on
-    // off, false, 0 == off
-    
-    // default if none triggered
-
-}

--- a/client/utils/parseURLParams.js
+++ b/client/utils/parseURLParams.js
@@ -7,74 +7,81 @@ const DEFAULTS = {
   data: false
 };
 
-// One centralized parser
+/**
+ * Sorts version strings in descending order and returns the highest version
+ * @param {string[]} versions - Array of version strings (e.g., ['1.11.2', '1.11.1'])
+ * @returns {string} The highest version from the array
+ */
+function getNewestVersion(versions) {
+  return versions.sort((a, b) => {
+    const pa = a.split('.').map((n) => parseInt(n, 10));
+    const pb = b.split('.').map((n) => parseInt(n, 10));
+    for (let i = 0; i < 3; i++) {
+      const na = pa[i] || 0;
+      const nb = pb[i] || 0;
+      if (na !== nb) return nb - na;
+    }
+    return 0;
+  })[0];
+}
+
+function validateVersion(version) {
+  if (!version) return currentP5Version;
+
+  const ver = String(version).trim();
+
+  if (p5Versions.includes(ver)) return ver;
+
+  // if only major.minor provided like "1.11"
+  const majorMinorMatch = /^(\d+)\.(\d+)$/.exec(ver);
+  if (majorMinorMatch) {
+    const [, major, minor] = majorMinorMatch;
+    const matches = p5Versions.filter((v) => {
+      const parts = v.split('.');
+      return parts[0] === major && parts[1] === minor;
+    });
+    if (matches.length) {
+      return getNewestVersion(matches);
+    }
+  }
+
+  // if only major provided like "1"
+  const majorOnlyMatch = /^(\d+)$/.exec(ver);
+  if (majorOnlyMatch) {
+    const [, major] = majorOnlyMatch;
+    const matches = p5Versions.filter((v) => v.split('.')[0] === major);
+    if (matches.length) {
+      return getNewestVersion(matches);
+    }
+  }
+
+  return currentP5Version;
+}
+
+function validateBool(value, defaultValue) {
+  if (!value) return defaultValue;
+
+  const v = String(value).trim().toLowerCase();
+
+  const TRUTHY = new Set(['on', 'true', '1']);
+  const FALSY = new Set(['off', 'false', '0']);
+
+  if (TRUTHY.has(v)) return true;
+  if (FALSY.has(v)) return false;
+
+  return defaultValue;
+}
+
 export function parseUrlParams(url) {
   const params = new URLSearchParams(
     new URL(url, 'https://dummy.origin').search
   );
 
   return {
-    version: validateVersion(params.get('version')), // string
-    sound: validateBool(params.get('sound'), DEFAULTS.sound), // bool
-    preload: validateBool(params.get('preload'), DEFAULTS.preload), // bool
-    shapes: validateBool(params.get('shapes'), DEFAULTS.shapes), // bool
-    data: validateBool(params.get('data'), DEFAULTS.data) // bool
-    // Easy to add more params here
+    version: validateVersion(params.get('version')),
+    sound: validateBool(params.get('sound'), DEFAULTS.sound),
+    preload: validateBool(params.get('preload'), DEFAULTS.preload),
+    shapes: validateBool(params.get('shapes'), DEFAULTS.shapes),
+    data: validateBool(params.get('data'), DEFAULTS.data)
   };
 }
-
-function validateVersion(version) {
-  if (!version) {
-    return currentP5Version;
-  }
-  const v = String(version).trim();
-  if (v.toLowerCase() === 'latest') {
-    const newest = getNewestVersion(p5Versions);
-    return newest ?? currentP5Version; //The ?? operator means: “if newest is null or undefined, use currentP5Version
-  }
-  if (v.toLowerCase() === 'current') return currentP5Version;
-  if (p5Versions.includes(v)) return v;
-  const normalized = v.replace(/^v/i, '');
-  if (p5Versions.includes(normalized)) return normalized;
-  //This line strips that leading v using a regular expression ^v (meaning “v at the start”) and then rechecks.
-
-  // if valid return version
-  return currentP5Version;
-}
-
-//picks highest version number from array
-function getNewestVersion(list) {
-  // Defensive copy + semver sort (major.minor.patch)
-  const parts = (s) => s.split('.').map((n) => parseInt(n, 10) || 0);
-  return [...list].sort((a, b) => {
-    const [am, an, ap] = parts(a);
-    const [bm, bn, bp] = parts(b);
-    if (am !== bm) return bm - am;
-    if (an !== bn) return bn - an;
-    return bp - ap;
-  })[0];
-}
-
-function validateBool(value, defaultValue) {
-  if (value) return defaultValue; // param absent
-  //if (value === '') return true; // bare flag: ?flag
-
-  const v = String(value).trim().toLowerCase();
-
-  const TRUTHY = new Set(['on', 'true', '1', 'yes', 'y', 'enable', 'enabled']);
-  const FALSY = new Set([
-    'off',
-    'false',
-    '0',
-    //'no',
-    //'n',
-    //'disable',
-    //'disabled'
-  ]);
-
-  if (TRUTHY.has(v)) return true;
-  if (FALSY.has(v)) return false;
-
-  return defaultValue; // unrecognized → fall back safely
-}
-

--- a/client/utils/parseURLParams.test.js
+++ b/client/utils/parseURLParams.test.js
@@ -1,0 +1,51 @@
+import { parseUrlParams } from './parseURLParams.js';
+import { currentP5Version } from '../../common/p5Versions';
+
+describe('parseUrlParams', () => {
+    test('returns defaults when no params are provided', () => {
+        const url = 'https://example.com';
+        const result = parseUrlParams(url);
+
+        expect(result).toEqual({
+            version: currentP5Version,
+            sound: undefined,
+            preload: undefined,
+            shapes: undefined,
+            data: undefined
+        });
+    });
+
+    test('parses a valid p5 version and falls back for invalid versions', () => {
+        const good = parseUrlParams('https://example.com?version=1.4.0');
+        expect(good.version).toBe('1.4.0');
+
+        const bad = parseUrlParams('https://example.com?version=9.9.9');
+        expect(bad.version).toBe(currentP5Version);
+    });
+
+    test('parses boolean-like params for sound/preload/shapes/data (true variants)', () => {
+        const trueVariants = ['on', 'true', '1', 'ON', 'True'];
+
+        trueVariants.forEach((v) => {
+            const url = `https://example.com?sound=${v}&preload=${v}&shapes=${v}&data=${v}`;
+            const result = parseUrlParams(url);
+            expect(result.sound).toBe(true);
+            expect(result.preload).toBe(true);
+            expect(result.shapes).toBe(true);
+            expect(result.data).toBe(true);
+        });
+    });
+
+    test('parses boolean-like params for sound/preload/shapes/data (false variants)', () => {
+        const falseVariants = ['off', 'false', '0', 'OFF', 'False'];
+
+        falseVariants.forEach((v) => {
+            const url = `https://example.com?sound=${v}&preload=${v}&shapes=${v}&data=${v}`;
+            const result = parseUrlParams(url);
+            expect(result.sound).toBe(false);
+            expect(result.preload).toBe(false);
+            expect(result.shapes).toBe(false);
+            expect(result.data).toBe(false);
+        });
+    });
+});

--- a/client/utils/parseURLParams.test.js
+++ b/client/utils/parseURLParams.test.js
@@ -1,51 +1,51 @@
-import { parseUrlParams } from './parseURLParams.js';
+import { parseUrlParams } from './parseURLParams';
 import { currentP5Version } from '../../common/p5Versions';
 
 describe('parseUrlParams', () => {
-    test('returns defaults when no params are provided', () => {
-        const url = 'https://example.com';
-        const result = parseUrlParams(url);
+  test('returns defaults when no params are provided', () => {
+    const url = 'https://example.com';
+    const result = parseUrlParams(url);
 
-        expect(result).toEqual({
-            version: currentP5Version,
-            sound: undefined,
-            preload: undefined,
-            shapes: undefined,
-            data: undefined
-        });
+    expect(result).toEqual({
+      version: currentP5Version,
+      sound: true,
+      preload: false,
+      shapes: false,
+      data: false
     });
+  });
 
-    test('parses a valid p5 version and falls back for invalid versions', () => {
-        const good = parseUrlParams('https://example.com?version=1.4.0');
-        expect(good.version).toBe('1.4.0');
+  test('parses a valid p5 version and falls back for invalid versions', () => {
+    const good = parseUrlParams('https://example.com?version=1.4.0');
+    expect(good.version).toBe('1.4.0');
 
-        const bad = parseUrlParams('https://example.com?version=9.9.9');
-        expect(bad.version).toBe(currentP5Version);
+    const bad = parseUrlParams('https://example.com?version=9.9.9');
+    expect(bad.version).toBe(currentP5Version);
+  });
+
+  test('parses boolean-like params for sound/preload/shapes/data (true variants)', () => {
+    const trueVariants = ['on', 'true', '1', 'ON', 'True'];
+
+    trueVariants.forEach((v) => {
+      const url = `https://example.com?sound=${v}&preload=${v}&shapes=${v}&data=${v}`;
+      const result = parseUrlParams(url);
+      expect(result.sound).toBe(true);
+      expect(result.preload).toBe(true);
+      expect(result.shapes).toBe(true);
+      expect(result.data).toBe(true);
     });
+  });
 
-    test('parses boolean-like params for sound/preload/shapes/data (true variants)', () => {
-        const trueVariants = ['on', 'true', '1', 'ON', 'True'];
+  test('parses boolean-like params for sound/preload/shapes/data (false variants)', () => {
+    const falseVariants = ['off', 'false', '0', 'OFF', 'False'];
 
-        trueVariants.forEach((v) => {
-            const url = `https://example.com?sound=${v}&preload=${v}&shapes=${v}&data=${v}`;
-            const result = parseUrlParams(url);
-            expect(result.sound).toBe(true);
-            expect(result.preload).toBe(true);
-            expect(result.shapes).toBe(true);
-            expect(result.data).toBe(true);
-        });
+    falseVariants.forEach((v) => {
+      const url = `https://example.com?sound=${v}&preload=${v}&shapes=${v}&data=${v}`;
+      const result = parseUrlParams(url);
+      expect(result.sound).toBe(false);
+      expect(result.preload).toBe(false);
+      expect(result.shapes).toBe(false);
+      expect(result.data).toBe(false);
     });
-
-    test('parses boolean-like params for sound/preload/shapes/data (false variants)', () => {
-        const falseVariants = ['off', 'false', '0', 'OFF', 'False'];
-
-        falseVariants.forEach((v) => {
-            const url = `https://example.com?sound=${v}&preload=${v}&shapes=${v}&data=${v}`;
-            const result = parseUrlParams(url);
-            expect(result.sound).toBe(false);
-            expect(result.preload).toBe(false);
-            expect(result.shapes).toBe(false);
-            expect(result.data).toBe(false);
-        });
-    });
+  });
 });

--- a/common/p5URLs.js
+++ b/common/p5URLs.js
@@ -1,0 +1,12 @@
+export const p5SoundURLOldTemplate =
+  'https://cdnjs.cloudflare.com/ajax/libs/p5.js/$VERSION/addons/p5.sound.min.js';
+export const p5SoundURL =
+  'https://cdn.jsdelivr.net/npm/p5.sound@0.2.0/dist/p5.sound.min.js';
+export const p5PreloadAddonURL =
+  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/preload.js';
+export const p5ShapesAddonURL =
+  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/shapes.js';
+export const p5DataAddonURL =
+  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/data.js';
+export const p5URLTemplate =
+  'https://cdn.jsdelivr.net/npm/p5@$VERSION/lib/p5.js';

--- a/server/domain-objects/createDefaultFiles.js
+++ b/server/domain-objects/createDefaultFiles.js
@@ -8,11 +8,35 @@ function draw() {
   background(220);
 }`;
 
-export const defaultHTML = `<!DOCTYPE html>
+export function defaultHTML({
+  version = currentP5Version,
+  sound = true,
+  preload = false,
+  shapes = false,
+  data = false
+} = {}) {
+  const soundURL = version.startsWith('2.')
+    ? `https://cdn.jsdelivr.net/npm/p5.sound@0.2.0/dist/p5.sound.min.js`
+    : `https://cdnjs.cloudflare.com/ajax/libs/p5.js/${version}/addons/p5.sound.min.js`;
+
+  const libraries = [
+    `<script src="https://cdn.jsdelivr.net/npm/p5@${version}/lib/p5.js"></script>`,
+    sound ? `<script src="${soundURL}"></script>` : '',
+    preload
+      ? `<script src="https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/preload.js"></script>`
+      : '',
+    shapes
+      ? `<script src="https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/shapes.js"></script>`
+      : '',
+    data
+      ? `<script src="https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/data.js"></script>`
+      : ''
+  ].join('\n    ');
+
+  return `<!DOCTYPE html>
 <html lang="en">
   <head>
-    <script src="https://cdn.jsdelivr.net/npm/p5@${currentP5Version}/lib/p5.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/p5@${currentP5Version}/lib/addons/p5.sound.min.js"></script>
+    ${libraries}
     <link rel="stylesheet" type="text/css" href="style.css">
     <meta charset="utf-8" />
 
@@ -24,6 +48,7 @@ export const defaultHTML = `<!DOCTYPE html>
   </body>
 </html>
 `;
+}
 
 export const defaultCSS = `html, body {
   margin: 0;
@@ -37,7 +62,7 @@ canvas {
 export default function createDefaultFiles() {
   return {
     'index.html': {
-      content: defaultHTML
+      content: defaultHTML()
     },
     'style.css': {
       content: defaultCSS

--- a/server/domain-objects/createDefaultFiles.js
+++ b/server/domain-objects/createDefaultFiles.js
@@ -1,4 +1,12 @@
 import { currentP5Version } from '../../common/p5Versions';
+import {
+  p5SoundURLOldTemplate,
+  p5SoundURL,
+  p5PreloadAddonURL,
+  p5ShapesAddonURL,
+  p5DataAddonURL,
+  p5URLTemplate
+} from '../../common/p5URLs';
 
 export const defaultSketch = `function setup() {
   createCanvas(400, 400);
@@ -8,6 +16,8 @@ function draw() {
   background(220);
 }`;
 
+const majorVersion = (version) => version.split('.')[0];
+
 export function defaultHTML({
   version = currentP5Version,
   sound = true,
@@ -15,22 +25,19 @@ export function defaultHTML({
   shapes = false,
   data = false
 } = {}) {
-  const soundURL = version.startsWith('2.')
-    ? `https://cdn.jsdelivr.net/npm/p5.sound@0.2.0/dist/p5.sound.min.js`
-    : `https://cdnjs.cloudflare.com/ajax/libs/p5.js/${version}/addons/p5.sound.min.js`;
+  const p5URL = p5URLTemplate.replace('$VERSION', version);
+
+  const soundURL =
+    majorVersion(version) === '2'
+      ? p5SoundURL
+      : p5SoundURLOldTemplate.replace('$VERSION', version);
 
   const libraries = [
-    `<script src="https://cdn.jsdelivr.net/npm/p5@${version}/lib/p5.js"></script>`,
+    `<script src="${p5URL}"></script>`,
     sound ? `<script src="${soundURL}"></script>` : '',
-    preload
-      ? `<script src="https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/preload.js"></script>`
-      : '',
-    shapes
-      ? `<script src="https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/shapes.js"></script>`
-      : '',
-    data
-      ? `<script src="https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/data.js"></script>`
-      : ''
+    preload ? `<script src="${p5PreloadAddonURL}"></script>` : '',
+    shapes ? `<script src="${p5ShapesAddonURL}"></script>` : '',
+    data ? `<script src="${p5DataAddonURL}"></script>` : ''
   ].join('\n    ');
 
   return `<!DOCTYPE html>


### PR DESCRIPTION
Fixes #3647

## Changes

- Adds URL parser to allow p5.js version to be configured from URL.
- Includes URL parser test file to test edge cases and fallback response.

### Potential future extensions addressed

- Supports latest patch and minor versions as requested in issue #3647
- URL parser allows for toggling on and off add-on libraries with robust variants allowed.

## Demo Video

[Demo Video](https://youtu.be/Kg6xKqNQFTQ) (Wasn't able to upload it directly sorry!)

Video demonstrates:
- Default behavior (remains the same)
- Different version inputs
- Add-on toggling functionality
- Fallback behavior for invalid inputs
- Edge case handling for the sound add-on URL with p5 version 2.x vs 1.x/0.x

## Note about TypeScript migration

We began working on this before contributions to the migration effort were open to the public (October 31, 2025). As such, our implementation is in JavaScript. Given that it is now past October 31, we can:

- Edit our changes to utilize TypeScript
- Open a separate issue for migrating the URL parser to TypeScript
- Leave the changes as is
- Another approach (your choice)

Let us know your preference.

## I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
