### PR TITLE
Fix Blank Editor for S3-hosted Files (>80KB) and Improve Upload UX (#1516)

### DIFF
--- a/client/modules/IDE/actions/files.js
+++ b/client/modules/IDE/actions/files.js
@@ -11,6 +11,8 @@ import {
 import { setProjectSavedTime } from './project';
 import { createError } from './ide';
 
+const TEXT_FILE_REGEX = /\.(js|jsx|html|css|json|txt|csv|tsv|vert|frag|xml)$/i;
+
 export function appendToFilename(filename, string) {
   const dotIndex = filename.lastIndexOf('.');
   if (dotIndex === -1) return filename + string;
@@ -245,4 +247,23 @@ export function getBlobUrl(file) {
   const fileBlob = blobUtil.createBlob([file.content], { type: 'text/plain' });
   const blobURL = blobUtil.createObjectURL(fileBlob);
   return blobURL;
+}
+
+export function fetchS3FileContent(file) {
+  return (dispatch) => {
+    if (file.url && !file.content && TEXT_FILE_REGEX.test(file.name)) {
+      return fetch(file.url)
+        .then((response) => {
+          if (!response.ok) throw new Error('Failed to fetch from S3');
+          return response.text();
+        })
+        .then((text) => {
+          dispatch(updateFileContent(file.id, text));
+        })
+        .catch((err) => {
+          console.error('S3 Fetch Error:', err);
+        });
+    }
+    return Promise.resolve();
+  };
 }

--- a/client/modules/IDE/actions/ide.js
+++ b/client/modules/IDE/actions/ide.js
@@ -1,6 +1,7 @@
 import * as ActionTypes from '../../../constants';
 import { clearConsole } from './console';
 import { dispatchMessage, MessageTypes } from '../../../utils/dispatcher';
+import * as FileActions from './files';
 
 export function startVisualSketch() {
   return {
@@ -46,9 +47,16 @@ export function stopAccessibleOutput() {
 }
 
 export function setSelectedFile(fileId) {
-  return {
-    type: ActionTypes.SET_SELECTED_FILE,
-    selectedFile: fileId
+  return (dispatch, getState) => {
+    const state = getState();
+    const file = state.files.find((f) => f.id === fileId);
+    dispatch({
+      type: ActionTypes.SET_SELECTED_FILE,
+      selectedFile: fileId
+    });
+    if (file && file.url && !file.content) {
+      dispatch(FileActions.fetchS3FileContent(file));
+    }
   };
 }
 

--- a/client/modules/IDE/actions/uploader.js
+++ b/client/modules/IDE/actions/uploader.js
@@ -29,7 +29,7 @@ export async function dropzoneAcceptCallback(userId, file, done) {
       // eslint-disable-next-line no-param-reassign
       file.content = await file.text();
       // Make it an error so that it won't be sent to S3, but style as a success.
-      done('Uploading plaintext file locally.');
+      done('Large text file detected: Loading locally for editing.');
       file.previewElement.classList.remove('dz-error');
       file.previewElement.classList.add('dz-success');
       file.previewElement.classList.add('dz-processing');

--- a/client/styles/components/_uploader.scss
+++ b/client/styles/components/_uploader.scss
@@ -5,4 +5,16 @@
     max-height: 70vh;
     overflow-y: auto;
   }
+  .dz-preview.dz-success {
+    .dz-error-message {
+      display: block !important;
+      opacity: 1 !important;
+      background: #4caf50 !important;
+      color: white !important;
+
+      &:after {
+        border-bottom: 6px solid #4caf50 !important;
+      }
+    }
+  }
 }


### PR DESCRIPTION
Fixes  #1516   https://github.com/processing/p5.js-web-editor/issues/1516

Changes:

1. Root Cause Analysis (RCA)
The Visibility Issue: Files under 80KB are stored in the database's content field. However, files exceeding 80KB are hosted on an S3 bucket, leaving the content field empty and providing a url instead. The editor component was previously only rendering the content property; since this was empty for S3 files, the editor window remained blank.

The UX Confusion: In uploader.js, large plaintext files are intercepted to be handled locally. Passing a string to Dropzone's done() callback automatically triggers an "error" state, rendering a red notification box that users mistook for an upload failure.

2. Proposed Changes
A. Lazy-Loading S3 Content
Action Implementation (client/modules/IDE/actions/files.js): Created fetchS3FileContent to handle asynchronous GET requests for files that have a url but no content.

Thunk Update (client/modules/IDE/actions/ide.js): Modified the setSelectedFile thunk. Now, whenever a file is selected, the IDE checks if it is a text file with missing content. If so, it triggers the fetch action to populate the editor on-demand.

B. UX Styling Improvements
Message Update (client/modules/IDE/actions/uploader.js): Updated the local interceptor message to be more descriptive.

CSS Enhancement (client/styles/components/_uploader.scss): Added a scoped override for .dz-error-message. When a file is marked with the .dz-success class, the background color now transitions to a success green, clearly indicating that the local handling was intended and successful.

3. Verification and Testing
Since a local development environment typically lacks production AWS/S3 credentials, I verified the fix using a State Injection (Mocking) Strategy:

Redux State Manipulation: Temporarily exposed the store globally and manually cleared the content of a local test file while injecting a raw GitHub URL into the url property.

Selection Trigger: Clicked the modified file in the sidebar to trigger the updated setSelectedFile thunk.

Network Confirmation: Observed the Network Tab in Chrome DevTools to verify a successful GET request was fired to the mock URL.

State Consistency: Confirmed via store.getState() that the fetched text successfully replaced the empty state, allowing the editor to render the file content correctly.

4. Impact
Users: Can now view and use larger scripts (e.g., jszip.min.js) that were previously inaccessible in the editor interface.

Clarity: The upload UX is now more intuitive, providing positive visual feedback for local file handling.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
