### PR TITLE
Fix runtime error console

### DIFF
--- a/client/modules/IDE/actions/ide.js
+++ b/client/modules/IDE/actions/ide.js
@@ -236,23 +236,10 @@ export function hideErrorModal() {
   };
 }
 
-export function hideRuntimeErrorWarning() {
-  return {
-    type: ActionTypes.HIDE_RUNTIME_ERROR_WARNING
-  };
-}
-
-export function showRuntimeErrorWarning() {
-  return {
-    type: ActionTypes.SHOW_RUNTIME_ERROR_WARNING
-  };
-}
-
 export function startSketch() {
   return (dispatch, getState) => {
     dispatch(clearConsole());
     dispatch(startVisualSketch());
-    dispatch(showRuntimeErrorWarning());
     const state = getState();
     dispatchMessage({
       type: MessageTypes.SKETCH,

--- a/client/modules/IDE/components/Editor/codemirror.js
+++ b/client/modules/IDE/components/Editor/codemirror.js
@@ -31,7 +31,6 @@ import tidyCodeWithPrettier from './tidier';
 
 /** This is a custom React hook that manages CodeMirror state. */
 export default function useCodeMirror({
-  theme,
   lineNumbers,
   linewrap,
   autocloseBracketsQuotes,
@@ -99,7 +98,6 @@ export default function useCodeMirror({
   }
 
   // When settings change, we pass those changes into CodeMirror.
-  // TODO: There should be a useEffect hook for when the theme changes.
   useEffect(() => {
     cmView.current.dom.style['font-size'] = `${fontSize}px`;
   }, [fontSize]);

--- a/client/modules/IDE/components/Editor/codemirror.js
+++ b/client/modules/IDE/components/Editor/codemirror.js
@@ -21,7 +21,6 @@ import { useEffectWithComparison } from '../../hooks/custom-hooks';
 import tidyCodeWithPrettier from './tidier';
 
 // ----- GENERAL TODOS (in order of priority) -----
-// - color themes
 // - any features lost in the p5 conversion git merge
 // - javascript color picker (extension works for css but needs to be forked for js)
 // - revisit keymap differences, esp around sublime
@@ -38,7 +37,6 @@ export default function useCodeMirror({
   autocloseBracketsQuotes,
   setUnsavedChanges,
   setCurrentLine,
-  hideRuntimeErrorWarning,
   updateFileContent,
   file,
   files,
@@ -63,7 +61,6 @@ export default function useCodeMirror({
   // When the file changes, update the file content and save status.
   function onChange() {
     setUnsavedChanges(true);
-    hideRuntimeErrorWarning();
     updateFileContent(fileId.current, cmView.current.state.doc.toString());
     if (autorefresh && isPlaying) {
       clearConsole();
@@ -220,6 +217,7 @@ export default function useCodeMirror({
     teardownCodeMirror,
     getContent,
     tidyCode,
-    showSearch
+    showSearch,
+    codemirrorView: cmView
   };
 }

--- a/client/modules/IDE/components/Editor/consoleErrorDecoration.js
+++ b/client/modules/IDE/components/Editor/consoleErrorDecoration.js
@@ -6,7 +6,8 @@ const ADD_ERROR_DECORATION = StateEffect.define();
 const FILTER_ERROR_DECORATION = StateEffect.define();
 
 // An extension for managing error line decorations
-// You can call this by calling addErrorDecoration and removeErrorDecorations
+// Mostly adapted from the Marked Text demo in https://codemirror.net/docs/migration/
+// You can affect this by calling addErrorDecoration and removeErrorDecorations
 export const errorDecorationStateField = StateField.define({
   // Start with an empty set of decorations
   create() {
@@ -16,7 +17,6 @@ export const errorDecorationStateField = StateField.define({
   update(value, transaction) {
     // Move the decorations to account for document changes
     let newValue = value.map(transaction.changes);
-    // If this transaction adds or removes decorations, apply those changes
     for (let i = 0; i < transaction.effects.length; i++) {
       const effect = transaction.effects[i];
       if (effect.is(ADD_ERROR_DECORATION))
@@ -31,9 +31,10 @@ export const errorDecorationStateField = StateField.define({
 });
 
 const ERROR_DECORATION = Decoration.line({
-  class: 'cm-errorLine'
+  class: 'cm-errorLine' // Defined in _editor.scss
 });
 
+// Add an error decoration to a specific line number
 export function addErrorDecoration(view, lineNumber) {
   const docLineNumber = view.state.doc.line(lineNumber);
   view.dispatch({
@@ -43,6 +44,7 @@ export function addErrorDecoration(view, lineNumber) {
   });
 }
 
+// Remove all error decorations
 export function removeErrorDecorations(view) {
   view.dispatch({
     effects: FILTER_ERROR_DECORATION.of(() => false)

--- a/client/modules/IDE/components/Editor/consoleErrorDecoration.js
+++ b/client/modules/IDE/components/Editor/consoleErrorDecoration.js
@@ -1,0 +1,50 @@
+import { StateField, StateEffect } from '@codemirror/state';
+import { EditorView, Decoration } from '@codemirror/view';
+
+// Effects for communicating with the state field
+const ADD_ERROR_DECORATION = StateEffect.define();
+const FILTER_ERROR_DECORATION = StateEffect.define();
+
+// An extension for managing error line decorations
+// You can call this by calling addErrorDecoration and removeErrorDecorations
+export const errorDecorationStateField = StateField.define({
+  // Start with an empty set of decorations
+  create() {
+    return Decoration.none;
+  },
+  // This is called whenever the editor updates
+  update(value, transaction) {
+    // Move the decorations to account for document changes
+    let newValue = value.map(transaction.changes);
+    // If this transaction adds or removes decorations, apply those changes
+    for (let i = 0; i < transaction.effects.length; i++) {
+      const effect = transaction.effects[i];
+      if (effect.is(ADD_ERROR_DECORATION))
+        newValue = newValue.update({ add: effect.value, sort: true });
+      else if (effect.is(FILTER_ERROR_DECORATION))
+        newValue = newValue.update({ filter: effect.value });
+    }
+    return newValue;
+  },
+  // Indicate that this field provides a set of decorations
+  provide: (f) => EditorView.decorations.from(f)
+});
+
+const ERROR_DECORATION = Decoration.line({
+  class: 'cm-errorLine'
+});
+
+export function addErrorDecoration(view, lineNumber) {
+  const docLineNumber = view.state.doc.line(lineNumber);
+  view.dispatch({
+    effects: ADD_ERROR_DECORATION.of([
+      ERROR_DECORATION.range(docLineNumber.from)
+    ])
+  });
+}
+
+export function removeErrorDecorations(view) {
+  view.dispatch({
+    effects: FILTER_ERROR_DECORATION.of(() => false)
+  });
+}

--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -133,7 +133,7 @@ function Editor({
     };
   }, []);
 
-  // Updates the error console.
+  // Updates the runtime error console.
   useEffect(() => {
     const consoleErrors = consoleEvents.filter((e) => e.method === 'error');
 

--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -42,7 +42,6 @@ function Editor({
   provideController,
   files,
   file,
-  theme,
   linewrap,
   lineNumbers,
   closeProjectOptions,
@@ -92,7 +91,6 @@ function Editor({
     tidyCode,
     showSearch
   } = useCodeMirror({
-    theme,
     lineNumbers,
     linewrap,
     autocloseBracketsQuotes,
@@ -270,7 +268,6 @@ Editor.propTypes = {
   startSketch: PropTypes.func.isRequired,
   autorefresh: PropTypes.bool.isRequired,
   isPlaying: PropTypes.bool.isRequired,
-  theme: PropTypes.string.isRequired,
   files: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.string.isRequired,

--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -32,7 +32,11 @@ import { FolderIcon } from '../../../../common/icons';
 import { IconButton } from '../../../../common/IconButton';
 
 import useCodeMirror from './codemirror';
-import { useEffectWithComparison } from '../../hooks/custom-hooks';
+
+import {
+  addErrorDecoration,
+  removeErrorDecorations
+} from './consoleErrorDecoration';
 
 function Editor({
   provideController,
@@ -57,8 +61,6 @@ function Editor({
   autocloseBracketsQuotes,
   fontSize,
   consoleEvents,
-  hideRuntimeErrorWarning,
-  runtimeErrorWarningVisible,
   expandConsole,
   isExpanded,
   t,
@@ -85,7 +87,7 @@ function Editor({
   const {
     setupCodeMirrorOnContainerMounted,
     teardownCodeMirror,
-    // cmInstance,
+    codemirrorView,
     getContent,
     tidyCode,
     showSearch
@@ -95,7 +97,6 @@ function Editor({
     linewrap,
     autocloseBracketsQuotes,
     setUnsavedChanges,
-    hideRuntimeErrorWarning,
     updateFileContent,
     file,
     files,
@@ -133,53 +134,31 @@ function Editor({
   }, []);
 
   // Updates the error console.
-  // TODO: Need to revisit this functionality for v6.
-  useEffectWithComparison(
-    (_, prevProps) => {
-      if (runtimeErrorWarningVisible) {
-        if (
-          prevProps.consoleEvents &&
-          consoleEvents.length !== prevProps.consoleEvents.length
-        ) {
-          consoleEvents.forEach((consoleEvent) => {
-            if (consoleEvent.method === 'error') {
-              // It doesn't work if you create a new Error, but this works
-              // LOL
-              const errorObj = { stack: consoleEvent.data[0].toString() };
-              StackTrace.fromError(errorObj).then((stackLines) => {
-                expandConsole();
-                const line = stackLines.find(
-                  (l) => l.fileName && l.fileName.startsWith('/')
-                );
-                if (!line) return;
-                const fileNameArray = line.fileName.split('/');
-                const fileName = fileNameArray.slice(-1)[0];
-                const filePath = fileNameArray.slice(0, -1).join('/');
-                const fileWithError = files.find(
-                  (f) => f.name === fileName && f.filePath === filePath
-                );
-                setSelectedFile(fileWithError.id);
-                // cmInstance.current.addLineClass(
-                //   line.lineNumber - 1,
-                //   'background',
-                //   'line-runtime-error'
-                // );
-              });
-            }
-          });
-        } else {
-          // for (let i = 0; i < cmInstance.current.lineCount(); i += 1) {
-          //   cmInstance.current.removeLineClass(
-          //     i,
-          //     'background',
-          //     'line-runtime-error'
-          //   );
-          // }
-        }
-      }
-    },
-    [consoleEvents, runtimeErrorWarningVisible]
-  );
+  useEffect(() => {
+    const consoleErrors = consoleEvents.filter((e) => e.method === 'error');
+
+    if (consoleErrors.length > 0) {
+      const firstError = consoleErrors[0];
+      const errorObj = { stack: firstError.data[0].toString() };
+      StackTrace.fromError(errorObj).then((stackLines) => {
+        expandConsole();
+        const line = stackLines.find(
+          (l) => l.fileName && l.fileName.startsWith('/')
+        );
+        if (!line) return;
+        const fileNameArray = line.fileName.split('/');
+        const fileName = fileNameArray.slice(-1)[0];
+        const filePath = fileNameArray.slice(0, -1).join('/');
+        const fileWithError = files.find(
+          (f) => f.name === fileName && f.filePath === filePath
+        );
+        setSelectedFile(fileWithError.id);
+        addErrorDecoration(codemirrorView.current, line.lineNumber);
+      });
+    } else {
+      removeErrorDecorations(codemirrorView.current);
+    }
+  }, [consoleEvents]);
 
   const editorSectionClass = classNames({
     editor: true,
@@ -304,8 +283,6 @@ Editor.propTypes = {
   closeProjectOptions: PropTypes.func.isRequired,
   expandSidebar: PropTypes.func.isRequired,
   clearConsole: PropTypes.func.isRequired,
-  hideRuntimeErrorWarning: PropTypes.func.isRequired,
-  runtimeErrorWarningVisible: PropTypes.bool.isRequired,
   provideController: PropTypes.func.isRequired,
   t: PropTypes.func.isRequired,
   setSelectedFile: PropTypes.func.isRequired,

--- a/client/modules/IDE/components/Editor/stateUtils.js
+++ b/client/modules/IDE/components/Editor/stateUtils.js
@@ -56,11 +56,11 @@ import { emmetConfig } from '@emmetio/codemirror6-plugin';
 import p5JavaScript from './p5JavaScript';
 import tidyCodeWithPrettier from './tidier';
 import { highlightStyle } from './highlightStyle';
+import { errorDecorationStateField } from './consoleErrorDecoration';
 
 // ----- TODOS -----
 // - JSON linter
 // - shader syntax highlighting
-// - should we add xml specific language support?
 // - add docstrings for all exported functions
 
 /** Detects what mode the file is based on the name. */
@@ -337,6 +337,7 @@ export function createNewFileState(filename, document, settings) {
     indentOnInput(),
     bracketMatching(),
     colorPicker,
+    errorDecorationStateField,
 
     // Setup the event listeners on the CodeMirror instance.
     EditorView.updateListener.of(onViewUpdate)

--- a/client/modules/IDE/reducers/ide.js
+++ b/client/modules/IDE/reducers/ide.js
@@ -22,7 +22,6 @@ const initialState = {
   justOpenedProject: false,
   previousPath: '/',
   errorType: undefined,
-  runtimeErrorWarningVisible: false,
   parentId: undefined
 };
 
@@ -111,10 +110,6 @@ const ide = (state = initialState, action) => {
       return Object.assign({}, state, { errorType: action.modalType });
     case ActionTypes.HIDE_ERROR_MODAL:
       return Object.assign({}, state, { errorType: undefined });
-    case ActionTypes.HIDE_RUNTIME_ERROR_WARNING:
-      return Object.assign({}, state, { runtimeErrorWarningVisible: false });
-    case ActionTypes.SHOW_RUNTIME_ERROR_WARNING:
-      return Object.assign({}, state, { runtimeErrorWarningVisible: true });
     case ActionTypes.OPEN_UPLOAD_FILE_MODAL:
       return Object.assign({}, state, {
         uploadFileModalVisible: true,

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -30,8 +30,12 @@
         }
       }
     }
-  }
 
+    .cm-errorLine.cm-activeLine, 
+    .cm-errorLine {
+      background-color: rgb(255 95 82 / 30%);
+    }
+  }
   .cm-focused > .cm-scroller .cm-selectionLayer .cm-selectionBackground,
   .cm-selectionLayer .cm-selectionBackground,
   ::selection {
@@ -152,16 +156,6 @@
 }
 
 // TODO: Add fold gutter styling back.
-
-.line-runtime-error + .CodeMirror-activeline-gutter {
-  background-color: rgb(255, 95, 82);
-  opacity: 0.3;
-}
-
-.line-runtime-error {
-  background-color: rgb(255, 95, 82) !important;
-  opacity: 0.3;
-}
 
 .editor-holder {
   height: calc(100% - #{math.div(29, $base-font-size)}rem);

--- a/client/testData/testReduxStore.ts
+++ b/client/testData/testReduxStore.ts
@@ -46,7 +46,6 @@ const initialTestState: RootState = {
     justOpenedProject: false,
     previousPath: '/',
     errorType: undefined,
-    runtimeErrorWarningVisible: true,
     parentId: undefined
   },
   files: initialFilesState(),


### PR DESCRIPTION
Changes: Addresses the TODO that the runtime error console should work!

I suspect the state management around `runtimeErrorWarningVisible` had to do with Codemirror 5 leaving the old classes around between file changes so I've removed that since it's no longer necessary as files have separate states now.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.

![cm-demo](https://github.com/user-attachments/assets/48ad78e2-6dab-4b11-8f5c-a0d716b24c10)

