### PR TITLE
FIxing Visibility Updating Bug

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -420,12 +420,12 @@ export function changeVisibility(projectId, projectName, visibility, t) {
       .patch('/project/visibility', { projectId, visibility })
       .then((response) => {
         if (response.status === 200) {
-          const { visibility: newVisibility, updatedAt } = response.data;
+          const { visibility: newVisibility, updatedAt, id } = response.data;
 
           dispatch({
             type: ActionTypes.CHANGE_VISIBILITY,
             payload: {
-              id: response.data.id,
+              id,
               visibility: newVisibility
             }
           });

--- a/client/modules/IDE/reducers/projects.js
+++ b/client/modules/IDE/reducers/projects.js
@@ -7,13 +7,18 @@ const sketches = (state = [], action) => {
     case ActionTypes.DELETE_PROJECT:
       return state.projects.filter((sketch) => sketch.id !== action.id);
     case ActionTypes.CHANGE_VISIBILITY: {
-      return state.map((sketch) => {
-        if (sketch.id === action.payload.id) {
-          return { ...sketch, visibility: action.payload.visibility };
-        }
-        return sketch;
-      });
+      const updatedProjects = state.projects.map((sketch) =>
+        sketch.id === action.payload.id
+          ? { ...sketch, visibility: action.payload.visibility }
+          : sketch
+      );
+
+      return {
+        ...state,
+        projects: updatedProjects
+      };
     }
+
     case ActionTypes.RENAME_PROJECT: {
       return state.map((sketch) => {
         if (sketch.id === action.payload.id) {


### PR DESCRIPTION
### Issue:
Fixes #3864 
CHANGE_VISIBILITY was attempting to call .map() on the sketches state object instead of the projects array, causing the reducer to error and preventing the UI from updating.

### Demo:
<img width="1916" height="908" alt="image" src="https://github.com/user-attachments/assets/9e396735-5325-4898-b0e8-1ce30a056864" />


### Changes:
Updated the CHANGE_VISIBILITY case in the sketches reducer to:

- Operate on state.projects instead of state
- Return a new state object with an updated projects array

This ensures the Redux state slice that the Sketches list subscribes to actually changes.

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
