### PR TITLE
Add aria-live assertive to login submit error for accessibility

### DIFF
--- a/client/modules/User/components/LoginForm.tsx
+++ b/client/modules/User/components/LoginForm.tsx
@@ -105,10 +105,11 @@ export function LoginForm() {
               )}
             </Field>
             {submitError && !modifiedSinceLastSubmit && (
-              <span className="form-error">
+              <span className="form-error" aria-live="assertive">
                 {t('LoginForm.Errors.invalidCredentials')}
               </span>
             )}
+
             <Button type={ButtonTypes.SUBMIT} disabled={submitting}>
               {t('LoginForm.Submit')}
             </Button>


### PR DESCRIPTION
Fixes #3874

## Summary

Adds `aria-live="assertive"` to the submit-level login error in `LoginForm.tsx` to ensure screen readers announce the invalid credentials message when it appears dynamically.

## Background

The per-field validation errors already use `aria-live="polite"`, but the submit-level error did not include an aria-live region. As a result, screen readers do not announce the login failure message when it appears after form submission.

This violates WCAG 2.2 SC 4.1.3 (Status Messages).

## Changes

- Added `aria-live="assertive"` to the submit error `<span>`
- No changes to login logic or functionality
- Maintains consistency with existing accessibility patterns in the component

---
<img width="1912" height="1000" alt="Screenshot From 2026-02-14 23-09-43" src="https://github.com/user-attachments/assets/73c3ea70-459a-42f2-a3ea-62a248037645" />

## Verification Checklist

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`) *(see note below)*
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)

---

### Note

Some server tests fail locally due to a MongoDB binary version mismatch on Debian 12 (MongoDB 7.0.0 not available for this OS version). This appears unrelated to the changes made in `LoginForm.tsx`.
