### PR TITLE
Fix: 3741 - enable `fetch-examples` script to resolve both ts and js files

### DIFF
--- a/server/scripts/fetch-examples.js
+++ b/server/scripts/fetch-examples.js
@@ -1,4 +1,7 @@
-require('@babel/register');
+require('@babel/register')({
+  extensions: ['.js', '.ts'],
+  presets: ['@babel/preset-env', '@babel/preset-typescript']
+});
 require('regenerator-runtime/runtime');
 const dotenv = require('dotenv');
 


### PR DESCRIPTION
Fix https://github.com/processing/p5.js-web-editor/issues/3714
- script/fetch-examples calls script/examples
- inside script/examples we import the newly migrated /server/models/user file
- this file needs to know to try to resolve both ts and js files, instead of just js

Fixes #issue-number 3714

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
