### PR TITLE
fix: toast component color contrast

### DIFF
--- a/client/styles/abstracts/_placeholders.scss
+++ b/client/styles/abstracts/_placeholders.scss
@@ -34,15 +34,15 @@
 
 %icon-toast{
 	@include themify() {
-		color: $toast-text-color
+		color: getThemifyVariable('toast-text-color');
 		& g, & path {
-			fill: $toast-text-color
+			fill: getThemifyVariable('toast-text-color');
 		}
 		&:hover {
-			color: getThemifyVariable('icon-toast-hover-color');
+			color: getThemifyVariable('toast-text-color');
 			& g, & path {
 				opacity: 1;
-				fill: getThemifyVariable('icon-toast-hover-color');
+				fill: getThemifyVariable('toast-text-color');
 			}
 		}
 	}

--- a/client/styles/abstracts/_variables.scss
+++ b/client/styles/abstracts/_variables.scss
@@ -55,7 +55,6 @@ $themes: (
     modal-border-color: $middle-light,
     icon-color: $middle-gray,
     icon-hover-color: $darker,
-    icon-toast-hover-color: $lightest,
     shadow-color: rgba(0, 0, 0, 0.16),
     console-background-color: $light,
     console-input-background-color: $lightest,
@@ -130,6 +129,9 @@ $themes: (
     admonition-border: #22C8ED,
     admonition-background: #E4F8FF,
     admonition-text: #075769,
+
+    toast-background-color: $medium-dark,
+    toast-text-color: $lightest,
   ),
   dark: (
     logo-color: $p5js-pink,
@@ -156,7 +158,6 @@ $themes: (
     modal-border-color: $middle-dark,
     icon-color: $middle-light,
     icon-hover-color: $lightest,
-    icon-toast-hover-color: $lightest,
     shadow-color: rgba(0, 0, 0, 0.16),
     console-background-color: $dark,
     console-input-background-color: $darker,
@@ -229,6 +230,9 @@ $themes: (
     admonition-border: #22C8ED,
     admonition-background: #105A7F,
     admonition-text: #FFFFFF,
+
+    toast-background-color: $medium-light,
+    toast-text-color: $dark,
   ),
   contrast: (
     logo-color: $yellow,
@@ -255,7 +259,6 @@ $themes: (
     modal-border-color: $middle-dark,
     icon-color: $medium-light,
     icon-hover-color: $yellow,
-    icon-toast-hover-color: $yellow,
     shadow-color: rgba(0, 0, 0, 0.16),
     console-background-color: $dark,
     console-input-background-color: $darker,
@@ -328,9 +331,9 @@ $themes: (
     admonition-border: #22C8ED,
     admonition-background: #000000,
     admonition-text: #ffffff,
+
+    toast-background-color: $medium-light,
+    toast-text-color: $darker,
+
   )
 );
-
-$toast-background-color: $medium-dark;
-$toast-text-color: $lightest;
-

--- a/client/styles/components/_toast.scss
+++ b/client/styles/components/_toast.scss
@@ -1,8 +1,10 @@
 @use "sass:math";
 
 .toast {
-  background-color: $toast-background-color;
-  color: $toast-text-color;
+  @include themify() {
+    color: getThemifyVariable('toast-text-color');
+    background-color: getThemifyVariable('toast-background-color');
+  }
   padding: #{math.div(10, $base-font-size)}rem;
   position: fixed;
   top: 0;


### PR DESCRIPTION
Fixes #3857

Changes:
- moved `toast-text-color` and `toast-background-color` into the `light`, `dark`, and `high contrast` themes in `__variables.scss`
- updated `.toast` color and background-color to use `@include themify  {...}` so the colors are configured depending on theme modees in `__toast.scss`
- updated `.toast__close` (the X button in the toast) to use the `toast-text-color` in `__placeholder.scss`. 
  - **this was not part of the issue description. i decided to do this because the `icon-toast-icon-hover` did not adhere to WCAG color contrast guidelines.**
- removed `icon-toast-icon-hover` in `__variables.scss`

Screenshots:

Video showing the new toast colors with High Contrast and Dark Mode: 

https://github.com/user-attachments/assets/9e301a63-f569-452c-9daf-7602715fff9b

I have verified that this pull request:

* [X] has no linting errors (`npm run lint`)
* [X] has no test errors (`npm run test`)
* [X] has no typecheck errors (`npm run typecheck`)
* [X] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [X] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [X] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
