### PR TITLE
EOY 2025 Donation Banner

### DIFF
--- a/client/modules/IDE/components/Banner.jsx
+++ b/client/modules/IDE/components/Banner.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { Trans } from 'react-i18next';
 import { CrossIcon } from '../../../common/icons';
 
 /**
@@ -23,12 +24,11 @@ import { CrossIcon } from '../../../common/icons';
 
 const Banner = ({ onClose }) => {
   // URL can be updated depending on the opportunity or announcement.
-  const bannerURL = 'https://openprocessing.org/curation/89576';
+  const bannerURL = 'https://processingfoundation.org/donate';
+
   const bannerCopy = (
     <>
-      We’re accepting p5.js sketches for a special curation exploring mental
-      health and the newest features in p5.js 2.0!{' '}
-      <span style={{ fontWeight: 600 }}>Submit by July 20!</span>
+      <Trans i18nKey="Banner.Copy" components={{ bold: <strong /> }} />
     </>
   );
 

--- a/client/modules/IDE/components/Preferences/index.jsx
+++ b/client/modules/IDE/components/Preferences/index.jsx
@@ -22,7 +22,7 @@ import {
   setPreferencesTab
 } from '../../actions/preferences';
 import { majorVersion, p5URL, useP5Version } from '../../hooks/useP5Version';
-import p5SoundURL from '../../../../../common/p5URLs';
+import { p5SoundURL } from '../../../../../common/p5URLs';
 import VersionPicker from '../VersionPicker';
 import { updateFileContent } from '../../actions/files';
 import { CmControllerContext } from '../../pages/IDEView';

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -49,6 +49,9 @@
       "LogOut": "Log Out"
     }
   },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Toggle Replace",
     "Find": "Find",

--- a/translations/locales/es-419/translations.json
+++ b/translations/locales/es-419/translations.json
@@ -47,6 +47,9 @@
       "LogOut": "Cerrar sesión"
     }
   },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Alternar reemplazar",
     "Find": "Buscar",

--- a/translations/locales/fr-CA/translations.json
+++ b/translations/locales/fr-CA/translations.json
@@ -48,6 +48,9 @@
         "LogOut": "Se déconnecter"
       }
     },
+    "Banner": {
+      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "Activer/désactiver le remplacement",
       "Find": "Rechercher",

--- a/translations/locales/hi/translations.json
+++ b/translations/locales/hi/translations.json
@@ -47,6 +47,9 @@
         "LogOut": "लॉग आउट"
       }
     },
+    "Banner": {
+      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "टॉगल बदली करें",
       "Find": "खोज",

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -47,6 +47,9 @@
       "LogOut": "Esci"
     }
   },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Attiva/disattiva Sostituzione",
     "Find": "Cerca",

--- a/translations/locales/ja/translations.json
+++ b/translations/locales/ja/translations.json
@@ -47,6 +47,9 @@
         "LogOut": "ログアウト"
       }
     },
+    "Banner": {
+      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "置換の切り替え",
       "Find": "検索",

--- a/translations/locales/ko/translations.json
+++ b/translations/locales/ko/translations.json
@@ -48,6 +48,9 @@
       "LogOut": "로그아웃"
     }
   },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
   "LoginForm": {
     "UsernameOrEmail": "이메일 또는 아이디",
     "UsernameOrEmailARIA": "이메일 또는 아이디",

--- a/translations/locales/pt-BR/translations.json
+++ b/translations/locales/pt-BR/translations.json
@@ -45,6 +45,9 @@
       "LogOut": "Sair"
     }
   },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Alternar entre localizar/substituir",
     "FindPlaceholder": "Localizar em arquivos",

--- a/translations/locales/sv/translations.json
+++ b/translations/locales/sv/translations.json
@@ -47,6 +47,9 @@
       "LogOut": "Logga ut"
     }
   },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Växla ersätt",
     "Find": "Sök",

--- a/translations/locales/tr/translations.json
+++ b/translations/locales/tr/translations.json
@@ -47,6 +47,9 @@
       "LogOut": "Çıkış Yap"
     }
   },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Değiştirme Aç/Kapa",
     "Find": "Bul",

--- a/translations/locales/uk-UA/translations.json
+++ b/translations/locales/uk-UA/translations.json
@@ -47,6 +47,9 @@
       "LogOut": "Вийти"
     }
   },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Увімкнути заміну",
     "Find": "Знайти",

--- a/translations/locales/ur/translations.json
+++ b/translations/locales/ur/translations.json
@@ -47,6 +47,9 @@
         "LogOut": "لاگ آوٹ"
       }
     },
+    "Banner": {
+      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "تبدیل کرنے کو ٹوگل کریں۔",
       "Find": "تلاش کریں",

--- a/translations/locales/zh-CN/translations.json
+++ b/translations/locales/zh-CN/translations.json
@@ -47,6 +47,9 @@
       "LogOut": "登出"
     }
   },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "开关替换选项",
     "Find": "查找",

--- a/translations/locales/zh-TW/translations.json
+++ b/translations/locales/zh-TW/translations.json
@@ -47,6 +47,9 @@
       "LogOut": "登出"
     }
   },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "切換取代",
     "Find": "尋找",


### PR DESCRIPTION
Changes:
- Sets the visibility for the Slim Donation Banner to `true` for the EOY 2025 PF Fundraiser with updated copy.
- Populates the `Banner` dynamically through i18n instead of static text. Adds translations to all language files. 
- Adds a banner cooldown so it reappears every 30 minutes after it's closed. 
- Updates `p5SoundURL` to be imported as a named export rather than a default export to address warning. 

<img width="1444" height="492" alt="Screenshot 2025-12-01 at 7 04 11 PM" src="https://github.com/user-attachments/assets/2896ba3e-1c80-49b4-a49f-57da818a68e4" />


I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
