### PR TITLE
Hover state removes the gap between logo block and “Back to Editor” button

### DIFF
--- a/client/styles/components/_nav.scss
+++ b/client/styles/components/_nav.scss
@@ -111,7 +111,7 @@
 }
 
 .nav__item--no-icon {
-  padding-left: #{math.div(15, $base-font-size)}rem;
+  padding-left: 0;
 }
 
 .nav__item-header-triangle polygon,
@@ -135,6 +135,13 @@
   & g, & path {
     @include themify() {
       fill: getThemifyVariable('nav-hover-color');
+    }
+  }
+
+  .nav__back-icon g,
+  .nav__back-icon path {
+    @include themify() {
+      fill: getThemifyVariable('button-hover-color');
     }
   }
 
@@ -277,4 +284,7 @@
 
 .nav__back-link {
   display: flex;
+  align-items: center;
+  height: 100%;
+  padding: 0 #{math.div(10, $base-font-size)}rem 0 #{math.div(15, $base-font-size)}rem;
 }


### PR DESCRIPTION
Fixes #3733 

Changes:

I have verified that this pull request:

What this PR does
->Ensures nav back icon color remains visible
->Prevents opacity or theming issues
->Changes made
->Updated SCSS for nav back icon
->Forced white color visibility