### PR TITLE
Add typecheck-check into pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,6 +6,7 @@ I have verified that this pull request:
 
 * [ ] has no linting errors (`npm run lint`)
 * [ ] has no test errors (`npm run test`)
+* [ ] has no typecheck errors (`npm run typecheck`)
 * [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
 * [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
 * [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)


### PR DESCRIPTION
Fixes #issue-number - none

Adding this as I noticed it's not in the PR template yet and might be useful for folks wanting to contribute for the first time via typescript migration contributions

Changes:

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
