### PR TITLE
Remove Donation Compaign and Address Warnings

### DIFF
--- a/client/index.jsx
+++ b/client/index.jsx
@@ -23,7 +23,10 @@ const store = setupStore(initialState);
 
 const DONATE_LOGO_IMAGE_URL = 'https://donorbox.org/images/white_logo.svg';
 
+const showDonateCampaign = false;
+
 if (
+  showDonateCampaign &&
   window.location.href.indexOf('full') === -1 &&
   window.location.href.indexOf('embed') === -1
 ) {

--- a/client/utils/showRenameDialog.jsx
+++ b/client/utils/showRenameDialog.jsx
@@ -1,6 +1,6 @@
 import announceToScreenReader from './ScreenReaderHelper';
 import p5CodeAstAnalyzer from './p5CodeAstAnalyzer';
-import { getClassContext, getContext, getAST } from './renameVariableHelper';
+import { getContext, getAST } from './renameVariableHelper';
 
 const allFuncs = require('./p5-reference-functions.json');
 

--- a/common/p5Versions.js
+++ b/common/p5Versions.js
@@ -1,4 +1,4 @@
-export const currentP5Version = '1.11.10'; // Don't update to 2.x until 2026
+export const currentP5Version = '1.11.11'; // Don't update to 2.x until 2026
 
 // Generated from https://www.npmjs.com/package/p5?activeTab=versions
 // Run this in the console:


### PR DESCRIPTION
Changes:
- Adds a `showDonationCampaign` variable set to `false` to remove visibility of donation campaign, which may be reused in the future. 
- Addresses warnings in `client/utils/rename-variable.js` and `client/index.jsx`

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
