### PR TITLE
Switch to jsdelivr for p5.sound CDN

### DIFF
--- a/common/p5URLs.js
+++ b/common/p5URLs.js
@@ -1,5 +1,5 @@
 export const p5SoundURLOldTemplate =
-  'https://cdnjs.cloudflare.com/ajax/libs/p5.js/$VERSION/addons/p5.sound.min.js';
+  'https://cdn.jsdelivr.net/npm/p5@$VERSION/lib/addons/p5.sound.min.js';
 export const p5SoundURL =
   'https://cdn.jsdelivr.net/npm/p5.sound@0.2.0/dist/p5.sound.min.js';
 export const p5PreloadAddonURL =


### PR DESCRIPTION
Fixes https://github.com/processing/p5.js-web-editor/issues/3728

Apologies for jumping the queue on this one, but since we've been seeing a number of reports both on the p5.js repo, Discord, subreddit, this seems like maybe the sort of thing worth fixing ourselves rather than applying time pressure to community members.

This switches the CDN used for 1.x p5.sound from Cloudflare's cdnjs to jsdelivr. This is [not the first time we've seen issues with cdnjs](https://github.com/processing/p5.js-website/pull/579), so on the p5 website and elsewhere in the web editor, we've switched to jsdelivr, which seems to be a more automated cache of files from npm and has been more stable for us.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)

Tested with this sketch code in the default project:

```js
let mySound;

function preload(){
  mySound = loadSound("https://upload.wikimedia.org/wikipedia/commons/d/d9/Wilhelm_Scream.ogg");
}

function setup() {
  createCanvas(400, 400);
  background(220);
  text("click to play sound", 10,10);
}

function mousePressed() {
  mySound.play();
}
```