### PR TITLE
Harden embed preview iframe with sandbox restrictions

### DIFF
--- a/client/modules/Preview/EmbedFrame.jsx
+++ b/client/modules/Preview/EmbedFrame.jsx
@@ -262,6 +262,9 @@ function EmbedFrame({ files, isPlaying, basePath, gridOutput, textOutput }) {
   const htmlFile = useMemo(() => getHtmlFile(files), [files]);
   const srcRef = useRef();
 
+  const sandboxAttributes =
+    'allow-forms allow-modals allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation allow-downloads';
+
   useEffect(() => {
     const unsubscribe = registerFrame(
       iframe.current.contentWindow,
@@ -306,6 +309,8 @@ function EmbedFrame({ files, isPlaying, basePath, gridOutput, textOutput }) {
       role="main"
       frameBorder="0"
       ref={iframe}
+      sandbox={sandboxAttributes}
+      allow="accelerometer; ambient-light-sensor; autoplay; bluetooth; camera; encrypted-media; geolocation; gyroscope; hid; microphone; magnetometer; midi; payment; usb; serial; vr; xr-spatial-tracking"
     />
   );
 }

--- a/client/modules/Preview/EmbedFrame.jsx
+++ b/client/modules/Preview/EmbedFrame.jsx
@@ -262,8 +262,16 @@ function EmbedFrame({ files, isPlaying, basePath, gridOutput, textOutput }) {
   const htmlFile = useMemo(() => getHtmlFile(files), [files]);
   const srcRef = useRef();
 
-  const sandboxAttributes =
-    'allow-forms allow-modals allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-top-navigation-by-user-activation allow-downloads';
+  const sandboxAttributes = [
+    'allow-forms',
+    'allow-modals',
+    'allow-pointer-lock',
+    'allow-popups',
+    'allow-same-origin',
+    'allow-scripts',
+    'allow-top-navigation-by-user-activation',
+    'allow-downloads'
+  ].join(' ');
 
   useEffect(() => {
     const unsubscribe = registerFrame(
@@ -310,7 +318,25 @@ function EmbedFrame({ files, isPlaying, basePath, gridOutput, textOutput }) {
       frameBorder="0"
       ref={iframe}
       sandbox={sandboxAttributes}
-      allow="accelerometer; ambient-light-sensor; autoplay; bluetooth; camera; encrypted-media; geolocation; gyroscope; hid; microphone; magnetometer; midi; payment; usb; serial; vr; xr-spatial-tracking"
+      allow={[
+        'accelerometer',
+        'ambient-light-sensor',
+        'autoplay',
+        'bluetooth',
+        'camera',
+        'encrypted-media',
+        'geolocation',
+        'gyroscope',
+        'hid',
+        'microphone',
+        'magnetometer',
+        'midi',
+        'payment',
+        'usb',
+        'serial',
+        'vr',
+        'xr-spatial-tracking'
+      ].join('; ')}
     />
   );
 }


### PR DESCRIPTION
Changes:
Adds sandbox restrictions to the embed/standalone preview iframe to align its behavior with the existing IDE preview security model.

This is a minimal, non-functional hardening change; normal sketches continue to run as expected, while previously unrestricted behaviors are constrained.

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
