### PR TITLE
fix-make nav back icon visible and made the sepration

### DIFF
--- a/client/modules/IDE/components/Header/Nav.jsx
+++ b/client/modules/IDE/components/Header/Nav.jsx
@@ -134,8 +134,8 @@ const DashboardMenu = () => {
   const editorLink = useSelector(selectSketchPath);
   return (
     <ul className="nav__items-left" role="group">
-      <li className="nav__item nav__item--no-icon">
-        <Link to={editorLink} className="nav__back-link">
+      <li className="nav__item--no-icon">
+        <Link to={editorLink} className="nav__back-link nav__item">
           <CaretLeftIcon
             className="nav__back-icon"
             focusable="false"

--- a/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
+++ b/client/modules/IDE/components/Header/__snapshots__/Nav.unit.test.jsx.snap
@@ -31,10 +31,10 @@ exports[`Nav renders dashboard version for desktop 1`] = `
           role="group"
         >
           <li
-            class="nav__item nav__item--no-icon"
+            class="nav__item--no-icon"
           >
             <a
-              class="nav__back-link"
+              class="nav__back-link nav__item"
               href="/"
             >
               <test-file-stub

--- a/client/styles/components/_nav.scss
+++ b/client/styles/components/_nav.scss
@@ -112,6 +112,7 @@
 
 .nav__item--no-icon {
   padding-left: #{math.div(15, $base-font-size)}rem;
+  height:100%
 }
 
 .nav__item-header-triangle polygon,
@@ -277,4 +278,13 @@
 
 .nav__back-link {
   display: flex;
+  height: 100%;
+  &:hover .nav__back-icon {
+    & g, & path {
+      @include themify() {
+        fill: getThemifyVariable('button-hover-color');
+      }
+    }
+  }
 }
+


### PR DESCRIPTION
Fixes #3733 

Changes:

I have verified that this pull request:

### What this PR does
- Ensures nav back icon color remains visible
- Prevents opacity or theming issues

### Changes made
- Updated SCSS for nav back icon
- Forced white color visibility
