### PR TITLE
fix: update deprecated codemirror import to restore Storybook build

### DIFF
--- a/client/styles/main.scss
+++ b/client/styles/main.scss
@@ -6,7 +6,7 @@
 @import 'base/reset';
 @import 'base/base';
 
-@import '~codemirror/lib/codemirror';
+@import 'codemirror/lib/codemirror.css';
 @import '~codemirror/addon/lint/lint';
 @import '~codemirror-colorpicker/addon/codemirror-colorpicker';
 @import '~dropzone/dist/dropzone';


### PR DESCRIPTION
### Summary
Storybook’s CSS build was failing because Sass no longer supports the ~ tilde import syntax. 

### Problem
The file `client/styles/main.scss` still uses the old pattern:
@import '~codemirror/lib/codemirror';

This causes Sass to throw:
"Can't find stylesheet to import"

### Fix
Updated the SCSS import to the modern path:
@import 'codemirror/lib/codemirror.css';

This resolves the Storybook build issue and improves contributor experience.

No breaking changes.
