### PR TITLE
Update Autocomplete Hinter Reference URL to 2.x Docs on Version Change

### DIFF
--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -421,6 +421,17 @@ class Editor extends React.Component {
     this._cm.execCommand('findPersistent');
   }
 
+  // temporary until p5.js 2.0 becomes default
+  // checks if sketch is using p5.js 2.0 to pass correct base url for autocomplete hinter reference
+  getReferenceBaseUrl = () => {
+    const html = this.props.htmlFile?.content || '';
+
+    const isV2 =
+      /https:\/\/beta\.p5js\.org\b/i.test(html) || /\bp5(@|-)2\./i.test(html);
+
+    return isV2 ? 'https://beta.p5js.org' : 'https://p5js.org';
+  };
+
   showHint(_cm) {
     if (!_cm) return;
 
@@ -460,6 +471,7 @@ class Editor extends React.Component {
 
     const hintOptions = {
       _fontSize: this.props.fontSize,
+      referenceBaseUrl: this.getReferenceBaseUrl(),
       completeSingle: false,
       extraKeys: {
         'Shift-Right': (cm, e) => {
@@ -731,6 +743,9 @@ Editor.propTypes = {
       content: PropTypes.string.isRequired
     })
   ).isRequired,
+  htmlFile: PropTypes.shape({
+    content: PropTypes.string
+  }),
   isExpanded: PropTypes.bool.isRequired,
   collapseSidebar: PropTypes.func.isRequired,
   closeProjectOptions: PropTypes.func.isRequired,
@@ -742,6 +757,10 @@ Editor.propTypes = {
   t: PropTypes.func.isRequired,
   setSelectedFile: PropTypes.func.isRequired,
   expandConsole: PropTypes.func.isRequired
+};
+
+Editor.defaultProps = {
+  htmlFile: null
 };
 
 function mapStateToProps(state) {

--- a/client/modules/IDE/components/show-hint.js
+++ b/client/modules/IDE/components/show-hint.js
@@ -296,11 +296,12 @@ import CodeMirror from 'codemirror';
   }
 
   // hintsElement is the parent for hints and el is the clicked element within that container
-  function displayHint(name, type, p5, isBlacklistedFunction) {
+  function displayHint(name, type, p5, isBlacklistedFunction, referenceBaseUrl) {
+    const base = referenceBaseUrl || 'https://p5js.org';
+    const refName = typeof p5 === 'string' ? p5 : name;
+
     const linkOrPlaceholder = p5
-      ? `<a href="https://p5js.org/reference/p5/${
-          typeof p5 === 'string' ? p5 : name
-        }" role="link" onclick="event.stopPropagation()" target="_blank">
+      ? `<a href="${base}/reference/p5/${refName}" role="link" onclick="event.stopPropagation()" target="_blank">
       <span class="hint-hidden">open ${name} reference</span>
       <span aria-hidden="true" class="arrow-icon">➔</span>
     </a>`
@@ -400,6 +401,8 @@ import CodeMirror from 'codemirror';
     hints.className = 'CodeMirror-hints ' + theme;
     this.selectedHint = data.selectedHint || 0;
 
+    const referenceBaseUrl = completion.options.referenceBaseUrl || 'https://p5js.org';
+
     // Show inline hint
     changeInlineHint(cm, data.list[this.selectedHint]);
 
@@ -430,7 +433,8 @@ import CodeMirror from 'codemirror';
             name,
             cur.item.type,
             cur.item.p5,
-            cur.isBlacklisted
+            cur.isBlacklisted,
+            referenceBaseUrl
           );
         }
 


### PR DESCRIPTION
Fixes #3847 

Changes:
- Adds p5.js version detection to the `Editor` to pass the correct base URL for the p5.js Reference for the Autocomplete Hinter. 
- This implementation is temporary, and should use the `useP5Version` hook once the Editor is converted to a functional component in the upcoming CodeMirror v6 upgrade. This should also become default when 2.x is the default version. 

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
