### PR TITLE
Update p5.js compatibility URLs to version 0.2.0

### DIFF
--- a/client/modules/IDE/hooks/useP5Version.jsx
+++ b/client/modules/IDE/hooks/useP5Version.jsx
@@ -15,11 +15,11 @@ export const p5SoundURLOld = p5SoundURLOldTemplate.replace(
 export const p5SoundURL =
   'https://cdn.jsdelivr.net/npm/p5.sound@0.2.0/dist/p5.sound.min.js';
 export const p5PreloadAddonURL =
-  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/preload.js';
+  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/preload.js';
 export const p5ShapesAddonURL =
-  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/shapes.js';
+  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/shapes.js';
 export const p5DataAddonURL =
-  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.1.2/src/data.js';
+  'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/data.js';
 export const p5URL = `https://cdn.jsdelivr.net/npm/p5@${currentP5Version}/lib/p5.js`;
 
 const P5VersionContext = React.createContext({});


### PR DESCRIPTION
To reflect updates in [p5.js-compatibility modules](https://github.com/processing/p5.js-compatibility), the paths have been updated

I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
