### PR TITLE
Fixes IDE Overlays Leading to a White Screen

### DIFF
--- a/client/modules/App/components/Overlay.tsx
+++ b/client/modules/App/components/Overlay.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useRef } from 'react';
-import MediaQuery from 'react-responsive';
+import { useMediaQuery } from 'react-responsive';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
@@ -9,8 +9,8 @@ import type { RootState } from '../../../reducers';
 import ExitIcon from '../../../images/exit.svg';
 
 type OverlayProps = {
-  children?: React.ReactElement;
-  actions?: React.ReactElement;
+  children?: React.ReactNode;
+  actions?: React.ReactNode;
   closeOverlay?: () => void;
   title?: string;
   ariaLabel?: string;
@@ -34,6 +34,9 @@ export const Overlay = ({
   const ref = useRef<HTMLElement>(null);
 
   const browserHistory = useHistory();
+
+  const isDesktop = useMediaQuery({ minWidth: 770 });
+  const isMobile = useMediaQuery({ maxWidth: 769 });
 
   const close = useCallback(() => {
     const node = ref.current;
@@ -66,7 +69,7 @@ export const Overlay = ({
           <header className="overlay__header">
             <h2 className="overlay__title">{title}</h2>
             <div className="overlay__actions">
-              <MediaQuery minWidth={770}>{actions}</MediaQuery>
+              {isDesktop && actions}
               <button
                 className="overlay__close-button"
                 onClick={close}
@@ -76,11 +79,9 @@ export const Overlay = ({
               </button>
             </div>
           </header>
-          <MediaQuery maxWidth={769}>
-            {actions && (
-              <div className="overlay__actions-mobile">{actions}</div>
-            )}
-          </MediaQuery>
+          {isMobile && actions && (
+            <div className="overlay__actions-mobile">{actions}</div>
+          )}
           {children}
         </section>
       </div>


### PR DESCRIPTION
Fixes #3793 

Changes:
- The recent TS migration for `App` related components was able to flag that current the installed version of `react-responsive` doesn't seem to support the use of the `MediaQuery` component anymore in `Overlay.tsx`. This PR updates the Overlay component to use the now supported `useMediaQuery` hook instead.  

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
