### PR TITLE
Adding additional documentation to the new Styling Guide Readme

### DIFF
--- a/contributor_docs/styling.md
+++ b/contributor_docs/styling.md
@@ -3,5 +3,11 @@
 Currently in progress. 
 
 ---
+Additional Resources: 
 - [Zeplin File with Official Colors](google.com/url?q=https://github.com/processing/p5.js-web-editor/wiki/Color-Combinations-for-Accessibility&sa=D&source=docs&ust=1769528946688435&usg=AOvVaw2626esAvAi1JMEjarRcDcT)
 - [Accessible Links Color Combinations](https://scene.zeplin.io/project/55f746c54a02e1e50e0632c3)
+
+Tips when making styling contributions: 
+- Define color specifications and other design tokens as CSS custom properties (e.g. `--var(primary-color)`) instead of hard coded values like HEX, RGB ..etc.
+- Ensure your changes only affect what you intend. For example, review what uses a variable before modifying it to avoid unintended changes. 
+- Before creating a new CSS, check for utility classes and variables that provide styling you need. 


### PR DESCRIPTION
Fixes #3821

Changes: Adding some more documentation within the new [Style Guide readMe](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/styling.md). 

I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] has no test errors (`npm run test`)
* [X] has no typecheck errors (`npm run typecheck`)
* [X] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [X] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
