### PR TITLE
Update docs for setting up google auth

### DIFF
--- a/client/modules/IDE/actions/assets.js
+++ b/client/modules/IDE/actions/assets.js
@@ -30,7 +30,10 @@ export function getAssets() {
 export function deleteAssetRequest(assetKey) {
   return async (dispatch) => {
     try {
-      await apiClient.delete(`/S3/${assetKey}`);
+      const path = assetKey.split('/').pop();
+      await apiClient.delete(
+        `/S3/delete?objectKey=${encodeURIComponent(path)}`
+      );
       dispatch(deleteAsset(assetKey));
     } catch (error) {
       dispatch({

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -65,8 +65,9 @@ export async function deleteObjectsFromS3(keyList) {
 }
 
 export async function deleteObjectFromS3(req, res) {
-  const { objectKey, userId } = req.params;
-  const fullObjectKey = userId ? `${userId}/${objectKey}` : objectKey;
+  const userId = req.user.id;
+  const { objectKey } = req.query;
+  const fullObjectKey = `${userId}/${objectKey}`;
 
   try {
     await deleteObjectsFromS3([fullObjectKey]);

--- a/server/routes/aws.routes.ts
+++ b/server/routes/aws.routes.ts
@@ -10,11 +10,7 @@ router.post(
   isAuthenticated,
   AWSController.copyObjectInS3RequestHandler
 );
-router.delete(
-  '/S3/:userId?/:objectKey',
-  isAuthenticated,
-  AWSController.deleteObjectFromS3
-);
+router.delete('/S3/delete', isAuthenticated, AWSController.deleteObjectFromS3);
 router.get('/S3/objects', AWSController.listObjectsInS3ForUserRequestHandler);
 
 // eslint-disable-next-line import/no-default-export


### PR DESCRIPTION
Changes:
Removes the client provided userId at backend and uses the authenticated user.id instead. The object key is sent from by splitting the asset url filename.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
