### PR TITLE
Refetch Projects on Project Deletion in Sketch List

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -386,7 +386,7 @@ export function changeProjectName(id, newName) {
 }
 
 export function deleteProject(id) {
-  return (dispatch, getState) => {
+  return (dispatch, getState) =>
     apiClient
       .delete(`/projects/${id}`)
       .then(() => {
@@ -411,7 +411,6 @@ export function deleteProject(id) {
           });
         }
       });
-  };
 }
 export function changeVisibility(projectId, projectName, visibility, t) {
   return (dispatch, getState) => {

--- a/client/modules/IDE/components/SketchList.jsx
+++ b/client/modules/IDE/components/SketchList.jsx
@@ -73,6 +73,30 @@ const SketchList = ({
     [username, user.username, t]
   );
 
+  const handleDeletedProject = useCallback(() => {
+    // sketches table refetches projects post-project deletion for server-side pagination
+    if (sketches.length === 1 && page > 1) {
+      setPage((p) => p - 1);
+    } else {
+      getProjects(username, {
+        page,
+        limit,
+        sortField,
+        sortDir,
+        q: search
+      });
+    }
+  }, [
+    sketches.length,
+    page,
+    getProjects,
+    username,
+    limit,
+    sortField,
+    sortDir,
+    search
+  ]);
+
   const isLoading = () => loading && isInitialDataLoad;
 
   const hasSketches = () => !isLoading() && sketches.length > 0;
@@ -184,6 +208,7 @@ const SketchList = ({
                   user={user}
                   username={username}
                   onAddToCollection={() => setSketchToAddToCollection(sketch)}
+                  onDeletedProject={handleDeletedProject}
                   t={t}
                 />
               ))}

--- a/client/modules/IDE/components/SketchListRowBase.jsx
+++ b/client/modules/IDE/components/SketchListRowBase.jsx
@@ -24,6 +24,7 @@ const SketchListRowBase = ({
   changeProjectName,
   cloneProject,
   deleteProject,
+  onDeletedProject,
   showShareModal,
   changeVisibility,
   t,
@@ -85,7 +86,9 @@ const SketchListRowBase = ({
 
   const handleSketchDelete = () => {
     if (window.confirm(t('Common.DeleteConfirmation', { name: sketch.name }))) {
-      deleteProject(sketch.id);
+      deleteProject(sketch.id).finally(() => {
+        onDeletedProject();
+      });
     }
   };
 
@@ -174,6 +177,7 @@ SketchListRowBase.propTypes = {
     authenticated: PropTypes.bool.isRequired
   }).isRequired,
   deleteProject: PropTypes.func.isRequired,
+  onDeletedProject: PropTypes.func.isRequired,
   cloneProject: PropTypes.func.isRequired,
   changeProjectName: PropTypes.func.isRequired,
   showShareModal: PropTypes.func.isRequired,


### PR DESCRIPTION
Fixes https://github.com/processing/p5.js-web-editor/issues/3854

Changes:
- Updates `deleteProject` action returns promise to indicate that the action is completed to `SketchListRowBase`
- Adds handler to refetch projects on project deletion within `SketchList` while preserving the pagination page/query

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
