### PR TITLE
Fix CSS linter highlight range in CodeMirror v6

### DIFF
--- a/client/modules/IDE/components/Editor/stateUtils.js
+++ b/client/modules/IDE/components/Editor/stateUtils.js
@@ -121,10 +121,12 @@ function makeCssLinter(callback) {
       } = message;
       const cmLine = view.state.doc.line(messageLine);
 
-      // TODO: Can we to do the to/from smarter?
+      const start = cmLine.from + messageCharacter - 1;
+      const end = cmLine.to;
+
       diagnostics.push({
-        from: cmLine.from + messageCharacter - 1,
-        to: cmLine.from + messageCharacter,
+        from: start,
+        to: end,
         severity: messageType,
         message: messageText
       });


### PR DESCRIPTION
Fixes #3871

## Summary
This PR fixes incorrect highlight ranges produced by the CSS linter in the CodeMirror v6 branch.

The diagnostic range calculation was causing highlights to appear misaligned or incorrect.

## Changes
- Corrected highlight range calculation logic
- Ensured diagnostic positions align correctly with the document
- No server-side changes

## Verification
- Manually verified in develop-codemirror-v6 branch
- CSS lint errors now highlight the correct range
- No regressions observed in JavaScript or HTML linting

## Checklist
I have verified that this pull request:

- No linting errors (`npm run lint`)
- Changes are on a dedicated feature branch
- PR references the related issue