### PR TITLE
Fix: GitHub OAuth: use === instead of = in user email matching (#3877)

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -177,7 +177,7 @@ passport.use(
           // with emails that are connected to the same GitHub account
           if (existingEmailUsers.length > 1) {
             existingEmailUser = existingEmailUsers.find(
-              (u) => (u.email = primaryEmail)
+              (u) => u.email === primaryEmail
             );
           } else {
             [existingEmailUser] = existingEmailUsers;


### PR DESCRIPTION
Fixes #3877

## Changes
- **File:** `server/config/passport.js` (line 180)
- **Fix:** In the `.find()` callback when resolving which existing user to link for multiple accounts with the same GitHub emails, changed `(u) => (u.email = primaryEmail)` to `(u) => (u.email === primaryEmail)`.
- **Impact:** `.find()` now correctly returns the user whose email matches `primaryEmail` instead of the first user, and no longer mutates `u.email` during iteration, preventing wrong account linking and silent corruption of other users' email fields.

## Verification

I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #3877`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)