### PR TITLE
fix: resolve 502 error on project download (Fixes #3746)

### DIFF
--- a/server/controllers/project.controller.js
+++ b/server/controllers/project.controller.js
@@ -234,10 +234,12 @@ async function addFileToZip(file, files, zip) {
   } else if (file.url) {
     try {
       const res = await axios.get(file.url, {
-        responseType: 'arraybuffer'
+        responseType: 'arraybuffer',
+        timeout: 30000 // 30 second timeout to prevent hanging requests
       });
       zip.file(file.name, res.data);
     } catch (e) {
+      console.warn(`Failed to fetch file from ${file.url}:`, e.message);
       zip.file(file.name, new ArrayBuffer(0));
     }
   } else {
@@ -261,25 +263,48 @@ async function buildZip(project, req, res) {
 
     const base64 = await zip.generateAsync({ type: 'base64' });
     const buff = Buffer.from(base64, 'base64');
+
+    // nityam Check if response was already sent (e.g., client disconnected)
+    if (res.headersSent) {
+      return;
+    }
+
     res.writeHead(200, {
       'Content-Type': 'application/zip',
       'Content-disposition': `attachment; filename=${zipFileName}`
     });
     res.end(buff);
   } catch (err) {
-    console.error(err);
-    res.status(500).send(err);
+    console.error('Error building zip file:', err);
+    // Only send error if response hasn't been sent yet
+    if (!res.headersSent) {
+      res.status(500).json({
+        success: false,
+        message: 'Failed to generate zip file. Please try again.'
+      });
+    }
   }
 }
 
 export async function downloadProjectAsZip(req, res) {
-  const project = await Project.findById(req.params.project_id).exec();
-  if (!project) {
-    res.status(404).send({ message: 'Project with that id does not exist' });
-    return;
+  try {
+    const project = await Project.findById(req.params.project_id).exec();
+    if (!project) {
+      res.status(404).send({ message: 'Project with that id does not exist' });
+      return;
+    }
+    // Await buildZip to ensure it completes before the function returns
+    await buildZip(project, req, res);
+  } catch (err) {
+    console.error('Error in downloadProjectAsZip:', err);
+    // Only send error if response hasn't been sent yet
+    if (!res.headersSent) {
+      res.status(500).json({
+        success: false,
+        message: 'Failed to download project. Please try again.'
+      });
+    }
   }
-  // save project to some path
-  buildZip(project, req, res);
 }
 
 export async function changeProjectVisibility(req, res) {


### PR DESCRIPTION
## Progress towards #3746

## Problem
The `downloadProjectAsZip` function was calling `buildZip` without awaiting it, causing a 502 Bad Gateway error when downloading projects. This led to:
- Unhandled promise rejections if `buildZip` threw errors
- No timeout on S3 file fetches, causing requests to hang indefinitely
- Race conditions when clients disconnected before completion

## Changes Made
- **Added `await` to `buildZip` call** in `downloadProjectAsZip` to ensure errors are properly caught and the function waits for completion before responding
- **Added 30-second timeout** to axios requests when fetching files from S3 to prevent hanging requests
- **Improved error handling** by checking `res.headersSent` before sending error responses to avoid crashes on client disconnects
- **Enhanced error logging** with more descriptive error messages for better debugging

## Testing
I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)