### PR TITLE
Fixing Sketches list does not update after renaming a sketch

### DIFF
--- a/client/modules/IDE/reducers/projects.js
+++ b/client/modules/IDE/reducers/projects.js
@@ -15,12 +15,17 @@ const sketches = (state = [], action) => {
       });
     }
     case ActionTypes.RENAME_PROJECT: {
-      return state.map((sketch) => {
+      const updatedproject = state.projects.map((sketch) => {
         if (sketch.id === action.payload.id) {
           return { ...sketch, name: action.payload.name };
         }
         return sketch;
       });
+
+      return {
+        ...state,
+        projects: updatedproject
+      };
     }
     default:
       return state;


### PR DESCRIPTION
### Issue:
Fixes #3921 
### Demo:
<img width="1468" height="574" alt="image" src="https://github.com/user-attachments/assets/10669e5b-33f6-42d0-bc98-e409066ec8e0" />


### Changes:
the reducer logic for ActionTypes.RENAME_PROJECT. Previously, the implementation attempted to update the state directly, but did not properly handle the projects array inside the state.
Now, the reducer correctly:
- Iterates over state.projects using map.
- Matches the project by id from the action.payload.
- Returns a new project object with the updated name.
- Preserves all other projects and the rest of the state immutably.


### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
