### PR TITLE
Add optional +/− controls for live canvas resizing in Preview panel

### DIFF
--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -28,6 +28,7 @@ import IDEOverlays from '../components/IDEOverlays';
 import useIsMobile from '../hooks/useIsMobile';
 import Banner from '../components/Banner';
 import { P5VersionProvider } from '../hooks/useP5Version';
+import { dispatchMessage, MessageTypes } from '../../../utils/dispatcher';
 
 const BANNER_DISMISS_KEY = 'bannerLastDismissedAt';
 const BANNER_COOLDOWN_MINUTES = 30;
@@ -47,6 +48,13 @@ function isAuth(pathname) {
 
 function isOverlay(pathname) {
   return pathname === '/feedback';
+}
+
+function resize(delta) {
+  dispatchMessage({
+    type: MessageTypes.RESIZE_CANVAS,
+    payload: delta
+  });
 }
 
 function WarnIfUnsavedChanges() {
@@ -301,10 +309,26 @@ const IDEView = () => {
                   <Console />
                 </SplitPane>
                 <section className="preview-frame-holder">
-                  <header className="preview-frame__header">
+                  <header
+                    className="preview-frame__header"
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      minHeight: 36,
+                      paddingRight: 8,
+                      zIndex: 2
+                    }}
+                  >
                     <h2 className="preview-frame__title">
                       {t('Toolbar.Preview')}
                     </h2>
+                    <button
+                      style={{ marginLeft: 'auto' }}
+                      onClick={() => resize(+50)}
+                    >
+                      +
+                    </button>
+                    <button onClick={() => resize(-50)}>−</button>
                   </header>
                   <div className="preview-frame__content">
                     <PreviewFrame

--- a/client/modules/Preview/EmbedFrame.jsx
+++ b/client/modules/Preview/EmbedFrame.jsx
@@ -238,6 +238,48 @@ p5.prototype.registerMethod('afterSetup', p5.prototype.ensureAccessibleCanvas);`
   previewScripts.setAttribute('crossorigin', '');
   sketchDoc.head.appendChild(previewScripts);
 
+  const resizeHelper = sketchDoc.createElement('script');
+  resizeHelper.innerHTML = `
+    (function () {
+      if (!window.p5) return;
+
+      let currentP5 = null;
+
+      p5.prototype.registerMethod('afterSetup', function () {
+        currentP5 = this;
+
+        window.__resizeP5Canvas = function (delta) {
+          if (!currentP5 || typeof delta !== 'number') return;
+
+          try {
+            const minSize = 50;
+            const maxSize = 5000;
+
+            const newWidth = Math.min(
+              maxSize,
+              Math.max(minSize, currentP5.width + delta)
+            );
+
+            const newHeight = Math.min(
+              maxSize,
+              Math.max(minSize, currentP5.height + delta)
+            );
+
+            currentP5.resizeCanvas(newWidth, newHeight);
+          } catch (e) {
+            console.warn('Canvas resize failed', e);
+          }
+        };
+      });
+
+      window.addEventListener('unload', () => {
+        delete window.__resizeP5Canvas;
+        currentP5 = null;
+      });
+    })();
+  `;
+  sketchDoc.head.appendChild(resizeHelper);
+
   const sketchDocString = `<!DOCTYPE HTML>\n${sketchDoc.documentElement.outerHTML}`;
   scriptOffs = getAllScriptOffsets(sketchDocString);
   const consoleErrorsScript = sketchDoc.createElement('script');
@@ -261,11 +303,12 @@ function EmbedFrame({ files, isPlaying, basePath, gridOutput, textOutput }) {
   const iframe = useRef();
   const htmlFile = useMemo(() => getHtmlFile(files), [files]);
   const srcRef = useRef();
+  const previewOrigin = getConfig('PREVIEW_URL');
 
   useEffect(() => {
     const unsubscribe = registerFrame(
       iframe.current.contentWindow,
-      window.origin
+      previewOrigin
     );
     return () => {
       unsubscribe();

--- a/client/modules/Preview/previewIndex.jsx
+++ b/client/modules/Preview/previewIndex.jsx
@@ -18,13 +18,26 @@ const GlobalStyle = createGlobalStyle`
   }
 `;
 
+function callSketchResize(delta) {
+  const sketchFrame = document.querySelector(
+    'iframe[aria-label="Sketch Preview"]'
+  );
+
+  if (!sketchFrame || !sketchFrame.contentWindow) return;
+
+  sketchFrame.contentWindow.__resizeP5Canvas?.(delta);
+}
+
 const App = () => {
   const [state, dispatch] = useReducer(filesReducer, [], initialState);
   const [isPlaying, setIsPlaying] = useState(false);
   const [basePath, setBasePath] = useState('');
   const [textOutput, setTextOutput] = useState(false);
   const [gridOutput, setGridOutput] = useState(false);
-  registerFrame(window.parent, getConfig('EDITOR_URL'));
+  useEffect(() => {
+    const unregister = registerFrame(window.parent, getConfig('EDITOR_URL'));
+    return unregister;
+  }, []);
 
   function handleMessageEvent(message) {
     const { type, payload } = message;
@@ -47,6 +60,9 @@ const App = () => {
       case MessageTypes.EXECUTE:
         dispatchMessage(payload);
         break;
+      case MessageTypes.RESIZE_CANVAS:
+        callSketchResize(payload);
+        break;
       default:
         break;
     }
@@ -66,11 +82,9 @@ const App = () => {
   }
 
   useEffect(() => {
-    const unsubscribe = listen(handleMessageEvent);
-    return function cleanup() {
-      unsubscribe();
-    };
-  });
+    const unlisten = listen(handleMessageEvent);
+    return unlisten;
+  }, []);
   return (
     <React.Fragment>
       <GlobalStyle />

--- a/client/utils/dispatcher.ts
+++ b/client/utils/dispatcher.ts
@@ -14,7 +14,8 @@ export enum MessageTypes {
   FILES = 'FILES',
   SKETCH = 'SKETCH',
   REGISTER = 'REGISTER',
-  EXECUTE = 'EXECUTE'
+  EXECUTE = 'EXECUTE',
+  RESIZE_CANVAS = 'RESIZE_CANVAS'
 }
 /* eslint-enable no-shadow */
 


### PR DESCRIPTION
Related to #3768 

Changes:

I have verified that this pull request:
- Adds + / − resize controls to the Preview header
- Resizes the active canvas live using `resizeCanvas()` without reloading
- Intentionally limited to the non-logged-in editor view for safety

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
