### PR TITLE
Update p5 version from 2.2.1 to 2.2.2

### DIFF
--- a/common/p5Versions.js
+++ b/common/p5Versions.js
@@ -5,7 +5,8 @@ export const currentP5Version = '1.11.11'; // Don't update to 2.x until 2026
 // JSON.stringify([...document.querySelectorAll('._132722c7')].map(n => n.innerText), null, 2)
 // TODO: use their API for this to grab these at build time?
 export const p5Versions = [
-  { version: '2.2.1', label: '(Beta)' },
+  { version: '2.2.2', label: '(Beta)' },
+  '2.2.1',
   '2.2.0',
   '2.1.2',
   '2.1.1',


### PR DESCRIPTION
We recently [released p5.js 2.2.2](https://github.com/processing/p5.js/releases/tag/v2.2.2)! This adds it to the version picker.

I have verified that this pull request 

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)