### PR TITLE
fix(i18n): apply missing translations to MobileNav component

### DIFF
--- a/client/modules/IDE/components/Header/MobileNav.jsx
+++ b/client/modules/IDE/components/Header/MobileNav.jsx
@@ -237,7 +237,7 @@ const MobileNav = () => {
       case 'examples':
         return t('Nav.File.Examples');
       case 'myStuff':
-        return 'My Stuff';
+        return t('MobileDashboardView.MyStuff');
       default:
         return project.name;
     }
@@ -256,7 +256,11 @@ const MobileNav = () => {
       </LogoContainer>
       <Title>
         <h1>{title === project?.name ? <ProjectName /> : title}</h1>
-        {showOwner && <h5>by {project?.owner?.username}</h5>}
+        {showOwner && (
+          <h5>
+            {t('PreviewNav.ByUser')} {project?.owner?.username}
+          </h5>
+        )}
       </Title>
 
       {/* check if the user is in login page */}
@@ -333,6 +337,7 @@ const StuffMenu = () => {
 const AccountMenu = () => {
   const user = useSelector((state) => state.user);
   const dispatch = useDispatch();
+  const { t } = useTranslation();
 
   const { isOpen, handlers } = useMenuProps('account');
 
@@ -343,11 +348,13 @@ const AccountMenu = () => {
         <ParentMenuContext.Provider value="account">
           <li className="user">{user.username}</li>
           <MobileMenuItem href={`/${user.username}/sketches`}>
-            My Stuff
+            {t('MobileDashboardView.MyStuff')}
           </MobileMenuItem>
-          <MobileMenuItem href="/account">Settings</MobileMenuItem>
+          <MobileMenuItem href="/account">
+            {t('MobilePreferences.Settings')}
+          </MobileMenuItem>
           <MobileMenuItem onClick={() => dispatch(logoutUser())}>
-            Log Out
+            {t('Nav.Auth.LogOut')}
           </MobileMenuItem>
         </ParentMenuContext.Provider>
       </ul>
@@ -382,9 +389,8 @@ const MoreMenu = () => {
     <div>
       {isLanguageModalVisible && (
         <Overlay
-          // TODO: add translations
-          title="Select Language"
-          ariaLabel="Select Language"
+          title={t('MobilePreferences.SelectLanguage')}
+          ariaLabel={t('MobilePreferences.SelectLanguage')}
           closeOverlay={() => setIsLanguageModalVisible(false)}
         >
           <LanguageSelect>

--- a/translations/locales/bn/translations.json
+++ b/translations/locales/bn/translations.json
@@ -8,7 +8,13 @@
       "Open": "খুলুন",
       "Download": "ডাউনলোড",
       "AddToCollection": "সংগ্রহে যোগ করুন",
-      "Examples": "উদাহরণ সমূহ"
+      "Examples": "উদাহরণ সমূহ",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "এডিট",
@@ -42,8 +48,12 @@
       "MySketches": "আমার স্কেচ",
       "MyCollections": "আমার সংগ্রহ",
       "MyAssets": "আমার সম্পদ",
-      "LogOut": "লগ আউট"
-    }
+      "LogOut": "লগ আউট",
+      "Welcome": "Welcome",
+      "My": "My",
+      "Asset": "Asset"
+    },
+    "Lang": "Language"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "প্রতিস্থাপন টগল করুন",
@@ -57,7 +67,8 @@
     "Previous": "পূর্ববর্তী",
     "Next": "পরবর্তী",
     "NoResults": "কোন ফলাফল নেই",
-    "Close": "বন্ধ"
+    "Close": "বন্ধ",
+    "Find": "Find"
   },
   "LoginForm": {
     "UsernameOrEmail": "ই-মেইল অথবা ব্যবহারকারীর নাম",
@@ -67,7 +78,9 @@
     "Submit": "লগ ইন করুন",
     "Errors": {
       "invalidCredentials": "ভুল ই-মেইল বা পাসওয়ার্ড।"
-    }
+    },
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password"
   },
   "LoginView": {
     "Title": "p5.js ওয়েব এডিটর | লগ ইন",
@@ -76,7 +89,9 @@
     "SignUp": "সাইন আপ করুন",
     "DontHaveAccount": " অ্যাকাউন্ট নেই? ",
     "ForgotPassword": "আপনি কি পাসওয়ার্ড ভুলে গিয়েছেন? ",
-    "ResetPassword": "আপনার পাসওয়ার্ড রিসেট করুন"
+    "ResetPassword": "আপনার পাসওয়ার্ড রিসেট করুন",
+    "Email": "email",
+    "Username": "username"
   },
   "SocialAuthButton": {
     "Connect": "{{serviceauth}} সাথে যোগাযোগ করুন",
@@ -127,7 +142,8 @@
       "Forum": "প্রশ্ন জিজ্ঞাসা করুন, স্কেচ শেয়ার করুন এবং p5.js কমিউনিটির সাহায্য নিন।",
       "Discord": "p5.js কমিউনিটির সাথে চ্যাট করুন এবং দ্রুত সাহায্য পান।"
     },
-    "Contact": "আমাদের সাথে যোগাযোগ করুন"
+    "Contact": "আমাদের সাথে যোগাযোগ করুন",
+    "Learn": "Learn"
   },
   "Toast": {
     "OpenedNewSketch": "নতুন স্কেচ খোলা হয়েছে।",
@@ -163,7 +179,9 @@
     "Clear": "ক্লিয়ার",
     "ClearARIA": "কনসোল ক্লিয়ার করুন",
     "CloseARIA": "কনসোল বন্ধ করুন",
-    "OpenARIA": "কনসোল খোলুন"
+    "OpenARIA": "কনসোল খোলুন",
+    "Close": "Close",
+    "Open": "Open"
   },
   "Preferences": {
     "Settings": "সেটিংস",
@@ -223,7 +241,9 @@
     "DataAddon": "p5.js 1.x সামঞ্জস্যপূর্ণ অ্যাড-অন লাইব্রেরি — ডেটা এবং ইভেন্ট",
     "SoundReference": "p5.js {{version}} এর সাথে সামঞ্জস্যপূর্ণ p5.sound এর রেফারেন্স দেখুন।",
     "CopyToClipboardSuccess": "ক্লিপবোর্ডে কপি করা হয়েছে!",
-    "CopyToClipboardFailure": "আমরা লেখাটি কপি করতে পারিনি, আপনি এটি নির্বাচন করে ম্যানুয়ালি কপি করার চেষ্টা করুন।"
+    "CopyToClipboardFailure": "আমরা লেখাটি কপি করতে পারিনি, আপনি এটি নির্বাচন করে ম্যানুয়ালি কপি করার চেষ্টা করুন।",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off"
   },
   "KeyboardShortcuts": {
     "Title": "কীবোর্ড শর্টকাট",
@@ -241,7 +261,9 @@
       "CodeEditing": "কোড এডিটিং",
       "ColorPicker": "ইনলাইন রঙ নির্বাচক দেখান",
       "CreateNewFile": "নতুন ফাইল তৈরি করুন",
-      "RenameVariable": "চলকটির নাম পরিবর্তন করুন"
+      "RenameVariable": "চলকটির নাম পরিবর্তন করুন",
+      "FindNextMatch": "Find Next Match",
+      "FindPrevMatch": "Find Previous Match"
     },
     "GeneralSelection": {
       "StartSketch": "স্কেচ শুরু",
@@ -260,7 +282,8 @@
     "AddFile": "ফাইল তৈরি করুন",
     "AddFileARIA": "ফাইল যোগ করুন",
     "UploadFile": "ফাইল আপলোড করুন",
-    "UploadFileARIA": "ফাইল আপলোড করুন"
+    "UploadFileARIA": "ফাইল আপলোড করুন",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "ফোল্ডার সামগ্রী খোলুন",
@@ -342,7 +365,10 @@
   "NewPasswordView": {
     "Title": "p5.js ওয়েব এডিটর | নতুন পাসওয়ার্ড",
     "Description": "নতুন পাসওয়ার্ড সেট করুন",
-    "TokenInvalidOrExpired": "পাসওয়ার্ড রিসেট টোকেন ভুল বা মেয়াদ উত্তীর্ণ হয়েছে।"
+    "TokenInvalidOrExpired": "পাসওয়ার্ড রিসেট টোকেন ভুল বা মেয়াদ উত্তীর্ণ হয়েছে।",
+    "EmptyPassword": "Please enter a password",
+    "PasswordConfirmation": "Please confirm your password",
+    "PasswordMismatch": "Passwords must match"
   },
   "AccountForm": {
     "Email": "ই-মেইল",
@@ -402,7 +428,11 @@
     "PasswordARIA": "পাসওয়ার্ড",
     "ConfirmPassword": "পাসওয়ার্ড নিশ্চিত করুন",
     "ConfirmPasswordARIA": "পাসওয়ার্ড নিশ্চিত করুন",
-    "SubmitSignup": "নিবন্ধন করুন"
+    "SubmitSignup": "নিবন্ধন করুন",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": "p5.js ওয়েব এডিটর | সাইন আপ করুন",
@@ -432,7 +462,13 @@
     "maximum": "সর্বোচ্চ"
   },
   "Feedback": {
-    "Title": "p5.js ওয়েব এডিটর | মন্তব্য করুন"
+    "Title": "p5.js ওয়েব এডিটর | মন্তব্য করুন",
+    "ViaGithubHeader": "Via Github Issues",
+    "ViaGithubDescription": "If you're familiar with Github, this is our preferred method for receiving bug reports and feedback.",
+    "GoToGithub": "Go to Github",
+    "ViaGoogleHeader": "Via Google Form",
+    "ViaGoogleDescription": "You can also submit this quick form.",
+    "GoToForm": "Go to Form"
   },
   "Searchbar": {
     "SearchSketch": "স্কেচ অনুসন্ধান করুন...",
@@ -484,11 +520,15 @@
     "DirectionAscendingARIA": "ঊর্ধ্বগামী",
     "DirectionDescendingARIA": "নিম্নগামী",
     "ButtonLabelAscendingARIA": "{{displayName}} দ্বারা ঊর্ধ্বগামী করুন।",
-    "ButtonLabelDescendingARIA": "{{displayName}} দ্বারা নিম্নগামী করুন।"
+    "ButtonLabelDescendingARIA": "{{displayName}} দ্বারা নিম্নগামী করুন।",
+    "RemoveFromCollection": "Remove from Collection",
+    "Description": "description",
+    "NumSketches_plural": "{{count}} sketches"
   },
   "AddToCollectionList": {
     "Title": "p5.js Web এডিটর | আমার সংগ্রহগুলি",
-    "Empty": "কোন সংগ্রহ নেই"
+    "Empty": "কোন সংগ্রহ নেই",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s collections"
   },
   "CollectionCreate": {
     "Title": "p5.js Web এডিটর | সংগ্রহ তৈরি করুন",
@@ -524,7 +564,10 @@
     "DirectionDescendingARIA": "নিম্নগামী",
     "ButtonLabelAscendingARIA": "{{displayName}} দ্বারা ঊর্ধ্বগামী করুন।",
     "ButtonLabelDescendingARIA": "{{displayName}} দ্বারা নিম্নগামী করুন।",
-    "AddSketch": "স্কেচ যোগ করুন"
+    "AddSketch": "স্কেচ যোগ করুন",
+    "HeaderCreatedAt_mobile": "Created",
+    "HeaderUpdatedAt_mobile": "Updated",
+    "HeaderNumItems_mobile": "# sketches"
   },
   "CollectionListRow": {
     "ToggleCollectionOptionsARIA": "সংগ্রহ বিকল্পগুলি খোলা/বন্ধ করুন",
@@ -565,11 +608,15 @@
     "HeaderName": "স্কেচ",
     "HeaderCreatedAt": "তারিখ তৈরি হয়েছে",
     "HeaderUpdatedAt": "তারিখ আপডেট হয়েছে",
-    "NoSketches": "কোন স্কেচ নেই।"
+    "NoSketches": "কোন স্কেচ নেই।",
+    "View": "View",
+    "HeaderCreatedAt_mobile": "Created",
+    "HeaderUpdatedAt_mobile": "Updated"
   },
   "AddToCollectionSketchList": {
     "Title": "p5.js ওয়েব এডিটর | আমার স্কেচগুলি",
-    "NoCollections": "কোন সংগ্রহ নেই।"
+    "NoCollections": "কোন সংগ্রহ নেই।",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s sketches"
   },
   "Editor": {
     "OpenSketchARIA": "স্কেচ ফাইল নেভিগেশন খোলুন",
@@ -592,7 +639,8 @@
     "Ago": "{{timeAgo}} আগে"
   },
   "CopyableInput": {
-    "CopiedARIA": "ক্লিপবোর্ডে কপি করা হয়েছে!"
+    "CopiedARIA": "ক্লিপবোর্ডে কপি করা হয়েছে!",
+    "OpenViewTabARIA": "Open {{label}} view in new tab"
   },
   "EditableInput": {
     "EditValue": "{{display}} ভ্যালু এডিট করুন",
@@ -605,7 +653,24 @@
   "MobilePreferences": {
     "Settings": "সেটিংস",
     "Preferences": "পছন্দসমূহ",
-    "Language": "ভাষা"
+    "Language": "ভাষা",
+    "SelectLanguage": "ভাষা নির্বাচন করুন",
+    "GeneralSettings": "General settings",
+    "Accessibility": "Accessibility",
+    "AccessibleOutput": "Accessible Output",
+    "Theme": "Theme",
+    "LightTheme": "Light",
+    "DarkTheme": "Dark",
+    "HighContrastTheme": "High Contrast",
+    "Autosave": "Autosave",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "WordWrap": "Word Wrap",
+    "LineNumbers": "Line numbers",
+    "LintWarningSound": "Lint warning sound",
+    "UsedScreenReader": "Used with screen reader",
+    "PlainText": "Plain-text",
+    "TableText": "Table-text",
+    "Sound": "Sound"
   },
   "PreferenceCreators": {
     "On": "চালু",
@@ -639,5 +704,24 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
+  "CollectionView": {
+    "TitleCreate": "Create collection",
+    "TitleDefault": "collection"
+  },
+  "MobileDashboardView": {
+    "Examples": "Examples",
+    "Sketches": "Sketches",
+    "Collections": "Collections",
+    "Assets": "Assets",
+    "MyStuff": "My Stuff",
+    "CreateSketch": "Create Sketch",
+    "CreateCollection": "Create Collection"
+  },
+  "Explorer": {
+    "Files": "Files"
   }
 }

--- a/translations/locales/de/translations.json
+++ b/translations/locales/de/translations.json
@@ -8,7 +8,13 @@
       "Open": "Öffnen",
       "Download": "Herunterladen",
       "AddToCollection": "Zur Sammlung hinzufügen",
-      "Examples": "Beispiele"
+      "Examples": "Beispiele",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "Bearbeiten",
@@ -27,7 +33,10 @@
       "Title": "Hilfe",
       "KeyboardShortcuts": "Tastenkürzel",
       "Reference": "Referenz",
-      "About": "Über"
+      "About": "Über",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
     "Lang": "Sprache",
     "BackEditor": "Zurück zum Editor",
@@ -67,7 +76,12 @@
     "UsernameOrEmailARIA": "E-Mail oder Nutzername",
     "Password": "Passwort",
     "PasswordARIA": "Passwort",
-    "Submit": "Einloggen"
+    "Submit": "Einloggen",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
   },
   "LoginView": {
     "Title": "p5.js Web Editor | Anmelden",
@@ -104,7 +118,34 @@
     "Examples": "Beispiele",
     "PrivacyPolicy": "Datenschutzbestimmungen",
     "TermsOfUse": "Nutzungsbedingungen",
-    "CodeOfConduct": "Verhaltenskodex"
+    "CodeOfConduct": "Verhaltenskodex",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
+    },
+    "Contact": "Contact Us"
   },
   "Toast": {
     "OpenedNewSketch": "Neuer Sketch geöffnet.",
@@ -113,7 +154,12 @@
     "AutosaveEnabled": "Automatisches Sichern aktiviert.",
     "LangChange": "Sprache geändert",
     "SettingsSaved": "Einstellungen gespeichert.",
-    "CloseAlertARIA": "Close Alert"
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
   },
   "Toolbar": {
     "Preview": "Vorschau",
@@ -125,7 +171,10 @@
     "EditSketchARIA": "Sketch Namen bearbeiten",
     "NewSketchNameARIA": "Neuer Sketch name",
     "By": " von ",
-    "SelectVersionARIA": "Select p5.js version"
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
   },
   "Console": {
     "Title": "Konsole",
@@ -176,7 +225,27 @@
     "PlainText": "Nur Text",
     "TextOutputARIA": "Text Ausgabe an",
     "TableText": "Tabellarisch",
-    "TableOutputARIA": "Tabellarische Ausgabe an"
+    "TableOutputARIA": "Tabellarische Ausgabe an",
+    "LibraryManagement": "Library Management",
+    "FontSize": "Font Size",
+    "SetFontSize": "set font size",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "AutocompleteHinterOnARIA": "autocomplete hinter on",
+    "AutocompleteHinterOffARIA": "autocomplete hinter off",
+    "LibraryVersion": "p5.js Version",
+    "LibraryVersionInfo": "There's a [new 2.0 release](https://github.com/processing/p5.js/releases/) of p5.js available! It will become default in August, 2026, so take this time to test it out and report bugs. Interested in transitioning sketches from 1.x to 2.0? Check out the [compatibility & transition resources.](https://github.com/processing/p5.js-compatibility)",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "SoundAddon": "p5.sound.js Add-on Library",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on Library — Preload",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on Library — Shapes",
+    "DataAddon": "p5.js 1.x Compatibility Add-on Library — Data & Events",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
   },
   "KeyboardShortcuts": {
     "Title": "Tastenkürzel",
@@ -193,14 +262,19 @@
       "CommentLine": "Kommentar einfügen",
       "FindNextTextMatch": "Nächsten Text-Treffer finden",
       "FindPreviousTextMatch": "Vorherigen Text-Treffer finden",
-      "CodeEditing": "Code editieren"
+      "CodeEditing": "Code editieren",
+      "ColorPicker": "Show Inline Color Picker",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
     },
     "GeneralSelection": {
       "StartSketch": "Sketch starten",
       "StopSketch": "Sketch stoppen",
       "TurnOnAccessibleOutput": "Barrierefreie Ausgabe einschalten",
-      "TurnOffAccessibleOutput": "Barrierefreie Ausgabe ausschalten"
-    }
+      "TurnOffAccessibleOutput": "Barrierefreie Ausgabe ausschalten",
+      "Reference": "Go to Reference for Selected Item in Hinter"
+    },
+    "General": "General"
   },
   "Sidebar": {
     "Title": "Sketch Dateien",
@@ -210,7 +284,8 @@
     "AddFile": "Datei erstellen",
     "AddFileARIA": "Datei erstellen",
     "UploadFile": "Datei hochladen",
-    "UploadFileARIA": "Datei hochladen"
+    "UploadFileARIA": "Datei hochladen",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "Ordner Inhalte öffnen",
@@ -286,7 +361,8 @@
     "errorNewPassword": "Gib bitte ein neues Passwort ein oder lass dieses Feld frei.",
     "errorEmptyUsername": "Gib bitte einen Nutzernamen ein.",
     "errorLongUsername": "Der Nutzername muss weniger als 20 Zeichen haben.",
-    "errorValidUsername": "Der Nutzername darf nur aus Zahlen, Buchstaben, Punkten, Bindestrichen oder Unterstrichen bestehen."
+    "errorValidUsername": "Der Nutzername darf nur aus Zahlen, Buchstaben, Punkten, Bindestrichen oder Unterstrichen bestehen.",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
   },
   "NewPasswordView": {
     "Title": "p5.js Web Editor | Neues Passwort",
@@ -354,14 +430,19 @@
     "PasswordARIA": "Passwort",
     "ConfirmPassword": "Passwort bestätigen",
     "ConfirmPasswordARIA": "Passwort bestätigen",
-    "SubmitSignup": "Registrieren"
+    "SubmitSignup": "Registrieren",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": "p5.js Web Editor | Registrieren",
     "Description": "Registrieren",
     "Or": "Oder",
     "AlreadyHave": "Hast Du bereits einen Account? ",
-    "Login": "Anmelden"
+    "Login": "Anmelden",
+    "Warning": "By signing up, you agree to the p5.js Editor's <0>Terms of Use</0> and <1>Privacy Policy.</1>"
   },
   "EmailVerificationView": {
     "Title": "p5.js Web Editor | E-Mail Bestätigung",
@@ -379,7 +460,8 @@
     "NoUploadedAssets": "Keine hochgeladenen Assets",
     "HeaderName": "Name",
     "HeaderSize": "Größe",
-    "HeaderSketch": "Sketch"
+    "HeaderSketch": "Sketch",
+    "maximum": "Maximum"
   },
   "Feedback": {
     "Title": "p5.js Web Editor | Feedback",
@@ -446,7 +528,8 @@
     "DirectionAscendingARIA": "Aufsteigend",
     "DirectionDescendingARIA": "Absteigend",
     "ButtonLabelAscendingARIA": "Sortiere nach {{displayName}} aufsteigend.",
-    "ButtonLabelDescendingARIA": "Sortiere nach {{displayName}} absteigend."
+    "ButtonLabelDescendingARIA": "Sortiere nach {{displayName}} absteigend.",
+    "RemoveFromCollection": "Remove from Collection"
   },
   "AddToCollectionList": {
     "Title": "p5.js Web Editor | Meine Sammlungen",
@@ -589,7 +672,11 @@
     "UsedScreenReader": "Nutzung mit Bildschirmlesegerät ",
     "PlainText": "Nur Text",
     "TableText": "Tabellarisch",
-    "Sound": "Sound"
+    "Sound": "Sound",
+    "SelectLanguage": "Sprache auswählen",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "Preferences": "Preferences",
+    "Language": "Language"
   },
   "PreferenceCreators": {
     "On": "An",
@@ -609,5 +696,34 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
+  "Cookies": {
+    "Header": "Cookies",
+    "Body": "The p5.js Editor uses cookies. Some are essential to the website functionality and allow you to manage an account and preferences. Others are not essential—they are used for analytics and allow us to learn more about our community. <strong> We never sell this data or use it for advertising. </strong> You can decide which cookies you would like to allow, and learn more in our <0>Privacy Policy<0>.",
+    "AllowAll": "Allow All",
+    "AllowEssential": "Allow Essential"
+  },
+  "Legal": {
+    "PrivacyPolicy": "Privacy Policy",
+    "TermsOfUse": "Terms of Use",
+    "CodeOfConduct": "Code of Conduct"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
 }

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -677,6 +677,7 @@
     "PlainText": "Plain-text",
     "TableText": "Table-text",
     "Sound": "Sound",
+    "SelectLanguage": "Select Language",
     "Preferences": "Preferences",
     "Language": "Language"
   },

--- a/translations/locales/es-419/translations.json
+++ b/translations/locales/es-419/translations.json
@@ -8,7 +8,13 @@
       "Open": "Abrir",
       "Download": "Descargar",
       "AddToCollection": "Agregar a colección",
-      "Examples": "Ejemplos"
+      "Examples": "Ejemplos",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "Editar",
@@ -27,7 +33,10 @@
       "Title": "Ayuda",
       "KeyboardShortcuts": "Atajos",
       "Reference": "Referencia",
-      "About": "Acerca de"
+      "About": "Acerca de",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
     "Lang": "Lenguaje",
     "BackEditor": "Regresa al editor",
@@ -70,7 +79,12 @@
     "UsernameOrEmailARIA": "Introduce Correo o Identificación",
     "Password": "Contraseña",
     "PasswordARIA": "Contraseña",
-    "Submit": "Ingresa"
+    "Submit": "Ingresa",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
   },
   "LoginView": {
     "Title": " Editor Web p5.js  | Ingreso",
@@ -107,7 +121,34 @@
     "Examples": "Ejemplos",
     "PrivacyPolicy": "Política de privacidad",
     "TermsOfUse": "Términos de uso",
-    "CodeOfConduct": "Código de conducta"
+    "CodeOfConduct": "Código de conducta",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
+    },
+    "Contact": "Contact Us"
   },
   "Toast": {
     "OpenedNewSketch": "Abriste un nuevo bosquejo.",
@@ -116,7 +157,12 @@
     "AutosaveEnabled": "Grabado automático activado.",
     "LangChange": "Lenguaje cambiado",
     "SettingsSaved": "Configuración guardada.",
-    "CloseAlertARIA": "Close Alert"
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
   },
   "Toolbar": {
     "Preview": "Vista previa",
@@ -128,7 +174,10 @@
     "EditSketchARIA": "Editar nombre de bosquejo",
     "NewSketchNameARIA": "Nuevo nombre de bosquejo",
     "By": " de ",
-    "SelectVersionARIA": "Select p5.js version"
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
   },
   "Console": {
     "Title": "Consola",
@@ -186,7 +235,20 @@
     "SoundAddon": "p5.sound.js Add-on Biblioteca",
     "PreloadAddon": "p5.js 1.x Compatibility Add-on Biblioteca — Precarga",
     "ShapesAddon": "p5.js 1.x Compatibility Add-on Biblioteca — formas",
-    "DataAddon": "p5.js 1.x Compatibility Add-on Biblioteca — Estructuras de datos"
+    "DataAddon": "p5.js 1.x Compatibility Add-on Biblioteca — Estructuras de datos",
+    "FontSize": "Font Size",
+    "SetFontSize": "set font size",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "AutocompleteHinterOnARIA": "autocomplete hinter on",
+    "AutocompleteHinterOffARIA": "autocomplete hinter off",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
   },
   "KeyboardShortcuts": {
     "Title": " Atajos de teclado",
@@ -203,14 +265,19 @@
       "CommentLine": "Comentar línea de código",
       "FindNextTextMatch": "Encontrar la siguiente ocurrencia de texto",
       "FindPreviousTextMatch": "Encontrar la ocurrencia previa de texto",
-      "CodeEditing": "Editando Código"
+      "CodeEditing": "Editando Código",
+      "ColorPicker": "Show Inline Color Picker",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
     },
     "GeneralSelection": {
       "StartSketch": "Iniciar bosquejo",
       "StopSketch": "Detener bosquejo",
       "TurnOnAccessibleOutput": "Activar salida accesible",
-      "TurnOffAccessibleOutput": "Desactivar salida accesible"
-    }
+      "TurnOffAccessibleOutput": "Desactivar salida accesible",
+      "Reference": "Go to Reference for Selected Item in Hinter"
+    },
+    "General": "General"
   },
   "Sidebar": {
     "Title": "Archivos de Bosquejo",
@@ -220,7 +287,8 @@
     "AddFile": "Crear archivo",
     "AddFileARIA": "agregar archivo",
     "UploadFile": "Subir archivo",
-    "UploadFileARIA": "Subir archivo"
+    "UploadFileARIA": "Subir archivo",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "Abrir contenidos del directorio",
@@ -296,7 +364,8 @@
     "errorNewPasswordRepeat": "Your New Password must differ from the current one.",
     "errorEmptyUsername": "Por favor introduce tu identificación",
     "errorLongUsername": "La identificación debe ser menor a 20 caracteres.",
-    "errorValidUsername": "La identificación debe consistir solamente de números, letras, puntos, guiones y guiones bajos."
+    "errorValidUsername": "La identificación debe consistir solamente de números, letras, puntos, guiones y guiones bajos.",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
   },
   "NewPasswordView": {
     "Title": "Editor Web p5.js | Nueva Contraseña",
@@ -318,7 +387,8 @@
     "CurrentPasswordARIA": "Contraseña Actual",
     "NewPassword": "Nueva Contraseña",
     "NewPasswordARIA": "Nueva Contraseña",
-    "SubmitSaveAllSettings": "Guardar Todas Las Configuraciones"
+    "SubmitSaveAllSettings": "Guardar Todas Las Configuraciones",
+    "SaveAccountDetails": "Save Account Details"
   },
   "AccountView": {
     "SocialLogin": "Identificacion usando redes sociales",
@@ -364,14 +434,19 @@
     "PasswordARIA": "contraseña",
     "ConfirmPassword": "Confirma tu contraseña",
     "ConfirmPasswordARIA": "Confirma tu contraseña",
-    "SubmitSignup": "Registráte"
+    "SubmitSignup": "Registráte",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": " Editor Web p5.js | Registráte",
     "Description": "Registráte",
     "Or": "o",
     "AlreadyHave": "¿Ya tienes cuenta? ",
-    "Login": "Ingresa"
+    "Login": "Ingresa",
+    "Warning": "By signing up, you agree to the p5.js Editor's <0>Terms of Use</0> and <1>Privacy Policy.</1>"
   },
   "EmailVerificationView": {
     "Title": "Editor Web p5.js | Correo de Verificación",
@@ -389,7 +464,8 @@
     "NoUploadedAssets": "No has subido recursos.",
     "HeaderName": "Nombre",
     "HeaderSize": "Tamaño",
-    "HeaderSketch": "Bosquejo"
+    "HeaderSketch": "Bosquejo",
+    "maximum": "Maximum"
   },
   "Feedback": {
     "Title": "Editor Web p5.js | Retroalimentación",
@@ -456,7 +532,8 @@
     "DirectionAscendingARIA": "Ascendente",
     "DirectionDescendingARIA": "Descendente",
     "ButtonLabelAscendingARIA": "Ordenar por {{displayName}} ascendente.",
-    "ButtonLabelDescendingARIA": "Ordenar por {{displayName}} descendente."
+    "ButtonLabelDescendingARIA": "Ordenar por {{displayName}} descendente.",
+    "RemoveFromCollection": "Remove from Collection"
   },
   "AddToCollectionList": {
     "Title": "p5.js Web Editor | Mis colecciones",
@@ -599,7 +676,11 @@
     "UsedScreenReader": "Uso con screen reader",
     "PlainText": "Texto sin formato",
     "TableText": "Tablero de texto",
-    "Sound": "Sonido"
+    "Sound": "Sonido",
+    "SelectLanguage": "Seleccionar idioma",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "Preferences": "Preferences",
+    "Language": "Language"
   },
   "PreferenceCreators": {
     "On": "Activar",
@@ -619,5 +700,31 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "Cookies": {
+    "Header": "Cookies",
+    "Body": "The p5.js Editor uses cookies. Some are essential to the website functionality and allow you to manage an account and preferences. Others are not essential—they are used for analytics and allow us to learn more about our community. <strong> We never sell this data or use it for advertising. </strong> You can decide which cookies you would like to allow, and learn more in our <0>Privacy Policy<0>.",
+    "AllowAll": "Allow All",
+    "AllowEssential": "Allow Essential"
+  },
+  "Legal": {
+    "PrivacyPolicy": "Privacy Policy",
+    "TermsOfUse": "Terms of Use",
+    "CodeOfConduct": "Code of Conduct"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
 }

--- a/translations/locales/fr-CA/translations.json
+++ b/translations/locales/fr-CA/translations.json
@@ -1,628 +1,733 @@
 {
-    "Nav": {
-      "File": {
-        "Title": "Fichier",
-        "New": "Nouveau",
-        "Share": "Partager",
-        "Duplicate": "Dupliquer",
-        "Open": "Ouvrir",
-        "Download": "Télécharger",
-        "AddToCollection": "Ajouter à la collection",
-        "Examples": "Exemples"
-      },
-      "Edit": {
-        "Title": "Edition",
-        "TidyCode": "Nettoyer le code",
-        "Find": "Rechercher",
-        "FindNext": "Prochaine correspondance",
-        "Replace": "Remplacer"
-      },
-      "Sketch": {
-        "Title": "Croquis",
-        "AddFile": "Nouveau fichier",
-        "AddFolder": "Nouveau dossier",
-        "Run": "Exécuter",
-        "Stop": "Arrêter"
-      },
-      "Help": {
-        "Title": "Aide",
-        "KeyboardShortcuts": "Raccourcis clavier",
-        "Reference": "Référence",
-        "About": "À propos"
-      },
-      "Lang": "Langue",
-      "BackEditor": "Retour à l'éditeur",
-      "WarningUnsavedChanges": "Êtes-vous certain de vouloir quitter cette page? Vous avez des changements non enregistrés.",
-      "Login": "Se connecter",
-      "LoginOr": "ou",
-      "SignUp": "S'inscrire",
-      "Auth": {
-        "Welcome": "Bienvenue",
-        "Hello": "Bonjour",
-        "MyAccount": "compte",
-        "My": "Mon",
-        "MySketches": "Mes croquis",
-        "MyCollections": "Mes collections",
-        "Asset": "Ressources",
-        "MyAssets": "Mes ressources",
-        "LogOut": "Se déconnecter"
-      }
-    },
-    "Banner": {
-      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
-    },
-    "CodemirrorFindAndReplace": {
-      "ToggleReplace": "Activer/désactiver le remplacement",
-      "Find": "Rechercher",
-      "FindPlaceholder": "Trouver dans les fichiers",
-      "Replace": "Remplacer",
-      "ReplaceAll": "Remplacer tout",
-      "ReplacePlaceholder": "Texte à remplacer",
-      "Regex": "Expression régulière",
-      "CaseSensitive": "Sensible à la casse",
-      "WholeWords": "Mots entiers",
-      "Previous": "Précédent",
-      "Next": "Suivant",
-      "NoResults": "Aucun résultat",
-      "Close": "Fermer"
-    },
-    "LoginForm": {
-      "UsernameOrEmail": "Courriel ou nom d'utilisateur",
-      "UsernameOrEmailARIA": "Courriel ou nom d'utilisateur",
-      "Password": "Mot de passe",
-      "PasswordARIA": "Mot de passe",
-      "Submit": "Se connecter"
-    },
-    "LoginView": {
-      "Title": "Editeur web p5.js | Se connecter",
-      "Login": "Se connecter",
-      "LoginOr": "ou",
-      "SignUp": "S'enregistrer",
-      "Email": "courriel",
-      "Username": "Nom d'utilisateur",
-      "DontHaveAccount": "Vous n'avez pas encore de compte? ",
-      "ForgotPassword": "Mot de passe oublié? ",
-      "ResetPassword": "Réinitialiser son mot de passe"
-    },
-    "SocialAuthButton": {
-      "Connect": "Connecter au compte {{serviceauth}}",
-      "Unlink": "Se déconnecter du compte {{serviceauth}}",
-      "Login": "Se connecter via {{serviceauth}}",
-      "LogoARIA": "logo {{serviceauth}}"
-    },
-    "About": {
-      "Title": "À propos",
-      "TitleHelmet": "Éditeur web p5.js | À propos",
-      "Contribute": "Contribuer",
-      "NewP5": "Nouveau à p5.js?",
-      "Report": "Signaler un bogue",
-      "Learn": "Apprendre",
-      "Twitter": "Twitter",
-      "Home": "Accueil",
-      "Instagram": "Instagram",
-      "Discord": "Discord",
-      "WebEditor": "Éditeur web",
-      "Resources": "Ressources",
-      "Libraries": "Librairies",
-      "Forum": "Forum",
-      "Examples": "Exemples",
-      "PrivacyPolicy": "Politique de confidentialité",
-      "TermsOfUse": "Conditions d'utilisation",
-      "CodeOfConduct": "Code de conduite"
-    },
-    "Toast": {
-      "OpenedNewSketch": "Ouvrir un nouveau croquis.",
-      "SketchSaved": "Croquis sauvegardé.",
-      "SketchFailedSave": "Echec de la sauvegarde du croquis.",
-      "AutosaveEnabled": "Sauvegarde automatique activée.",
-      "LangChange": "Langue changée.",
-      "SettingsSaved": "Paramètres sauvegardés.",
-      "CloseAlertARIA": "Close Alert"
-    },
-    "Toolbar": {
-      "Preview": "Aperçu",
-      "Auto-refresh": "Actualisation automatique",
-      "OpenPreferencesARIA": "Ouvrir les préférences",
-      "PlaySketchARIA": "Exécuter le croquis",
-      "PlayOnlyVisualSketchARIA": "Exécuter seulement le croquis visuel",
-      "StopSketchARIA": "Arrêter le croquis",
-      "EditSketchARIA": "Éditer le nom du croquis",
-      "NewSketchNameARIA": "Nouveau nom de croquis",
-      "By": " par ",
-      "SelectVersionARIA": "Select p5.js version"
-    },
-    "Console": {
-      "Title": "Console",
-      "Clear": "Effacer",
-      "ClearARIA": "Effacer la console",
-      "Close": "Fermer",
-      "CloseARIA": "Fermer la console",
-      "Open": "Ouvrir",
-      "OpenARIA": "Ouvrir la console"
-    },
-    "Preferences": {
-      "Settings": "Paramètres",
-      "GeneralSettings": "Paramètres généraux",
-      "Accessibility": "Accessibilité",
-      "LibraryManagement": "Gestion de bibliothèque",
-      "Theme": "Thème",
-      "LightTheme": "Clair",
-      "LightThemeARIA": "Thème clair activé",
-      "DarkTheme": "Sombre",
-      "DarkThemeARIA": "Thème sombre activé",
-      "HighContrastTheme": "Contraste élevé",
-      "HighContrastThemeARIA": "Thème contraste élevé activé",
-      "TextSize": "Taille du texte",
-      "DecreaseFont": "Diminuer",
-      "DecreaseFontARIA": "diminuer la taille de la police",
-      "IncreaseFont": "Augmenter",
-      "IncreaseFontARIA": "augmenter la taille de la police",
-      "Autosave": "Sauvegarde automatique",
-      "On": "Activé",
-      "AutosaveOnARIA": "sauvegarde automatique activée",
-      "Off": "Désactivé",
-      "AutosaveOffARIA": "sauvegarde automatique désactivée",
-      "AutocloseBracketsQuotes": "Fermeture automatique des crochets et des guillemets",
-      "AutocloseBracketsQuotesOnARIA": "fermeture automatique des crochets et des guillemets activée",
-      "AutocloseBracketsQuotesOffARIA": "fermeture automatique des crochets et des guillemets désactivée",
-      "WordWrap": "Retour à la ligne automatique",
-      "WordWrapOnARIA": "retour à la ligne automatique activé",
-      "WordWrapOffARIA": "retour à la ligne automatique désactivé",
-      "LineNumbers": "Numéros de lignes",
-      "LineNumbersOnARIA": "numéros de lignes activés",
-      "LineNumbersOffARIA": "numéros de lignes désactivés",
-      "LintWarningSound": "Son d'alarme Lint",
-      "LintWarningOnARIA": "son d'alarme Lint activé",
-      "LintWarningOffARIA": "son d'alarme Lint désactivé",
-      "PreviewSound": "Tester le son",
-      "PreviewSoundARIA": "Tester le son",
-      "AccessibleTextBasedCanvas": "Canvas textuel accessible",
-      "UsedScreenReader": "Utilisé avec un lecteur de texte",
-      "PlainText": "Texte brut",
-      "TextOutputARIA": "sortie texte activée",
-      "TableText": "Tableau de texte",
-      "TableOutputARIA": "sortie tableau de texte activée",
-      "LibraryVersion": "Version de p5.js",
-      "LibraryVersionInfo": "Une [nouvelle version 2.0](https://github.com/processing/p5.js/releases/) de p5.js est disponible ! Elle deviendra la version par défaut en août 2026, alors profitez de ce temps pour la tester et signaler les bogues. Intéressé à migrer vos esquisses de 1.x vers 2.0 ? Consultez les [ressources de compatibilité et de transition.](https://github.com/processing/p5.js-compatibility)",
-      "SoundAddon": "p5.sound.js Add-on Bibliothèque",
-      "PreloadAddon": "p5.js 1.x Compatibility Add-on Bibliothèque — Préchargement",
-      "ShapesAddon": "p5.js 1.x Compatibility Add-on Bibliothèque — Formes",
-      "DataAddon": "p5.js 1.x Compatibility Add-on Bibliothèque — Structures de données",
-      "Sound": "Son",
-      "SoundOutputARIA": "sortie son activée"
-    },
-    "KeyboardShortcuts": {
-      "Title": " Raccourcis clavier",
-      "ShortcutsFollow": "Les raccourcis clavier de l'éditeur suivent",
-      "SublimeText": "les raccourcis de Sublime Text",
-      "CodeEditing": {
-        "Tidy": "Nettoyer",
-        "FindText": "Rechercher",
-        "FindNextMatch": "Correspondance suivante",
-        "FindPrevMatch": "Correspondance précédente",
-        "IndentCodeLeft": "Indenter le code à gauche",
-        "ReplaceTextMatch": "Remplacer la correspondance",
-        "IndentCodeRight": "Indenter le code à droite",
-        "CommentLine": "Ligne de commentaire",
-        "FindNextTextMatch": "Correspondance texte suivante",
-        "FindPreviousTextMatch": "Correspondance texte précédente",
-        "CodeEditing": "Édition de code"
-      },
-      "GeneralSelection": {
-        "StartSketch": "Exécuter le croquis",
-        "StopSketch": "Arrêter le croquis",
-        "TurnOnAccessibleOutput": "Activer la sortie accessible",
-        "TurnOffAccessibleOutput": "Désactiver la sortie accessible"
-      }
-    },
-    "Sidebar": {
-      "Title": "Fichiers croquis",
-      "ToggleARIA": "Alterner les options d'ouverture/fermeture du fichier croquis",
-      "AddFolder": "Créer un dossier",
-      "AddFolderARIA": "ajouter un dossier",
-      "AddFile": "Créer un fichier",
-      "AddFileARIA": "ajouter un fichier",
-      "UploadFile": "Téléverser un fichier",
-      "UploadFileARIA": "téléverser un fichier"
-    },
-    "FileNode": {
-      "OpenFolderARIA": "Ouvrir le contenu du dossier",
-      "CloseFolderARIA": "Fermer le contenu du dossier",
-      "ToggleFileOptionsARIA": "Alterner l'ouverture/fermeture des options de fichiers",
-      "AddFolder": "Créer un dossier",
-      "AddFolderARIA": "ajouter un dossier",
-      "AddFile": "Créer un fichier",
-      "AddFileARIA": "ajouter un fichier",
-      "UploadFile": "Téléverser un fichier",
-      "UploadFileARIA": "téléverser un fichier",
-      "Rename": "Renommer",
-      "Delete": "Supprimer"
-    },
-    "Common": {
-      "SiteName": "Éditeur web p5.js",
-      "Error": "Erreur",
-      "ErrorARIA": "Erreur",
-      "Save": "Sauvegarder",
-      "p5logoARIA": "Logo p5.js",
-      "DeleteConfirmation": "Etes-vous sûr que vous voulez supprimer {{name}}?"
-    },
-    "IDEView": {
-      "SubmitFeedback": "Soumettre des commentaires",
-      "SubmitFeedbackARIA": "Soumettre des commentaires",
-      "AddCollectionTitle": "Ajouter à la collection",
-      "AddCollectionARIA":"Ajouter à la collection",
-      "ShareTitle": "Partager",
-      "ShareARIA":"partager"
-    },
-    "NewFileModal": {
-      "Title": "Créer un fichier",
-      "CloseButtonARIA": "Fermer la boîte de dialogue de création de fichier",
-      "EnterName": "Veuillez saisir un nom",
-      "InvalidType": "Type de fichier invalide. Les extensions valides sont .js, .css, .json, .txt, .csv, .tsv, .frag, and .vert."
-    },
-    "NewFileForm": {
-      "AddFileSubmit": "Ajouter un fichier",
-      "Placeholder": "Nom"
-    },
-    "NewFolderModal": {
-      "Title": "Créer un dossier",
-      "CloseButtonARIA": "Fermer la boîte de dialogue de création de dossier",
-      "EnterName": "Veuillez saisir un nom",
-      "EmptyName": "Le nom du dossier ne peut contenir uniquement des espaces",
-      "InvalidExtension": "Le nom du dossier ne peut contenir une extension"
-    },
-    "NewFolderForm": {
-      "AddFolderSubmit": "Ajouter un dossier",
-      "Placeholder": "Nom"
-    },
-    "ResetPasswordForm": {
-      "Email": "Courriel utilisé pour l'inscription",
-      "EmailARIA": "courriel",
-      "Submit": "Envoyer un courriel de réinitialisation du mot de passe"
-    },
-    "ResetPasswordView": {
-      "Title": "Éditeur web p5.js | Réinitialisation du mot de passe",
-      "Reset": "Réinitialiser votre mot de passe",
-      "Submitted": "Votre courriel de réinitialisation de mot de passe devrait arriver sous peu. Si vous ne le voyez pas, vérifiez\n            vos courriers indésirables, il est possible qu'il s'y retrouve.",
-      "Login": "Se connecter",
-      "LoginOr": "ou",
-      "SignUp": "S'enregistrer"
-    },
-    "ReduxFormUtils": {
-      "errorInvalidEmail": "Veuillez saisir une adresse courriel valide",
-      "errorEmptyEmail": "Veuillez saisir une adresse courriel",
-      "errorPasswordMismatch": "Les mots de passe doivent correspondre",
-      "errorEmptyPassword": "Veuillez saisir un mot de passe",
-      "errorShortPassword": "Le mot de passe doit comporter au moins 6 caractères",
-      "errorConfirmPassword": "Veuillez saisir une confirmation de mot de passe",
-      "errorNewPasswordRepeat":"Votre nouveau mot de passe doit être différent du mot de passe actuel.",
-      "errorNewPassword": "Veuillez saisir un nouveau mot de passe ou laisser le mot de passe actuel vide.",
-      "errorEmptyUsername": "Veuillez saisir un nom d'utilisateur.",
-      "errorLongUsername": "Le nom d'utilisateur doit comporter moins de 20 caractères.",
-      "errorValidUsername": "Le nom d'utilisateur ne peut qu'être composé de chiffres, de lettres, de points, de tirets et de traits de soulignement."
-    },
-    "NewPasswordView": {
-      "Title": "Éditeur Web p5.js | Nouveau mot de passe",
-      "Description": "Définir un nouveau mot de passe",
-      "TokenInvalidOrExpired": "Le jeton de réinitialisation du mot de passe n'est pas valide ou a expiré.",
-      "EmptyPassword": "Veuillez saisir un mot de passe",
-      "PasswordConfirmation": "Veuillez saisir une confirmation de mot de passe",
-      "PasswordMismatch": "les mots de passe doivent correspondre"
-    },
-    "AccountForm": {
-      "Email": "Courriel",
-      "EmailARIA": "courriel",
-      "Unconfirmed": "Non confirmé.",
-      "EmailSent": "Confirmation envoyée, vérifiez votre courriel.",
-      "Resend": "Renvoyer un courriel de confirmation",
-      "UserName": "Nom d'utilisateur",
-      "UserNameARIA": "Nom d'utilisateur",
-      "CurrentPassword": "Mot de passe actuel",
-      "CurrentPasswordARIA": "Mot de passe actuel",
-      "NewPassword": "Nouveau mot de passe",
-      "NewPasswordARIA": "Nouveau mot de passe",
-      "SubmitSaveAllSettings": "Sauvegarder tous les paramètres"
-    },
-    "AccountView": {
-      "SocialLogin": "Identification à l'aide des réseaux sociaux",
-      "SocialLoginDescription": "Utilisez votre compte GitHub ou Google pour vous connecter à l'éditeur Web p5.js.",
-      "Title": "Éditeur web p5.js | Paramètres du compte",
-      "Settings": "Paramètres du compte",
-      "AccountTab": "Compte",
-      "AccessTokensTab": "Jetons d'accès"
-    },
-    "APIKeyForm": {
-      "ConfirmDelete": "Êtes-vous sûr de vouloir supprimer {{key_label}}?",
-      "Summary": "Les jetons d'accès personnels agissent comme votre mot de passe\n          pour permettre aux scripts automatisés d'accéder à l'API de l'éditeur.\n          Créez un jeton pour chaque script nécessitant un accès.",
-      "CreateToken": "Créer un nouveau jeton",
-      "TokenLabel": "À quoi sert ce jeton?",
-      "TokenPlaceholder": "À quoi sert ce jeton ? p. ex. Exemple de script d'importation",
-      "CreateTokenSubmit": "Créer",
-      "NoTokens": "Vous n'avez pas de jetons existants.",
-      "NewTokenTitle": "Votre nouveau jeton d'accès",
-      "NewTokenInfo": "Assurez-vous de copier votre nouveau jeton d'accès personnel.\n                  Vous ne pourrez plus revenir le voir!",
-      "ExistingTokensTitle": "Jetons existants"
-    },
-    "APIKeyList": {
-      "Name": "Nom",
-      "Created": "Créée le",
-      "LastUsed": "Dernière utilisation",
-      "Actions": "Actions",
-      "Never": "Jamais",
-      "DeleteARIA": "Supprimer la clé API"
-    },
-    "NewPasswordForm": {
-      "Title": "Mot de passe",
-      "TitleARIA": "Mot de passe",
-      "ConfirmPassword": "Confirmer le mot de passe",
-      "ConfirmPasswordARIA": "Confirmer le mot de passe",
-      "SubmitSetNewPassword": "Définir un nouveau mot de passe"
-    },
-    "SignupForm": {
-      "Title": "Nom d'utilisateur",
-      "TitleARIA": "nom d'utilisateur",
-      "Email": "Courriel",
-      "EmailARIA": "courriel",
-      "Password": "Mot de passe",
-      "PasswordARIA": "mot de passe",
-      "ConfirmPassword": "Confirmer le mot de passe",
-      "ConfirmPasswordARIA": "Confirmer le mot de passe",
-      "SubmitSignup": "S'inscrire"
-    },
-    "SignupView": {
-      "Title": "Éditeur web p5.js | S'inscrire",
-      "Description": "S'inscrire",
-      "Or": "Ou",
-      "AlreadyHave": "Vous avez déjà un compte?",
-      "Login": "Se connecter",
-      "Warning" : "En vous inscrivant, vous acceptez les <0>Conditions d'utilisation</0> et la <1>Politique de confidentialité</1> de l'éditeur p5.js."
-    },
-    "EmailVerificationView": {
-      "Title": "Éditeur web p5.js | Vérification du courriel",
-      "Verify": "Vérifiez votre courriel",
-      "InvalidTokenNull": "Ce lien n'est pas valide.",
-      "Checking": "Validation du jeton, veuillez patienter...",
-      "Verified": "Ça y est, votre adresse courriel a été vérifiée.",
-      "InvalidState": "Le jeton est invalide ou expiré."
-    },
-    "AssetList": {
-      "Title": "Éditeur web p5.js | Mes ressources",
-      "ToggleOpenCloseARIA": "Activer/désactiver l'ouverture/fermeture des options ressources",
-      "Delete": "Supprimer",
-      "OpenNewTab": "Ouvrir dans un nouvel onglet",
-      "NoUploadedAssets": "Aucune ressource téléversée.",
-      "HeaderName": "Nom",
-      "HeaderSize": "Taille",
-      "HeaderSketch": "Croquis"
-    },
-    "Feedback": {
-      "Title": "Éditeur web p5.js | Commentaires",
-      "ViaGithubHeader": "Via Github Issues",
-      "ViaGithubDescription": "Si vous connaissez bien Github, c'est notre méthode préférée pour recevoir des rapports de bugs et des commentaires.",
-      "GoToGithub": "Aller à Github",
-      "ViaGoogleHeader": "Via Google Form",
-      "ViaGoogleDescription": "Vous pouvez également soumettre vos commentaires via ce formulaire.",
-      "GoToForm": "Aller au formulaire"
-    },
-    "Searchbar": {
-      "SearchSketch": "Chercher des croquis...",
-      "SearchCollection": "Chercher des collections...",
-      "ClearTerm": "effacer"
-    },
-    "UploadFileModal": {
-      "Title": "Téléverser un fichier",
-      "CloseButtonARIA": "Fermer la boîte de dialogue de téléversement de fichiers",
-      "SizeLimitError": "Erreur: Vous ne pouvez plus téléverser de fichiers. Vous avez atteint la limite de taille totale de {{sizeLimit}}.\n                If you would like to upload more, please remove the ones you aren't using anymore by\n                in your "
-    },
-    "FileUploader": {
-      "DictDefaultMessage": "Déposez des fichiers ici ou cliquez pour utiliser le navigateur de fichiers"
-    },
-    "ErrorModal": {
-      "MessageLogin": "Pour pouvoir sauvegarder les croquis, vous devez être connecté. Veuillez ",
-      "Login": "Se connecter",
-      "LoginOr": " ou ",
-      "SignUp": "S'enregistrer",
-      "MessageLoggedOut": "Il semble que vous ayez été déconnecté. Veuillez ",
-      "LogIn": "Se connecter",
-      "SavedDifferentWindow": "Le projet que vous avez tenté de sauvegarder a été sauvegardé à partir d'une\n        autre fenêtre. Veuillez rafraîchir la page pour voir la dernière version.",
-      "LinkTitle": "Erreur de liaison de compte",
-      "LinkMessage": "Il y a eu un problème pour relier votre compte {{serviceauth}} à votre compte éditeur web p5.js. Votre compte {{serviceauth}} a déjà été lié à un autre compte de éditeur Web p5.js."
-    },
-    "ShareModal": {
-      "Embed": "Intégrer",
-      "Present": "Présenter",
-      "Fullscreen": "Plein écran",
-      "Edit": "Éditer"
-    },
-    "CollectionView": {
-      "TitleCreate": "Créer une collection",
-      "TitleDefault": "collection"
-    },
-    "Collection": {
-      "Title": "Éditeur web p5.js | Mes collections",
-      "AnothersTitle": "Éditeur web p5.js | Collections de {{anotheruser}}",
+  "Nav": {
+    "File": {
+      "Title": "Fichier",
+      "New": "Nouveau",
       "Share": "Partager",
-      "URLLink": "Lien vers la collection",
-      "AddSketch": "Ajouter un croquis",
-      "DeleteFromCollection": "Êtes-vous sûr de vouloir supprimer {{name_sketch}} de cette collection?",
-      "SketchDeleted": "Croquis supprimé",
-      "SketchRemoveARIA": "Supprimer le croquis de la collection",
-      "DescriptionPlaceholder": "Ajouter une description",
-      "Description": "description",
-      "NumSketches": "{{count}} croquis",
-      "NumSketches_plural": "{{count}} croquis",
-      "By":"Collection par ",
-      "NoSketches": "Aucun croquis dans la collection",
-      "TableSummary": "tableau contenant toutes les collections",
-      "HeaderName": "Nom",
-      "HeaderCreatedAt": "Date ajoutée",
-      "HeaderUser": "Propriétaire",
-      "DirectionAscendingARIA": "Ascendant",
-      "DirectionDescendingARIA": "Descendant",
-      "ButtonLabelAscendingARIA": "Trier par {{displayName}} ascendant.",
-      "ButtonLabelDescendingARIA": "Trier par {{displayName}} descendant."
-    },
-    "AddToCollectionList": {
-      "Title": "Éditeur web p5.js | Mes collections",
-      "AnothersTitle": "Éditeur web p5.js | Collections de {{anotheruser}}",
-      "Empty": "Aucune collection"
-    },
-    "CollectionCreate": {
-      "Title": "Éditeur web p5.js | Créer une collection",
-      "FormError": "Impossible de créer une collection",
-      "FormLabel": "Nom de la collection",
-      "FormLabelARIA": "nom",
-      "NameRequired": "Le nom de la collection est requis",
-      "Description": "Description (optionnel)",
-      "DescriptionARIA": "description",
-      "DescriptionPlaceholder": "Mes croquis préférés",
-      "SubmitCollectionCreate": "Créer la collection"
-    },
-    "DashboardView": {
-      "CreateCollection": "Créer une collection",
-      "NewSketch": "Nouveau croquis",
-      "CreateCollectionOverlay": "Créer une collection"
-    },
-    "DashboardTabSwitcher": {
-      "Sketches": "Croquis",
-      "Collections": "Collections",
-      "Assets": "Ressources"
-    },
-    "CollectionList": {
-      "Title": "Éditeur web p5.js | Mes collections",
-      "AnothersTitle": "Éditeur web p5.js | collections de {{anotheruser}}",
-      "NoCollections": "Aucune collection.",
-      "TableSummary": "tableau contenant toutes les collections",
-      "HeaderName": "Nom",
-      "HeaderCreatedAt": "Date de création",
-      "HeaderCreatedAt_mobile": "Créé",
-      "HeaderUpdatedAt": "Date de mise à jour",
-      "HeaderUpdatedAt_mobile": "Mise à jour",
-      "HeaderNumItems": "# croquis",
-      "HeaderNumItems_mobile": "# croquis",
-      "DirectionAscendingARIA": "Ascendant",
-      "DirectionDescendingARIA": "Descendant",
-      "ButtonLabelAscendingARIA": "Trier par {{displayName}} ascendant.",
-      "ButtonLabelDescendingARIA": "Trier par {{displayName}} descendant.",
-      "AddSketch": "Ajouter un croquis"
-    },
-    "CollectionListRow": {
-      "ToggleCollectionOptionsARIA": "Activer/désactiver l'ouverture/fermeture des options de collections",
-      "AddSketch": "Ajouter un croquis",
-      "Delete": "Supprimer",
-      "Rename": "Renommer"
-    },
-    "Overlay": {
-      "AriaLabel": "Fermer {{title}} superposé"
-    },
-    "QuickAddList":{
-      "ButtonRemoveARIA": "Supprimer de la collection",
-      "ButtonAddToCollectionARIA": "Ajouter à la collection",
-      "View": "Voir"
-    },
-    "Pagination": {
-      "Next": "Next",
-      "Previous": "Previous",
-      "Of": "of",
-      "PreviousPageARIA": "Previous Page",
-      "NextPageARIA": "Next Page"
-    },
-    "SketchList": {
-      "View": "Voir",
-      "Title": "Éditeur web p5.js | Mes croquis",
-      "AnothersTitle": "Éditeur web p5.js | Croquis de {{anotheruser}}",
-      "ToggleLabelARIA": "Activer/désactiver l'ouverture/fermeture des options de croquis",
-      "DropdownRename": "Renommer",
-      "DropdownDownload": "Télécharger",
-      "DropdownDuplicate": "Dupliquer",
-      "DropdownAddToCollection": "Ajouter à la collection",
-      "DropdownDelete": "Supprimer",
-      "DirectionAscendingARIA": "Ascendant",
-      "DirectionDescendingARIA": "Descendant",
-      "ButtonLabelAscendingARIA": "Trier par {{displayName}} ascendant.",
-      "ButtonLabelDescendingARIA": "Trier par {{displayName}} descendant.",
-      "AddToCollectionOverlayTitle": "Ajouter à la collection",
-      "TableSummary": "tableau contenant toutes projets sauvegardés",
-      "HeaderName": "Croquis",
-      "HeaderCreatedAt": "Date de création",
-      "HeaderCreatedAt_mobile": "Créé",
-      "HeaderUpdatedAt": "Date de mise à jour",
-      "HeaderUpdatedAt_mobile": "mise à jour",
-      "NoSketches": "Aucun croquis."
-    },
-    "AddToCollectionSketchList": {
-      "Title": "Éditeur web p5.js | Mes croquis",
-      "AnothersTitle": "Éditeur web p5.js | Croquis de {{anotheruser}}",
-      "NoCollections": "Aucune collection."
-    },
-    "Editor": {
-      "OpenSketchARIA": "Ouvrir la navigation dans les fichiers croquis",
-      "CloseSketchARIA": "Fermer la navigation dans les fichiers croquis",
-      "UnsavedChangesARIA": "Le croquis a des modifications non sauvegardées",
-      "KeyUpLineNumber": "ligne {{lineNumber}}"
-    },
-    "EditorAccessibility": {
-      "NoLintMessages": "Il n'y a pas de messages lint",
-      "CurrentLine": "Ligne actuelle"
-    },
-    "Timer": {
-      "SavedAgo": "Sauvegardé: {{timeAgo}}"
-    },
-    "formatDate": {
-      "JustNow": "à l'instant",
-      "15Seconds": "Il y a 15 secondes",
-      "25Seconds": "Il y a 25 secondes",
-      "35Seconds": "Il y a 35 secondes",
-      "Ago": "Il y a {{timeAgo}}"
-    },
-    "CopyableInput": {
-      "CopiedARIA": "Copié dans le presse-papiers!",
-      "OpenViewTabARIA": "Ouvrir la fenêtre {{label}} dans un nouvel onglet"
-    },
-    "EditableInput": {
-      "EditValue": "Modifier la valeur de {{display}}",
-      "EmptyPlaceholder": "Aucune valeur"
-    },
-    "PreviewNav": {
-      "EditSketchARIA": "Modifier le croquis",
-      "ByUser": "par"
-    },
-    "MobilePreferences": {
-      "Settings": "Paramètres",
-      "GeneralSettings": "Paramètres généraux",
-      "Accessibility": "Accessibilité",
-      "AccessibleOutput": "Sortie accessible",
-      "Theme": "Thème",
-      "LightTheme": "Clair",
-      "DarkTheme": "Sombre",
-      "HighContrastTheme": "Contraste élevé",
-      "Autosave": "Sauvegarde automatique",
-      "WordWrap": "Retour à la ligne automatique",
-      "LineNumbers": "Numéros de ligne",
-      "LintWarningSound": "Son d'alarme Lint",
-      "UsedScreenReader": "Utilisé avec un lecteur de texte",
-      "PlainText": "Text brut",
-      "TableText": "Tableau de texte",
-      "Sound": "Son"
-    },
-    "PreferenceCreators": {
-      "On": "Activé",
-      "Off": "Désactivé"
-    },
-    "MobileDashboardView": {
+      "Duplicate": "Dupliquer",
+      "Open": "Ouvrir",
+      "Download": "Télécharger",
+      "AddToCollection": "Ajouter à la collection",
       "Examples": "Exemples",
-      "Sketches": "Croquis",
-      "Collections": "Collections",
-      "Assets": "Ressources",
-      "MyStuff": "Mes trucs",
-      "CreateSketch": "Créer un croquis",
-      "CreateCollection": "Créer une collection"
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
-    "Explorer": {
-      "Files": "Fichiers"
+    "Edit": {
+      "Title": "Edition",
+      "TidyCode": "Nettoyer le code",
+      "Find": "Rechercher",
+      "FindNext": "Prochaine correspondance",
+      "Replace": "Remplacer"
     },
-    "TextArea": {
-      "CopyARIA": "Copy"
+    "Sketch": {
+      "Title": "Croquis",
+      "AddFile": "Nouveau fichier",
+      "AddFolder": "Nouveau dossier",
+      "Run": "Exécuter",
+      "Stop": "Arrêter"
+    },
+    "Help": {
+      "Title": "Aide",
+      "KeyboardShortcuts": "Raccourcis clavier",
+      "Reference": "Référence",
+      "About": "À propos",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
+    },
+    "Lang": "Langue",
+    "BackEditor": "Retour à l'éditeur",
+    "WarningUnsavedChanges": "Êtes-vous certain de vouloir quitter cette page? Vous avez des changements non enregistrés.",
+    "Login": "Se connecter",
+    "LoginOr": "ou",
+    "SignUp": "S'inscrire",
+    "Auth": {
+      "Welcome": "Bienvenue",
+      "Hello": "Bonjour",
+      "MyAccount": "compte",
+      "My": "Mon",
+      "MySketches": "Mes croquis",
+      "MyCollections": "Mes collections",
+      "Asset": "Ressources",
+      "MyAssets": "Mes ressources",
+      "LogOut": "Se déconnecter"
     }
+  },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
+  "CodemirrorFindAndReplace": {
+    "ToggleReplace": "Activer/désactiver le remplacement",
+    "Find": "Rechercher",
+    "FindPlaceholder": "Trouver dans les fichiers",
+    "Replace": "Remplacer",
+    "ReplaceAll": "Remplacer tout",
+    "ReplacePlaceholder": "Texte à remplacer",
+    "Regex": "Expression régulière",
+    "CaseSensitive": "Sensible à la casse",
+    "WholeWords": "Mots entiers",
+    "Previous": "Précédent",
+    "Next": "Suivant",
+    "NoResults": "Aucun résultat",
+    "Close": "Fermer"
+  },
+  "LoginForm": {
+    "UsernameOrEmail": "Courriel ou nom d'utilisateur",
+    "UsernameOrEmailARIA": "Courriel ou nom d'utilisateur",
+    "Password": "Mot de passe",
+    "PasswordARIA": "Mot de passe",
+    "Submit": "Se connecter",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
+  },
+  "LoginView": {
+    "Title": "Editeur web p5.js | Se connecter",
+    "Login": "Se connecter",
+    "LoginOr": "ou",
+    "SignUp": "S'enregistrer",
+    "Email": "courriel",
+    "Username": "Nom d'utilisateur",
+    "DontHaveAccount": "Vous n'avez pas encore de compte? ",
+    "ForgotPassword": "Mot de passe oublié? ",
+    "ResetPassword": "Réinitialiser son mot de passe"
+  },
+  "SocialAuthButton": {
+    "Connect": "Connecter au compte {{serviceauth}}",
+    "Unlink": "Se déconnecter du compte {{serviceauth}}",
+    "Login": "Se connecter via {{serviceauth}}",
+    "LogoARIA": "logo {{serviceauth}}"
+  },
+  "About": {
+    "Title": "À propos",
+    "TitleHelmet": "Éditeur web p5.js | À propos",
+    "Contribute": "Contribuer",
+    "NewP5": "Nouveau à p5.js?",
+    "Report": "Signaler un bogue",
+    "Learn": "Apprendre",
+    "Twitter": "Twitter",
+    "Home": "Accueil",
+    "Instagram": "Instagram",
+    "Discord": "Discord",
+    "WebEditor": "Éditeur web",
+    "Resources": "Ressources",
+    "Libraries": "Librairies",
+    "Forum": "Forum",
+    "Examples": "Exemples",
+    "PrivacyPolicy": "Politique de confidentialité",
+    "TermsOfUse": "Conditions d'utilisation",
+    "CodeOfConduct": "Code de conduite",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
+    },
+    "Contact": "Contact Us"
+  },
+  "Toast": {
+    "OpenedNewSketch": "Ouvrir un nouveau croquis.",
+    "SketchSaved": "Croquis sauvegardé.",
+    "SketchFailedSave": "Echec de la sauvegarde du croquis.",
+    "AutosaveEnabled": "Sauvegarde automatique activée.",
+    "LangChange": "Langue changée.",
+    "SettingsSaved": "Paramètres sauvegardés.",
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
+  },
+  "Toolbar": {
+    "Preview": "Aperçu",
+    "Auto-refresh": "Actualisation automatique",
+    "OpenPreferencesARIA": "Ouvrir les préférences",
+    "PlaySketchARIA": "Exécuter le croquis",
+    "PlayOnlyVisualSketchARIA": "Exécuter seulement le croquis visuel",
+    "StopSketchARIA": "Arrêter le croquis",
+    "EditSketchARIA": "Éditer le nom du croquis",
+    "NewSketchNameARIA": "Nouveau nom de croquis",
+    "By": " par ",
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
+  },
+  "Console": {
+    "Title": "Console",
+    "Clear": "Effacer",
+    "ClearARIA": "Effacer la console",
+    "Close": "Fermer",
+    "CloseARIA": "Fermer la console",
+    "Open": "Ouvrir",
+    "OpenARIA": "Ouvrir la console"
+  },
+  "Preferences": {
+    "Settings": "Paramètres",
+    "GeneralSettings": "Paramètres généraux",
+    "Accessibility": "Accessibilité",
+    "LibraryManagement": "Gestion de bibliothèque",
+    "Theme": "Thème",
+    "LightTheme": "Clair",
+    "LightThemeARIA": "Thème clair activé",
+    "DarkTheme": "Sombre",
+    "DarkThemeARIA": "Thème sombre activé",
+    "HighContrastTheme": "Contraste élevé",
+    "HighContrastThemeARIA": "Thème contraste élevé activé",
+    "TextSize": "Taille du texte",
+    "DecreaseFont": "Diminuer",
+    "DecreaseFontARIA": "diminuer la taille de la police",
+    "IncreaseFont": "Augmenter",
+    "IncreaseFontARIA": "augmenter la taille de la police",
+    "Autosave": "Sauvegarde automatique",
+    "On": "Activé",
+    "AutosaveOnARIA": "sauvegarde automatique activée",
+    "Off": "Désactivé",
+    "AutosaveOffARIA": "sauvegarde automatique désactivée",
+    "AutocloseBracketsQuotes": "Fermeture automatique des crochets et des guillemets",
+    "AutocloseBracketsQuotesOnARIA": "fermeture automatique des crochets et des guillemets activée",
+    "AutocloseBracketsQuotesOffARIA": "fermeture automatique des crochets et des guillemets désactivée",
+    "WordWrap": "Retour à la ligne automatique",
+    "WordWrapOnARIA": "retour à la ligne automatique activé",
+    "WordWrapOffARIA": "retour à la ligne automatique désactivé",
+    "LineNumbers": "Numéros de lignes",
+    "LineNumbersOnARIA": "numéros de lignes activés",
+    "LineNumbersOffARIA": "numéros de lignes désactivés",
+    "LintWarningSound": "Son d'alarme Lint",
+    "LintWarningOnARIA": "son d'alarme Lint activé",
+    "LintWarningOffARIA": "son d'alarme Lint désactivé",
+    "PreviewSound": "Tester le son",
+    "PreviewSoundARIA": "Tester le son",
+    "AccessibleTextBasedCanvas": "Canvas textuel accessible",
+    "UsedScreenReader": "Utilisé avec un lecteur de texte",
+    "PlainText": "Texte brut",
+    "TextOutputARIA": "sortie texte activée",
+    "TableText": "Tableau de texte",
+    "TableOutputARIA": "sortie tableau de texte activée",
+    "LibraryVersion": "Version de p5.js",
+    "LibraryVersionInfo": "Une [nouvelle version 2.0](https://github.com/processing/p5.js/releases/) de p5.js est disponible ! Elle deviendra la version par défaut en août 2026, alors profitez de ce temps pour la tester et signaler les bogues. Intéressé à migrer vos esquisses de 1.x vers 2.0 ? Consultez les [ressources de compatibilité et de transition.](https://github.com/processing/p5.js-compatibility)",
+    "SoundAddon": "p5.sound.js Add-on Bibliothèque",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on Bibliothèque — Préchargement",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on Bibliothèque — Formes",
+    "DataAddon": "p5.js 1.x Compatibility Add-on Bibliothèque — Structures de données",
+    "Sound": "Son",
+    "SoundOutputARIA": "sortie son activée",
+    "FontSize": "Font Size",
+    "SetFontSize": "set font size",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "AutocompleteHinterOnARIA": "autocomplete hinter on",
+    "AutocompleteHinterOffARIA": "autocomplete hinter off",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
+  },
+  "KeyboardShortcuts": {
+    "Title": " Raccourcis clavier",
+    "ShortcutsFollow": "Les raccourcis clavier de l'éditeur suivent",
+    "SublimeText": "les raccourcis de Sublime Text",
+    "CodeEditing": {
+      "Tidy": "Nettoyer",
+      "FindText": "Rechercher",
+      "FindNextMatch": "Correspondance suivante",
+      "FindPrevMatch": "Correspondance précédente",
+      "IndentCodeLeft": "Indenter le code à gauche",
+      "ReplaceTextMatch": "Remplacer la correspondance",
+      "IndentCodeRight": "Indenter le code à droite",
+      "CommentLine": "Ligne de commentaire",
+      "FindNextTextMatch": "Correspondance texte suivante",
+      "FindPreviousTextMatch": "Correspondance texte précédente",
+      "CodeEditing": "Édition de code",
+      "ColorPicker": "Show Inline Color Picker",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
+    },
+    "GeneralSelection": {
+      "StartSketch": "Exécuter le croquis",
+      "StopSketch": "Arrêter le croquis",
+      "TurnOnAccessibleOutput": "Activer la sortie accessible",
+      "TurnOffAccessibleOutput": "Désactiver la sortie accessible",
+      "Reference": "Go to Reference for Selected Item in Hinter"
+    },
+    "General": "General"
+  },
+  "Sidebar": {
+    "Title": "Fichiers croquis",
+    "ToggleARIA": "Alterner les options d'ouverture/fermeture du fichier croquis",
+    "AddFolder": "Créer un dossier",
+    "AddFolderARIA": "ajouter un dossier",
+    "AddFile": "Créer un fichier",
+    "AddFileARIA": "ajouter un fichier",
+    "UploadFile": "Téléverser un fichier",
+    "UploadFileARIA": "téléverser un fichier",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
+  },
+  "FileNode": {
+    "OpenFolderARIA": "Ouvrir le contenu du dossier",
+    "CloseFolderARIA": "Fermer le contenu du dossier",
+    "ToggleFileOptionsARIA": "Alterner l'ouverture/fermeture des options de fichiers",
+    "AddFolder": "Créer un dossier",
+    "AddFolderARIA": "ajouter un dossier",
+    "AddFile": "Créer un fichier",
+    "AddFileARIA": "ajouter un fichier",
+    "UploadFile": "Téléverser un fichier",
+    "UploadFileARIA": "téléverser un fichier",
+    "Rename": "Renommer",
+    "Delete": "Supprimer"
+  },
+  "Common": {
+    "SiteName": "Éditeur web p5.js",
+    "Error": "Erreur",
+    "ErrorARIA": "Erreur",
+    "Save": "Sauvegarder",
+    "p5logoARIA": "Logo p5.js",
+    "DeleteConfirmation": "Etes-vous sûr que vous voulez supprimer {{name}}?"
+  },
+  "IDEView": {
+    "SubmitFeedback": "Soumettre des commentaires",
+    "SubmitFeedbackARIA": "Soumettre des commentaires",
+    "AddCollectionTitle": "Ajouter à la collection",
+    "AddCollectionARIA": "Ajouter à la collection",
+    "ShareTitle": "Partager",
+    "ShareARIA": "partager"
+  },
+  "NewFileModal": {
+    "Title": "Créer un fichier",
+    "CloseButtonARIA": "Fermer la boîte de dialogue de création de fichier",
+    "EnterName": "Veuillez saisir un nom",
+    "InvalidType": "Type de fichier invalide. Les extensions valides sont .js, .css, .json, .txt, .csv, .tsv, .frag, and .vert."
+  },
+  "NewFileForm": {
+    "AddFileSubmit": "Ajouter un fichier",
+    "Placeholder": "Nom"
+  },
+  "NewFolderModal": {
+    "Title": "Créer un dossier",
+    "CloseButtonARIA": "Fermer la boîte de dialogue de création de dossier",
+    "EnterName": "Veuillez saisir un nom",
+    "EmptyName": "Le nom du dossier ne peut contenir uniquement des espaces",
+    "InvalidExtension": "Le nom du dossier ne peut contenir une extension"
+  },
+  "NewFolderForm": {
+    "AddFolderSubmit": "Ajouter un dossier",
+    "Placeholder": "Nom"
+  },
+  "ResetPasswordForm": {
+    "Email": "Courriel utilisé pour l'inscription",
+    "EmailARIA": "courriel",
+    "Submit": "Envoyer un courriel de réinitialisation du mot de passe"
+  },
+  "ResetPasswordView": {
+    "Title": "Éditeur web p5.js | Réinitialisation du mot de passe",
+    "Reset": "Réinitialiser votre mot de passe",
+    "Submitted": "Votre courriel de réinitialisation de mot de passe devrait arriver sous peu. Si vous ne le voyez pas, vérifiez\n            vos courriers indésirables, il est possible qu'il s'y retrouve.",
+    "Login": "Se connecter",
+    "LoginOr": "ou",
+    "SignUp": "S'enregistrer"
+  },
+  "ReduxFormUtils": {
+    "errorInvalidEmail": "Veuillez saisir une adresse courriel valide",
+    "errorEmptyEmail": "Veuillez saisir une adresse courriel",
+    "errorPasswordMismatch": "Les mots de passe doivent correspondre",
+    "errorEmptyPassword": "Veuillez saisir un mot de passe",
+    "errorShortPassword": "Le mot de passe doit comporter au moins 6 caractères",
+    "errorConfirmPassword": "Veuillez saisir une confirmation de mot de passe",
+    "errorNewPasswordRepeat": "Votre nouveau mot de passe doit être différent du mot de passe actuel.",
+    "errorNewPassword": "Veuillez saisir un nouveau mot de passe ou laisser le mot de passe actuel vide.",
+    "errorEmptyUsername": "Veuillez saisir un nom d'utilisateur.",
+    "errorLongUsername": "Le nom d'utilisateur doit comporter moins de 20 caractères.",
+    "errorValidUsername": "Le nom d'utilisateur ne peut qu'être composé de chiffres, de lettres, de points, de tirets et de traits de soulignement.",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
+  },
+  "NewPasswordView": {
+    "Title": "Éditeur Web p5.js | Nouveau mot de passe",
+    "Description": "Définir un nouveau mot de passe",
+    "TokenInvalidOrExpired": "Le jeton de réinitialisation du mot de passe n'est pas valide ou a expiré.",
+    "EmptyPassword": "Veuillez saisir un mot de passe",
+    "PasswordConfirmation": "Veuillez saisir une confirmation de mot de passe",
+    "PasswordMismatch": "les mots de passe doivent correspondre"
+  },
+  "AccountForm": {
+    "Email": "Courriel",
+    "EmailARIA": "courriel",
+    "Unconfirmed": "Non confirmé.",
+    "EmailSent": "Confirmation envoyée, vérifiez votre courriel.",
+    "Resend": "Renvoyer un courriel de confirmation",
+    "UserName": "Nom d'utilisateur",
+    "UserNameARIA": "Nom d'utilisateur",
+    "CurrentPassword": "Mot de passe actuel",
+    "CurrentPasswordARIA": "Mot de passe actuel",
+    "NewPassword": "Nouveau mot de passe",
+    "NewPasswordARIA": "Nouveau mot de passe",
+    "SubmitSaveAllSettings": "Sauvegarder tous les paramètres",
+    "SaveAccountDetails": "Save Account Details"
+  },
+  "AccountView": {
+    "SocialLogin": "Identification à l'aide des réseaux sociaux",
+    "SocialLoginDescription": "Utilisez votre compte GitHub ou Google pour vous connecter à l'éditeur Web p5.js.",
+    "Title": "Éditeur web p5.js | Paramètres du compte",
+    "Settings": "Paramètres du compte",
+    "AccountTab": "Compte",
+    "AccessTokensTab": "Jetons d'accès"
+  },
+  "APIKeyForm": {
+    "ConfirmDelete": "Êtes-vous sûr de vouloir supprimer {{key_label}}?",
+    "Summary": "Les jetons d'accès personnels agissent comme votre mot de passe\n          pour permettre aux scripts automatisés d'accéder à l'API de l'éditeur.\n          Créez un jeton pour chaque script nécessitant un accès.",
+    "CreateToken": "Créer un nouveau jeton",
+    "TokenLabel": "À quoi sert ce jeton?",
+    "TokenPlaceholder": "À quoi sert ce jeton ? p. ex. Exemple de script d'importation",
+    "CreateTokenSubmit": "Créer",
+    "NoTokens": "Vous n'avez pas de jetons existants.",
+    "NewTokenTitle": "Votre nouveau jeton d'accès",
+    "NewTokenInfo": "Assurez-vous de copier votre nouveau jeton d'accès personnel.\n                  Vous ne pourrez plus revenir le voir!",
+    "ExistingTokensTitle": "Jetons existants"
+  },
+  "APIKeyList": {
+    "Name": "Nom",
+    "Created": "Créée le",
+    "LastUsed": "Dernière utilisation",
+    "Actions": "Actions",
+    "Never": "Jamais",
+    "DeleteARIA": "Supprimer la clé API"
+  },
+  "NewPasswordForm": {
+    "Title": "Mot de passe",
+    "TitleARIA": "Mot de passe",
+    "ConfirmPassword": "Confirmer le mot de passe",
+    "ConfirmPasswordARIA": "Confirmer le mot de passe",
+    "SubmitSetNewPassword": "Définir un nouveau mot de passe"
+  },
+  "SignupForm": {
+    "Title": "Nom d'utilisateur",
+    "TitleARIA": "nom d'utilisateur",
+    "Email": "Courriel",
+    "EmailARIA": "courriel",
+    "Password": "Mot de passe",
+    "PasswordARIA": "mot de passe",
+    "ConfirmPassword": "Confirmer le mot de passe",
+    "ConfirmPasswordARIA": "Confirmer le mot de passe",
+    "SubmitSignup": "S'inscrire",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
+  },
+  "SignupView": {
+    "Title": "Éditeur web p5.js | S'inscrire",
+    "Description": "S'inscrire",
+    "Or": "Ou",
+    "AlreadyHave": "Vous avez déjà un compte?",
+    "Login": "Se connecter",
+    "Warning": "En vous inscrivant, vous acceptez les <0>Conditions d'utilisation</0> et la <1>Politique de confidentialité</1> de l'éditeur p5.js."
+  },
+  "EmailVerificationView": {
+    "Title": "Éditeur web p5.js | Vérification du courriel",
+    "Verify": "Vérifiez votre courriel",
+    "InvalidTokenNull": "Ce lien n'est pas valide.",
+    "Checking": "Validation du jeton, veuillez patienter...",
+    "Verified": "Ça y est, votre adresse courriel a été vérifiée.",
+    "InvalidState": "Le jeton est invalide ou expiré."
+  },
+  "AssetList": {
+    "Title": "Éditeur web p5.js | Mes ressources",
+    "ToggleOpenCloseARIA": "Activer/désactiver l'ouverture/fermeture des options ressources",
+    "Delete": "Supprimer",
+    "OpenNewTab": "Ouvrir dans un nouvel onglet",
+    "NoUploadedAssets": "Aucune ressource téléversée.",
+    "HeaderName": "Nom",
+    "HeaderSize": "Taille",
+    "HeaderSketch": "Croquis",
+    "maximum": "Maximum"
+  },
+  "Feedback": {
+    "Title": "Éditeur web p5.js | Commentaires",
+    "ViaGithubHeader": "Via Github Issues",
+    "ViaGithubDescription": "Si vous connaissez bien Github, c'est notre méthode préférée pour recevoir des rapports de bugs et des commentaires.",
+    "GoToGithub": "Aller à Github",
+    "ViaGoogleHeader": "Via Google Form",
+    "ViaGoogleDescription": "Vous pouvez également soumettre vos commentaires via ce formulaire.",
+    "GoToForm": "Aller au formulaire"
+  },
+  "Searchbar": {
+    "SearchSketch": "Chercher des croquis...",
+    "SearchCollection": "Chercher des collections...",
+    "ClearTerm": "effacer"
+  },
+  "UploadFileModal": {
+    "Title": "Téléverser un fichier",
+    "CloseButtonARIA": "Fermer la boîte de dialogue de téléversement de fichiers",
+    "SizeLimitError": "Erreur: Vous ne pouvez plus téléverser de fichiers. Vous avez atteint la limite de taille totale de {{sizeLimit}}.\n                If you would like to upload more, please remove the ones you aren't using anymore by\n                in your "
+  },
+  "FileUploader": {
+    "DictDefaultMessage": "Déposez des fichiers ici ou cliquez pour utiliser le navigateur de fichiers"
+  },
+  "ErrorModal": {
+    "MessageLogin": "Pour pouvoir sauvegarder les croquis, vous devez être connecté. Veuillez ",
+    "Login": "Se connecter",
+    "LoginOr": " ou ",
+    "SignUp": "S'enregistrer",
+    "MessageLoggedOut": "Il semble que vous ayez été déconnecté. Veuillez ",
+    "LogIn": "Se connecter",
+    "SavedDifferentWindow": "Le projet que vous avez tenté de sauvegarder a été sauvegardé à partir d'une\n        autre fenêtre. Veuillez rafraîchir la page pour voir la dernière version.",
+    "LinkTitle": "Erreur de liaison de compte",
+    "LinkMessage": "Il y a eu un problème pour relier votre compte {{serviceauth}} à votre compte éditeur web p5.js. Votre compte {{serviceauth}} a déjà été lié à un autre compte de éditeur Web p5.js."
+  },
+  "ShareModal": {
+    "Embed": "Intégrer",
+    "Present": "Présenter",
+    "Fullscreen": "Plein écran",
+    "Edit": "Éditer"
+  },
+  "CollectionView": {
+    "TitleCreate": "Créer une collection",
+    "TitleDefault": "collection"
+  },
+  "Collection": {
+    "Title": "Éditeur web p5.js | Mes collections",
+    "AnothersTitle": "Éditeur web p5.js | Collections de {{anotheruser}}",
+    "Share": "Partager",
+    "URLLink": "Lien vers la collection",
+    "AddSketch": "Ajouter un croquis",
+    "DeleteFromCollection": "Êtes-vous sûr de vouloir supprimer {{name_sketch}} de cette collection?",
+    "SketchDeleted": "Croquis supprimé",
+    "SketchRemoveARIA": "Supprimer le croquis de la collection",
+    "DescriptionPlaceholder": "Ajouter une description",
+    "Description": "description",
+    "NumSketches": "{{count}} croquis",
+    "NumSketches_plural": "{{count}} croquis",
+    "By": "Collection par ",
+    "NoSketches": "Aucun croquis dans la collection",
+    "TableSummary": "tableau contenant toutes les collections",
+    "HeaderName": "Nom",
+    "HeaderCreatedAt": "Date ajoutée",
+    "HeaderUser": "Propriétaire",
+    "DirectionAscendingARIA": "Ascendant",
+    "DirectionDescendingARIA": "Descendant",
+    "ButtonLabelAscendingARIA": "Trier par {{displayName}} ascendant.",
+    "ButtonLabelDescendingARIA": "Trier par {{displayName}} descendant.",
+    "RemoveFromCollection": "Remove from Collection"
+  },
+  "AddToCollectionList": {
+    "Title": "Éditeur web p5.js | Mes collections",
+    "AnothersTitle": "Éditeur web p5.js | Collections de {{anotheruser}}",
+    "Empty": "Aucune collection"
+  },
+  "CollectionCreate": {
+    "Title": "Éditeur web p5.js | Créer une collection",
+    "FormError": "Impossible de créer une collection",
+    "FormLabel": "Nom de la collection",
+    "FormLabelARIA": "nom",
+    "NameRequired": "Le nom de la collection est requis",
+    "Description": "Description (optionnel)",
+    "DescriptionARIA": "description",
+    "DescriptionPlaceholder": "Mes croquis préférés",
+    "SubmitCollectionCreate": "Créer la collection"
+  },
+  "DashboardView": {
+    "CreateCollection": "Créer une collection",
+    "NewSketch": "Nouveau croquis",
+    "CreateCollectionOverlay": "Créer une collection"
+  },
+  "DashboardTabSwitcher": {
+    "Sketches": "Croquis",
+    "Collections": "Collections",
+    "Assets": "Ressources"
+  },
+  "CollectionList": {
+    "Title": "Éditeur web p5.js | Mes collections",
+    "AnothersTitle": "Éditeur web p5.js | collections de {{anotheruser}}",
+    "NoCollections": "Aucune collection.",
+    "TableSummary": "tableau contenant toutes les collections",
+    "HeaderName": "Nom",
+    "HeaderCreatedAt": "Date de création",
+    "HeaderCreatedAt_mobile": "Créé",
+    "HeaderUpdatedAt": "Date de mise à jour",
+    "HeaderUpdatedAt_mobile": "Mise à jour",
+    "HeaderNumItems": "# croquis",
+    "HeaderNumItems_mobile": "# croquis",
+    "DirectionAscendingARIA": "Ascendant",
+    "DirectionDescendingARIA": "Descendant",
+    "ButtonLabelAscendingARIA": "Trier par {{displayName}} ascendant.",
+    "ButtonLabelDescendingARIA": "Trier par {{displayName}} descendant.",
+    "AddSketch": "Ajouter un croquis"
+  },
+  "CollectionListRow": {
+    "ToggleCollectionOptionsARIA": "Activer/désactiver l'ouverture/fermeture des options de collections",
+    "AddSketch": "Ajouter un croquis",
+    "Delete": "Supprimer",
+    "Rename": "Renommer"
+  },
+  "Overlay": {
+    "AriaLabel": "Fermer {{title}} superposé"
+  },
+  "QuickAddList": {
+    "ButtonRemoveARIA": "Supprimer de la collection",
+    "ButtonAddToCollectionARIA": "Ajouter à la collection",
+    "View": "Voir"
+  },
+  "Pagination": {
+    "Next": "Next",
+    "Previous": "Previous",
+    "Of": "of",
+    "PreviousPageARIA": "Previous Page",
+    "NextPageARIA": "Next Page"
+  },
+  "SketchList": {
+    "View": "Voir",
+    "Title": "Éditeur web p5.js | Mes croquis",
+    "AnothersTitle": "Éditeur web p5.js | Croquis de {{anotheruser}}",
+    "ToggleLabelARIA": "Activer/désactiver l'ouverture/fermeture des options de croquis",
+    "DropdownRename": "Renommer",
+    "DropdownDownload": "Télécharger",
+    "DropdownDuplicate": "Dupliquer",
+    "DropdownAddToCollection": "Ajouter à la collection",
+    "DropdownDelete": "Supprimer",
+    "DirectionAscendingARIA": "Ascendant",
+    "DirectionDescendingARIA": "Descendant",
+    "ButtonLabelAscendingARIA": "Trier par {{displayName}} ascendant.",
+    "ButtonLabelDescendingARIA": "Trier par {{displayName}} descendant.",
+    "AddToCollectionOverlayTitle": "Ajouter à la collection",
+    "TableSummary": "tableau contenant toutes projets sauvegardés",
+    "HeaderName": "Croquis",
+    "HeaderCreatedAt": "Date de création",
+    "HeaderCreatedAt_mobile": "Créé",
+    "HeaderUpdatedAt": "Date de mise à jour",
+    "HeaderUpdatedAt_mobile": "mise à jour",
+    "NoSketches": "Aucun croquis."
+  },
+  "AddToCollectionSketchList": {
+    "Title": "Éditeur web p5.js | Mes croquis",
+    "AnothersTitle": "Éditeur web p5.js | Croquis de {{anotheruser}}",
+    "NoCollections": "Aucune collection."
+  },
+  "Editor": {
+    "OpenSketchARIA": "Ouvrir la navigation dans les fichiers croquis",
+    "CloseSketchARIA": "Fermer la navigation dans les fichiers croquis",
+    "UnsavedChangesARIA": "Le croquis a des modifications non sauvegardées",
+    "KeyUpLineNumber": "ligne {{lineNumber}}"
+  },
+  "EditorAccessibility": {
+    "NoLintMessages": "Il n'y a pas de messages lint",
+    "CurrentLine": "Ligne actuelle"
+  },
+  "Timer": {
+    "SavedAgo": "Sauvegardé: {{timeAgo}}"
+  },
+  "formatDate": {
+    "JustNow": "à l'instant",
+    "15Seconds": "Il y a 15 secondes",
+    "25Seconds": "Il y a 25 secondes",
+    "35Seconds": "Il y a 35 secondes",
+    "Ago": "Il y a {{timeAgo}}"
+  },
+  "CopyableInput": {
+    "CopiedARIA": "Copié dans le presse-papiers!",
+    "OpenViewTabARIA": "Ouvrir la fenêtre {{label}} dans un nouvel onglet"
+  },
+  "EditableInput": {
+    "EditValue": "Modifier la valeur de {{display}}",
+    "EmptyPlaceholder": "Aucune valeur"
+  },
+  "PreviewNav": {
+    "EditSketchARIA": "Modifier le croquis",
+    "ByUser": "par"
+  },
+  "MobilePreferences": {
+    "Settings": "Paramètres",
+    "GeneralSettings": "Paramètres généraux",
+    "Accessibility": "Accessibilité",
+    "AccessibleOutput": "Sortie accessible",
+    "Theme": "Thème",
+    "LightTheme": "Clair",
+    "DarkTheme": "Sombre",
+    "HighContrastTheme": "Contraste élevé",
+    "Autosave": "Sauvegarde automatique",
+    "WordWrap": "Retour à la ligne automatique",
+    "LineNumbers": "Numéros de ligne",
+    "LintWarningSound": "Son d'alarme Lint",
+    "UsedScreenReader": "Utilisé avec un lecteur de texte",
+    "PlainText": "Text brut",
+    "TableText": "Tableau de texte",
+    "Sound": "Son",
+    "SelectLanguage": "Sélectionner la langue",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "Preferences": "Preferences",
+    "Language": "Language"
+  },
+  "PreferenceCreators": {
+    "On": "Activé",
+    "Off": "Désactivé"
+  },
+  "MobileDashboardView": {
+    "Examples": "Exemples",
+    "Sketches": "Croquis",
+    "Collections": "Collections",
+    "Assets": "Ressources",
+    "MyStuff": "Mes trucs",
+    "CreateSketch": "Créer un croquis",
+    "CreateCollection": "Créer une collection"
+  },
+  "Explorer": {
+    "Files": "Fichiers"
+  },
+  "TextArea": {
+    "CopyARIA": "Copy"
+  },
+  "Cookies": {
+    "Header": "Cookies",
+    "Body": "The p5.js Editor uses cookies. Some are essential to the website functionality and allow you to manage an account and preferences. Others are not essential—they are used for analytics and allow us to learn more about our community. <strong> We never sell this data or use it for advertising. </strong> You can decide which cookies you would like to allow, and learn more in our <0>Privacy Policy<0>.",
+    "AllowAll": "Allow All",
+    "AllowEssential": "Allow Essential"
+  },
+  "Legal": {
+    "PrivacyPolicy": "Privacy Policy",
+    "TermsOfUse": "Terms of Use",
+    "CodeOfConduct": "Code of Conduct"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
-  
+}

--- a/translations/locales/hi/translations.json
+++ b/translations/locales/hi/translations.json
@@ -1,445 +1,20 @@
 {
-    "Nav": {
-      "File": {
-        "Title": "फाइल",
-        "New": "नई",
-        "Share": "भेजें",
-        "Duplicate": "प्रतिलिपि बनाएँ",
-        "Open": "खोलें",
-        "Download": "डाउनलोड",
-        "AddToCollection": "संग्रह में जोड़ें",
-        "Examples": "उदाहरण"
-      },
-      "Edit": {
-        "Title": "संपादित करे",
-        "TidyCode": "कोड साफ़ करें",
-        "Find": "खोज",
-        "Replace": "बदली करें"
-      },
-      "Sketch": {
-        "Title": "चित्र",
-        "AddFile": "फाइल जोड़ें",
-        "AddFolder": "फोल्डर जोड़ें",
-        "Run": "चलाएं",
-        "Stop": "रोकें"
-      },
-     "Help": {
-      "Title": "मदद",
-      "KeyboardShortcuts": "कीबोर्ड शॉर्टकट",
-      "Reference": "रिफरेन्स",
-      "ReportBug": "बग रिपोर्ट करें",
-      "ChatOnDiscord": "डिस्कॉर्ड पर चैट करें",
-      "PostOnTheForum": "फ़ोरम पर पोस्ट करें"
-    },
-      "Lang": "भाषा",
-      "BackEditor": "एडिटर पर वापस जाएं",
-      "WarningUnsavedChanges": "क्या आप इस पेज को छोड़ना चाहते हैं? आपके पास अनसेव्ड परिवर्तन हैं।",
-      "Login": "लॉग इन",
-      "LoginOr": "या",
-      "SignUp": "साइन अप",
-      "Auth": {
-        "Welcome": "स्वागत है",
-        "Hello": "नमस्ते",
-        "MyAccount": "मेरा अकाउंट",
-        "My": "मेरा",
-        "MySketches": "मेरे स्केच",
-        "MyCollections": "मेरे संग्रह",
-        "Asset": "संपत्ति",
-        "MyAssets": "मेरी संपत्तियाँ",
-        "LogOut": "लॉग आउट"
-      }
-    },
-    "Banner": {
-      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
-    },
-    "CodemirrorFindAndReplace": {
-      "ToggleReplace": "टॉगल बदली करें",
-      "Find": "खोज",
-      "FindPlaceholder": "फ़ाइलों में खोजें",
-      "Replace": "बदली करें",
-      "ReplaceAll": "सबको बदली करें",
-      "ReplacePlaceholder": "बदलने के लिए पाठ",
-      "Regex": "रेगुलर एक्सप्रेशन",
-      "CaseSensitive": "केस सेंसिटिव",
-      "WholeWords": "संपूर्ण शब्द",
-      "Previous": "पिछला",
-      "Next": "अगला",
-      "NoResults": "कोई परिणाम नहीं",
-      "Close": "बंद करे"
-    },
-    "LoginForm": {
-      "UsernameOrEmail": "ईमेल या यूजरनेम",
-      "UsernameOrEmailARIA": "ईमेल या यूजरनेम",
-      "Password": "पासवर्ड",
-      "PasswordARIA": "पासवर्ड",
-      "Submit": "लॉग इन",
-        "Errors": {
-          "invalidCredentials": "अमान्य ईमेल या पासवर्ड।"
-        }
-    },
-    "LoginView": {
-      "Title": "p5.js वेब एडिटर | लॉग इन",
-      "Login": "लॉग इन",
-      "LoginOr": "या",
-      "SignUp": "साइन अप",
-      "Email": "ईमेल",
-      "Username": "यूजरनेम",
-      "DontHaveAccount": "अकाउंट नहीं है? ",
-      "ForgotPassword": "पासवर्ड भूल गए? ",
-      "ResetPassword": "पासवर्ड रीसेट करें"
-    },
-    "SocialAuthButton": {
-      "Connect": "कनेक्ट {{serviceauth}} अकाउंट",
-      "Unlink": "अनलिंक {{serviceauth}} अकाउंट",
-      "Login": "{{serviceauth}} से लोगिन करें",
-      "LogoARIA": "{{serviceauth}} प्रतीक चिन्ह"
-    },
-    "About": {
-      "Title": "के बारे में",
-      "TitleHelmet": "p5.js वेब एडिटर | के बारे में",
-      "Headline": "p5.js एडिटर के साथ p5.js स्केच बनाएं, शेयर करें और रीमिक्स करें।",
-      "IntroDescription1": "p5.js एक मुफ्त, ओपन-सोर्स जावास्क्रिप्ट लाइब्रेरी है जिससे कोडिंग सीखने और कला बनाने में मदद मिलती है। p5.js एडिटर का उपयोग करके, आप बिना कुछ भी डाउनलोड या कॉन्फ़िगर किए p5.js स्केच बना सकते हैं, शेयर कर सकते हैं और रीमिक्स कर सकते हैं।",
-      "IntroDescription2": "हमारा मानना है कि सॉफ़्टवेयर और इसे सीखने के उपकरण यथासंभव खुले और समावेशी होने चाहिए। आप प्रोसेसिंग फाउंडेशन को दान करके इस कार्य का समर्थन कर सकते हैं, जो संगठन p5.js का समर्थन करता है। आपका दान p5.js के लिए सॉफ़्टवेयर विकास, कोड उदाहरण और ट्यूटोरियल जैसे शिक्षा संसाधन, फेलोशिप और सामुदायिक कार्यक्रमों का समर्थन करता है।",
-      "Contribute": "योगदान",
-      "NewP5": "p5.js पर नये?",
-      "Report": "बग रिपोर्ट",
-      "Learn": "सीखें",
-      "WebEditor": "वेब संपादक",
-      "Resources": "साधन",
-      "Libraries": "लाइब्रेरीज़",
-      "Forum": "समूह",
-      "Examples": "उदाहरण",
-      "Home": "होम",
-      "Twitter": "ट्विटर",
-      "Instagram": "इंस्टाग्राम",
-      "Discord": "डिस्कॉर्ड",
-      "PrivacyPolicy": "गोपनीयता नीति",
-      "TermsOfUse": "उपयोग की शर्तें",
-      "CodeOfConduct": "आचार संहिता",
-      "DiscordCTA": "डिस्कॉर्ड से जुड़ें",
-      "ForumCTA": "समूह से जुड़ें",
-      "Socials": "सोशल मीडिया",
-      "Email": "ईमेल",
-      "Youtube": "यूट्यूब",
-      "Github": "गिटहब",
-      "Reference": "रेफरेंस",
-      "Donate": "दान करें",
-      "GetInvolved": "शामिल हों",
-      "X": "एक्स",
-      "LinkDescriptions": {
-        "Home": "p5.js और हमारे समुदाय के बारे में अधिक जानें।",
-        "Examples": "संक्षिप्त उदाहरणों के साथ p5.js की संभावनाओं का पता लगाएं।",
-        "CodeOfConduct": "हमारी सामुदायिक स्थिति और आचार संहिता पढ़ें।",
-        "Libraries": "समुदाय द्वारा बनाई गई लाइब्रेरीज़ के साथ p5.js की संभावनाओं का विस्तार करें।",
-        "Reference": "p5.js कोड के हर हिस्से के लिए आसान व्याख्याएं खोजें।",
-        "Donate": "प्रोसेसिंग फाउंडेशन को दान देकर इस काम का समर्थन करें।",
-        "Contribute": "गिटहब पर ओपन-सोर्स p5.js एडिटर में योगदान दें।",
-        "Report": "p5.js एडिटर के साथ टूटे या गलत व्यवहार की रिपोर्ट करें।",
-        "Forum": "समुदाय द्वारा बनाई गई लाइब्रेरीज़ के साथ p5.js की संभावनाओं का विस्तार करें।",
-        "Discord": "समुदाय द्वारा बनाई गई लाइब्रेरीज़ के साथ p5.js की संभावनाओं का विस्तार करें।"
-      }
-    },
-    "Toast": {
-      "OpenedNewSketch": "नया स्केच खोला",
-      "SketchSaved": "स्केच सेव किया",
-      "SketchFailedSave": "स्केच सेव करने में असमर्थ",
-      "AutosaveEnabled": "ऑटोसेव चालू",
-      "LangChange": "भाषा बदली",
-      "SettingsSaved": "सेटिंग्स सेव की",
-      "EmptyCurrentPass": "वर्तमान पासवर्ड फ़ील्ड खाली है",
-      "IncorrectCurrentPass": "वर्तमान पासवर्ड गलत है ",
-      "DefaultError":"कुछ गलत हो गया",
-      "UserNotFound": "उपयोगकर्ता नहीं मिला",
-      "NetworkError": "नेटवर्क त्रुटि",
-      "CloseAlertARIA": "Close Alert"
-    },
-    "Toolbar": {
-      "Preview": "पूर्वावलोकन",
-      "Auto-refresh": "ऑटो-रिफ़्रेश",
-      "OpenPreferencesARIA": "प्राथमिकताएँ खोलें",
-      "PlaySketchARIA": "स्केच चलाएं",
-      "PlayOnlyVisualSketchARIA": "केवल दृश्य स्केच चलाएं",
-      "StopSketchARIA": "स्केच बंद करे",
-      "EditSketchARIA": "स्केच का नाम संपादित करें",
-      "NewSketchNameARIA": "नया स्केच नाम",
-      "By": " द्वारा ",
-      "CustomLibraryVersion": "कस्टम p5.js संस्करण",
-      "VersionPickerARIA": "संस्करण चयनकर्ता",
-      "NewVersionPickerARIA": "संस्करण चयनकर्ता",
-      "SelectVersionARIA": "Select p5.js version"
-    },
-    "Console": {
-      "Title": "कंसोल",
-      "Clear": "साफ़ करें",
-      "ClearARIA": "कंसोल साफ़ करें",
-      "Close": "बंद करें",
-      "CloseARIA": "कंसोल बंद करें",
+  "Nav": {
+    "File": {
+      "Title": "फाइल",
+      "New": "नई",
+      "Share": "भेजें",
+      "Duplicate": "प्रतिलिपि बनाएँ",
       "Open": "खोलें",
-      "OpenARIA": "कंसोल खोलें"
-    },
-    "Preferences": {
-      "Settings": "सेटिंग्स",
-      "GeneralSettings": "सामान्य सेटिंग्स",
-      "Accessibility": "ऐक्सेसबिलिटी",
-      "LibraryManagement": "लाइब्रेरी प्रबंधन",
-      "Theme": "थीम",
-      "LightTheme": "लाइट",
-      "LightThemeARIA": "लाइट थीम चालू",
-      "DarkTheme": "डार्क",
-      "DarkThemeARIA": "डार्क थीम चालू",
-      "HighContrastTheme": "ज़्यादा कंट्रास्ट",
-      "HighContrastThemeARIA": "ज़्यादा कंट्रास्ट थीम चालू",
-      "TextSize": "शब्दों का साइज",
-      "DecreaseFont": "कम करें",
-      "DecreaseFontARIA": "फॉन्ट साइज़ कम करें",
-      "IncreaseFont": "बढ़ाएं",
-      "IncreaseFontARIA": "फॉन्ट साइज़ बढ़ाएं",
-      "FontSize": "फ़ॉन्ट आकार",
-      "SetFontSize": "फ़ॉन्ट आकार सेट करें",
-      "Autosave": "ऑटोसेव",
-      "On": "चालू",
-      "AutosaveOnARIA": "ऑटोसेव चालू",
-      "Off": "बंद",
-      "AutosaveOffARIA": "ऑटोसेव बंद",
-      "AutocloseBracketsQuotes": "ऑटोक्लोज ब्रैकिट और क्वोट",
-      "AutocloseBracketsQuotesOnARIA": "ऑटोक्लोज ब्रैकिट और क्वोट चालू",
-      "AutocloseBracketsQuotesOffARIA": "ऑटोक्लोज ब्रैकिट और क्वोट बंद",
-      "AutocompleteHinter": "ऑटोकम्प्लीट हिंटर",
-      "AutocompleteHinterOnARIA": "ऑटोकम्प्लीट हिंटर चालू",
-      "AutocompleteHinterOffARIA": "ऑटोकम्प्लीट हिंटर बंद",
-      "WordWrap": "वर्ड रैप",
-      "WordWrapOnARIA": "वर्डरैप चालू",
-      "WordWrapOffARIA": "वर्डरैप बंद",
-      "LineNumbers": "लाइन नम्बर्ज़",
-      "LineNumbersOnARIA": "लाइन नम्बर्ज़ चालू",
-      "LineNumbersOffARIA": "लाइन नम्बर्ज़ बंद",
-      "LintWarningSound": "लिन्ट वॉर्निंग साउन्ड",
-      "LintWarningOnARIA": "लिन्ट वॉर्निंग चालू",
-      "LintWarningOffARIA": "लिन्ट वॉर्निंग बंद",
-      "PreviewSound": "प्रीव्यू साउन्ड",
-      "PreviewSoundARIA": "प्रीव्यू साउन्ड",
-      "AccessibleTextBasedCanvas": "ऐक्सेसबल टेक्स्ट-आधारित कैन्वस",
-      "UsedScreenReader": "स्क्रीन रीडर के साथ उपयोग किया",
-      "PlainText": "प्लेन-टेक्स्ट",
-      "TextOutputARIA": "टेक्स्ट आउटपुट चालू",
-      "TableText": "टेबल-टेक्स्ट",
-      "TableOutputARIA": "टेबल आउटपुट चालू",
-      "LibraryVersion": "p5.js संस्करण",
-      "LibraryVersionInfo": "p5.js का एक [नया 2.0 संस्करण](https://github.com/processing/p5.js/releases/) उपलब्ध है! यह अगस्त 2026 में डिफ़ॉल्ट बन जाएगा, इसलिए इस समय का उपयोग इसे आज़माने और बग्स की रिपोर्ट करने के लिए करें। क्या आप 1.x से 2.0 में स्केच को स्थानांतरित करने में रुचि रखते हैं? [संगतता और स्थानांतरण संसाधनों](https://github.com/processing/p5.js-compatibility) को देखें।",
-      "SoundAddon": "p5.sound.js Add-on लाइब्रेरी",
-      "PreloadAddon": "p5.js 1.x Compatibility Add-on लाइब्रेरी — प्रीलोड",
-      "ShapesAddon": "p5.js 1.x Compatibility Add-on लाइब्रेरी — आकार",
-      "DataAddon": "p5.js 1.x Compatibility Add-on लाइब्रेरी — डेटा संरचनाएँ"
-    },
-    "KeyboardShortcuts": {
-      "Title": " कीबोर्ड शॉर्टकट",
-      "ShortcutsFollow": "कोड संपादन कीबोर्ड शॉर्टकट अनुसरण करते हैं",
-      "SublimeText": "सबलाइम टेक्स्ट शॉर्टकट",
-      "CodeEditing": {
-        "Tidy": "साफ",
-        "FindText": "शब्द ढूंढे",
-        "FindNextMatch": "अगला मिलान खोजें",
-        "FindPrevMatch": "पिछला मिलान ढूंढें",
-        "ReplaceTextMatch": "शब्द मिलान बदलें",
-        "IndentCodeLeft": "इंडेंट कोड लेफ्ट",
-        "IndentCodeRight": "इंडेंट कोड राइट",
-        "CommentLine": "टिप्पणी लाइन",
-        "FindNextTextMatch": "अगला शब्द मिलान खोजें",
-        "FindPreviousTextMatch": "पिछला शब्द मिलान खोजें",
-        "CodeEditing": "कोड संपादन",
-        "ColorPicker": "इनलाइन कलर पिकर दिखाएँ",
-        "CreateNewFile": "नया फ़ाइल बनाएँ"
-
-      },
-      "General": "सामान्य",
-      "GeneralSelection": {
-        "StartSketch": "स्केच शुरू करें",
-        "StopSketch": "स्केच रोकें",
-        "TurnOnAccessibleOutput": "सुलभ आउटपुट चालू करें",
-        "TurnOffAccessibleOutput": "सुलभ आउटपुट बंद करें",
-        "Reference": "हिंटर में चुने गए आइटम के लिए रेफरेंस जाएँ"
-      }
-    },
-    "Sidebar": {
-      "Title": "स्केच फ़ाइलें",
-      "ToggleARIA": "खुले / बंद स्केच विकल्प टॉगल करें",
-      "AddFolder": "फ़ोल्डर बनाएँ",
-      "AddFolderARIA": "फ़ोल्डर जोड़ें",
-      "AddFile": "फ़ाइल बनाएँ",
-      "AddFileARIA": "फ़ाइल जोड़ें",
-      "UploadFile": "फ़ाइल अपलोड करें",
-      "UploadFileARIA": "फ़ाइल अपलोड करें"
-    },
-    "FileNode": {
-      "OpenFolderARIA": "फ़ोल्डर सामग्री खोलें",
-      "CloseFolderARIA": "फ़ोल्डर सामग्री बंद करें",
-      "ToggleFileOptionsARIA": "खुले / बंद फ़ाइल विकल्प टॉगल करें",
-      "AddFolder": "फ़ोल्डर बनाएँ",
-      "AddFolderARIA": "फ़ोल्डर जोड़ें",
-      "AddFile": "फ़ाइल बनाएँ",
-      "AddFileARIA": "फ़ाइल जोड़ें",
-      "UploadFile": "फ़ाइल अपलोड करें",
-      "UploadFileARIA": "फ़ाइल अपलोड करें",
-      "Rename": "नाम बदलने",
-      "Delete": "मिटाना"
-    },
-    "Common": {
-      "SiteName": "p5.js वेब एडिटर",
-      "Error": "ग़लती",
-      "ErrorARIA": "ग़लती",
-      "Save": "सेव",
-      "p5logoARIA": "p5.js लोगो",
-      "DeleteConfirmation": "क्या आप पक्का {{name}} को डिलीट करना चाहते हैं?"
-    },
-    "IDEView": {
-      "SubmitFeedback": "प्रतिपुष्टि दें",
-      "SubmitFeedbackARIA": "प्रतिपुष्टि दें",
-      "AddCollectionTitle": "संग्रह में जोड़े",
-      "AddCollectionARIA":"संग्रह में जोड़े",
-      "ShareTitle": "शेयर",
-      "ShareARIA":"शेयर"
-    },
-    "NewFileModal": {
-      "Title": "फ़ाइल बनाएँ",
-      "CloseButtonARIA": "नई फ़ाइल मोडल बंद करें",
-      "EnterName": "कृपया एक नाम दर्ज करें",
-      "InvalidType": "अमान्य फ़ाइल प्रकार। मान्य एक्सटेंशन हैं .js, .css, .json, .xml, .stl, .txt, .csv, .tsv, .mtl, .frag, और .vert."
-    },
-    "NewFileForm": {
-      "AddFileSubmit": "फाइल जोडें",
-      "Placeholder": "नाम"
-    },
-    "NewFolderModal": {
-      "Title": "फोल्डर बनाएं",
-      "CloseButtonARIA": "नया फ़ोल्डर मोडल बंद करें",
-      "EnterName": "कृपया नाम दर्ज करें",
-      "EmptyName": "फ़ोल्डर नाम में केवल रिक्त स्थान नहीं हो सकते",
-      "InvalidExtension": "फ़ोल्डर नाम में एक्सटेंशन नहीं हो सकता"
-    },
-    "NewFolderForm": {
-      "AddFolderSubmit": "फोल्डर जोड़ें",
-      "Placeholder": "नाम"
-    },
-    "ResetPasswordForm": {
-      "Email": "रेजिस्ट्रेशन के लिए उपयोग किया गया ईमेल",
-      "EmailARIA": "ईमेल",
-      "Submit": "पासवर्ड रीसेट ईमेल भेजें"
-    },
-    "ResetPasswordView": {
-      "Title": "p5.js वेब एडिटर | रीसेट पासवर्ड",
-      "Reset": "अपना पासवर्ड रीसेट करें",
-      "Submitted": "आपका पासवर्ड रीसेट ईमेल शीघ्र ही आ जाना चाहिए। यदि ईमेल ना दिखे, तो अपने स्पैम फ़ोल्डर जांचें।",
-      "Login": "लॉग इन",
-      "LoginOr": "या",
-      "SignUp": "साइन अप"
-    },
-    "ReduxFormUtils": {
-      "errorInvalidEmail": "कृपया वैध ईमेल एड्रेस लिखें",
-      "errorEmptyEmail": "कृपया ईमेल एड्रेस लिखें",
-      "errorPasswordMismatch": "पासवर्डों को मेल खाना अनिवार्य है",
-      "errorEmptyPassword": "कृपया पासवर्ड लिखें",
-      "errorShortPassword": "पासवर्ड कम से कम ६ अक्षरों का होना चाहिए",
-      "errorConfirmPassword": "कृपया पासवर्ड कान्फर्मेशन दर्ज करें",
-      "errorNewPassword": "कृपया एक नया पासवर्ड दर्ज करें या वर्तमान पासवर्ड को खाली छोड़ दें।",
-      "errorEmptyUsername": "कृपया यूजरनेम लिखें",
-      "errorLongUsername": "यूजरनेम २० अक्षरों से कम होना चाहिए।",
-      "errorValidUsername": "यूजरनेम में केवल संख्या, अक्षर, पिरीअड्, डैश और अंडरस्कोर शामिल होना चाहिए।",
-      "errorNewPasswordRepeat":"नया पासवर्ड वर्तमान पासवर्ड से भिन्न होना चाहिए।."
-
-    },
-    "NewPasswordView": {
-      "Title": "p5.js वेब एडिटर | नया पासवर्ड",
-      "Description": "नया पासवर्ड सेट करें",
-      "TokenInvalidOrExpired":"पासवर्ड रीसेट टोकन अमान्य है या एक्सपायर हो गया है।",
-      "EmptyPassword": "कृपया पासवर्ड दर्ज करें",
-      "PasswordConfirmation": "कृपया पासवर्ड कान्फर्मेशन दर्ज करें",
-      "PasswordMismatch": "पासवर्डों को मेल खाना अनिवार्य है"
-    },
-    "AccountForm": {
-      "Email": "ईमेल",
-      "EmailARIA": "ईमेल",
-      "Unconfirmed": "कन्फर्म नहीं है",
-      "EmailSent": "कान्फर्मेशन भेज दिया, अपना ईमेल देखें",
-      "Resend": "कान्फर्मेशन ईमेल दोबारा भेजें",
-      "UserName": "यूजरनेम",
-      "UserNameARIA": "यूजरनेम",
-      "CurrentPassword": "वर्तमान पासवर्ड",
-      "CurrentPasswordARIA": "वर्तमान पासवर्ड",
-      "NewPassword": "नया पासवर्ड",
-      "NewPasswordARIA": "नया पासवर्ड",
-      "SaveAccountDetails": "खाता विवरण सहेजें"
-    },
-    "AccountView": {
-      "SocialLogin": "सामाजिक लॉग इन",
-      "SocialLoginDescription": "p5.js वेब संपादक में लॉग इन करने के लिए अपने GitHub या Google खाते का उपयोग करें।",
-      "Title": "p5.js वेब संपादक | खाता सेटिंग्स",
-      "Settings": "मेरा खाता",
-      "AccountTab": "खाता",
-      "AccessTokensTab": "टोकन का उपयोग"
-    },
-    "APIKeyForm": {
-      "ConfirmDelete": "क्या आप वाकई {{key_label}} को डिलीट करना चाहते हैं ?",
-      "Summary": "पर्सनल एक्सेस टोकन पासवर्ड की तरह काम करते हैं और ऑटोमेटिड स्क्रिप्ट को एडिटर API की अनुमति देते हैं।\n प्रत्येक स्क्रिप्ट जिसे एक्सेस की आवश्यकता है, उसके लिए एक टोकन बनाएं।",
-      "CreateToken": "नया टोकन बनाएं",
-      "TokenLabel": "यह टोकन किस लिए है?",
-      "TokenPlaceholder": "यह टोकन किस लिए है? उदाहरण इम्पोर्ट स्क्रिप्ट",
-      "CreateTokenSubmit": "बनाएँ",
-      "NoTokens": "आपके पास कोई मौजूदा टोकन नहीं है।",
-      "NewTokenTitle": "आपका नया एक्सेस टोकन",
-      "NewTokenInfo": "अपना नया पर्सनल एक्सेस टोकन कॉपी करना सुनिश्चित करें।\n आप इसे फिर से नहीं देख पाएंगे!",
-      "ExistingTokensTitle": "मौजूदा टोकन"
-    },
-    "APIKeyList": {
-      "Name": "नाम",
-      "Created": "बनाने की तारीख",
-      "LastUsed": "आखरी इस्तेमाल",
-      "Actions": "ऐक्शन्ज़",
-      "Never": "कभी नहीं",
-      "DeleteARIA": "डिलीट API Key"
-    },
-    "NewPasswordForm": {
-      "Title": "पासवर्ड",
-      "TitleARIA": "पासवर्ड",
-      "ConfirmPassword": "कन्फर्म पासवर्ड",
-      "ConfirmPasswordARIA": "कन्फर्म पासवर्ड",
-      "SubmitSetNewPassword": "नया पासवर्ड सेट करें"
-    },
-    "SignupForm": {
-      "Title": "यूजरनेम",
-      "TitleARIA": "यूजरनेम",
-      "Email": "ईमेल",
-      "EmailARIA": "ईमेल",
-      "Password": "पासवर्ड",
-      "PasswordARIA": "पासवर्ड",
-      "ConfirmPassword": "कन्फर्म पासवर्ड",
-      "ConfirmPasswordARIA": "कन्फर्म पासवर्ड",
-      "SubmitSignup": "साइन अप"
-    },
-    "SignupView": {
-      "Title": "p5.js वेब एडिटर | साइन अप",
-      "Description": "साइन अप",
-      "Or": "या",
-      "AlreadyHave": "पहले से ही अकाउंट है?",
-      "Login": "लॉग इन",
-      "Warning": "साइन अप करके, आप p5.js संपादक की उपयोग की <0>शर्तों</0> और <1>गोपनीयता नीति</1> से सहमत होते हैं।"
-    },
-    "EmailVerificationView": {
-      "Title": "p5.js वेब एडिटर | ईमेल वेरीफिकेशन",
-      "Verify": "अपना ईमेल व्हेरिफाय करें",
-      "InvalidTokenNull": "वह लिंक अमान्य है।",
-      "Checking": "टोकन की पुष्टि की जा रही है, कृपया प्रतीक्षा करें...",
-      "Verified": "सबकुछ ठीक है। आपके ईमेल का पुष्टीकरण हो चुका है।",
-      "InvalidState": "टोकन अमान्य है या समाप्त हो गया है।"
-    },
-    "AssetList": {
-      "Title": "p5.js वेब एडिटर | मेरे ऐसेट",
-      "ToggleOpenCloseARIA": "टॉगल ओपेन/क्लोज़ ऐसेट ऑप्शन्ज़",
-      "Delete": "डिलीट",
-      "OpenNewTab": "नये टैब में खोलें",
-      "NoUploadedAssets": "कोई ऐसेट अपलोड नही की।",
-      "HeaderName": "नाम",
-      "HeaderSize": "साइज़",
-      "HeaderSketch": "स्केच"
+      "Download": "डाउनलोड",
+      "AddToCollection": "संग्रह में जोड़ें",
+      "Examples": "उदाहरण",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "संपादित करे",
@@ -454,23 +29,476 @@
       "Run": "चलाएं",
       "Stop": "रोकें"
     },
-    
+    "Help": {
+      "Title": "मदद",
+      "KeyboardShortcuts": "कीबोर्ड शॉर्टकट",
+      "Reference": "रिफरेन्स",
+      "ReportBug": "बग रिपोर्ट करें",
+      "ChatOnDiscord": "डिस्कॉर्ड पर चैट करें",
+      "PostOnTheForum": "फ़ोरम पर पोस्ट करें"
+    },
+    "Lang": "भाषा",
     "BackEditor": "एडिटर पर वापस जाएं",
     "WarningUnsavedChanges": "क्या आप इस पेज को छोड़ना चाहते हैं? आपके पास अनसेव्ड परिवर्तन हैं।",
     "Login": "लॉग इन",
     "LoginOr": "या",
     "SignUp": "साइन अप",
     "Auth": {
+      "Welcome": "स्वागत है",
       "Hello": "नमस्ते",
       "MyAccount": "मेरा अकाउंट",
+      "My": "मेरा",
       "MySketches": "मेरे स्केच",
       "MyCollections": "मेरे संग्रह",
-      "MyAssets": "मेरे ऐसेट",
+      "Asset": "संपत्ति",
+      "MyAssets": "मेरी संपत्तियाँ",
       "LogOut": "लॉग आउट"
+    }
+  },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
+  "CodemirrorFindAndReplace": {
+    "ToggleReplace": "टॉगल बदली करें",
+    "Find": "खोज",
+    "FindPlaceholder": "फ़ाइलों में खोजें",
+    "Replace": "बदली करें",
+    "ReplaceAll": "सबको बदली करें",
+    "ReplacePlaceholder": "बदलने के लिए पाठ",
+    "Regex": "रेगुलर एक्सप्रेशन",
+    "CaseSensitive": "केस सेंसिटिव",
+    "WholeWords": "संपूर्ण शब्द",
+    "Previous": "पिछला",
+    "Next": "अगला",
+    "NoResults": "कोई परिणाम नहीं",
+    "Close": "बंद करे"
+  },
+  "LoginForm": {
+    "UsernameOrEmail": "ईमेल या यूजरनेम",
+    "UsernameOrEmailARIA": "ईमेल या यूजरनेम",
+    "Password": "पासवर्ड",
+    "PasswordARIA": "पासवर्ड",
+    "Submit": "लॉग इन",
+    "Errors": {
+      "invalidCredentials": "अमान्य ईमेल या पासवर्ड।"
     },
- 
-    "Feedback": {
-    "Title": "p5.js वेब एडिटर | फीडबैक"
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password"
+  },
+  "LoginView": {
+    "Title": "p5.js वेब एडिटर | लॉग इन",
+    "Login": "लॉग इन",
+    "LoginOr": "या",
+    "SignUp": "साइन अप",
+    "Email": "ईमेल",
+    "Username": "यूजरनेम",
+    "DontHaveAccount": "अकाउंट नहीं है? ",
+    "ForgotPassword": "पासवर्ड भूल गए? ",
+    "ResetPassword": "पासवर्ड रीसेट करें"
+  },
+  "SocialAuthButton": {
+    "Connect": "कनेक्ट {{serviceauth}} अकाउंट",
+    "Unlink": "अनलिंक {{serviceauth}} अकाउंट",
+    "Login": "{{serviceauth}} से लोगिन करें",
+    "LogoARIA": "{{serviceauth}} प्रतीक चिन्ह"
+  },
+  "About": {
+    "Title": "के बारे में",
+    "TitleHelmet": "p5.js वेब एडिटर | के बारे में",
+    "Headline": "p5.js एडिटर के साथ p5.js स्केच बनाएं, शेयर करें और रीमिक्स करें।",
+    "IntroDescription1": "p5.js एक मुफ्त, ओपन-सोर्स जावास्क्रिप्ट लाइब्रेरी है जिससे कोडिंग सीखने और कला बनाने में मदद मिलती है। p5.js एडिटर का उपयोग करके, आप बिना कुछ भी डाउनलोड या कॉन्फ़िगर किए p5.js स्केच बना सकते हैं, शेयर कर सकते हैं और रीमिक्स कर सकते हैं।",
+    "IntroDescription2": "हमारा मानना है कि सॉफ़्टवेयर और इसे सीखने के उपकरण यथासंभव खुले और समावेशी होने चाहिए। आप प्रोसेसिंग फाउंडेशन को दान करके इस कार्य का समर्थन कर सकते हैं, जो संगठन p5.js का समर्थन करता है। आपका दान p5.js के लिए सॉफ़्टवेयर विकास, कोड उदाहरण और ट्यूटोरियल जैसे शिक्षा संसाधन, फेलोशिप और सामुदायिक कार्यक्रमों का समर्थन करता है।",
+    "Contribute": "योगदान",
+    "NewP5": "p5.js पर नये?",
+    "Report": "बग रिपोर्ट",
+    "Learn": "सीखें",
+    "WebEditor": "वेब संपादक",
+    "Resources": "साधन",
+    "Libraries": "लाइब्रेरीज़",
+    "Forum": "समूह",
+    "Examples": "उदाहरण",
+    "Home": "होम",
+    "Twitter": "ट्विटर",
+    "Instagram": "इंस्टाग्राम",
+    "Discord": "डिस्कॉर्ड",
+    "PrivacyPolicy": "गोपनीयता नीति",
+    "TermsOfUse": "उपयोग की शर्तें",
+    "CodeOfConduct": "आचार संहिता",
+    "DiscordCTA": "डिस्कॉर्ड से जुड़ें",
+    "ForumCTA": "समूह से जुड़ें",
+    "Socials": "सोशल मीडिया",
+    "Email": "ईमेल",
+    "Youtube": "यूट्यूब",
+    "Github": "गिटहब",
+    "Reference": "रेफरेंस",
+    "Donate": "दान करें",
+    "GetInvolved": "शामिल हों",
+    "X": "एक्स",
+    "LinkDescriptions": {
+      "Home": "p5.js और हमारे समुदाय के बारे में अधिक जानें।",
+      "Examples": "संक्षिप्त उदाहरणों के साथ p5.js की संभावनाओं का पता लगाएं।",
+      "CodeOfConduct": "हमारी सामुदायिक स्थिति और आचार संहिता पढ़ें।",
+      "Libraries": "समुदाय द्वारा बनाई गई लाइब्रेरीज़ के साथ p5.js की संभावनाओं का विस्तार करें।",
+      "Reference": "p5.js कोड के हर हिस्से के लिए आसान व्याख्याएं खोजें।",
+      "Donate": "प्रोसेसिंग फाउंडेशन को दान देकर इस काम का समर्थन करें।",
+      "Contribute": "गिटहब पर ओपन-सोर्स p5.js एडिटर में योगदान दें।",
+      "Report": "p5.js एडिटर के साथ टूटे या गलत व्यवहार की रिपोर्ट करें।",
+      "Forum": "समुदाय द्वारा बनाई गई लाइब्रेरीज़ के साथ p5.js की संभावनाओं का विस्तार करें।",
+      "Discord": "समुदाय द्वारा बनाई गई लाइब्रेरीज़ के साथ p5.js की संभावनाओं का विस्तार करें।"
+    },
+    "EmailAddress": "hello@p5js.org",
+    "Contact": "Contact Us"
+  },
+  "Toast": {
+    "OpenedNewSketch": "नया स्केच खोला",
+    "SketchSaved": "स्केच सेव किया",
+    "SketchFailedSave": "स्केच सेव करने में असमर्थ",
+    "AutosaveEnabled": "ऑटोसेव चालू",
+    "LangChange": "भाषा बदली",
+    "SettingsSaved": "सेटिंग्स सेव की",
+    "EmptyCurrentPass": "वर्तमान पासवर्ड फ़ील्ड खाली है",
+    "IncorrectCurrentPass": "वर्तमान पासवर्ड गलत है ",
+    "DefaultError": "कुछ गलत हो गया",
+    "UserNotFound": "उपयोगकर्ता नहीं मिला",
+    "NetworkError": "नेटवर्क त्रुटि",
+    "CloseAlertARIA": "Close Alert"
+  },
+  "Toolbar": {
+    "Preview": "पूर्वावलोकन",
+    "Auto-refresh": "ऑटो-रिफ़्रेश",
+    "OpenPreferencesARIA": "प्राथमिकताएँ खोलें",
+    "PlaySketchARIA": "स्केच चलाएं",
+    "PlayOnlyVisualSketchARIA": "केवल दृश्य स्केच चलाएं",
+    "StopSketchARIA": "स्केच बंद करे",
+    "EditSketchARIA": "स्केच का नाम संपादित करें",
+    "NewSketchNameARIA": "नया स्केच नाम",
+    "By": " द्वारा ",
+    "CustomLibraryVersion": "कस्टम p5.js संस्करण",
+    "VersionPickerARIA": "संस्करण चयनकर्ता",
+    "NewVersionPickerARIA": "संस्करण चयनकर्ता",
+    "SelectVersionARIA": "Select p5.js version"
+  },
+  "Console": {
+    "Title": "कंसोल",
+    "Clear": "साफ़ करें",
+    "ClearARIA": "कंसोल साफ़ करें",
+    "Close": "बंद करें",
+    "CloseARIA": "कंसोल बंद करें",
+    "Open": "खोलें",
+    "OpenARIA": "कंसोल खोलें"
+  },
+  "Preferences": {
+    "Settings": "सेटिंग्स",
+    "GeneralSettings": "सामान्य सेटिंग्स",
+    "Accessibility": "ऐक्सेसबिलिटी",
+    "LibraryManagement": "लाइब्रेरी प्रबंधन",
+    "Theme": "थीम",
+    "LightTheme": "लाइट",
+    "LightThemeARIA": "लाइट थीम चालू",
+    "DarkTheme": "डार्क",
+    "DarkThemeARIA": "डार्क थीम चालू",
+    "HighContrastTheme": "ज़्यादा कंट्रास्ट",
+    "HighContrastThemeARIA": "ज़्यादा कंट्रास्ट थीम चालू",
+    "TextSize": "शब्दों का साइज",
+    "DecreaseFont": "कम करें",
+    "DecreaseFontARIA": "फॉन्ट साइज़ कम करें",
+    "IncreaseFont": "बढ़ाएं",
+    "IncreaseFontARIA": "फॉन्ट साइज़ बढ़ाएं",
+    "FontSize": "फ़ॉन्ट आकार",
+    "SetFontSize": "फ़ॉन्ट आकार सेट करें",
+    "Autosave": "ऑटोसेव",
+    "On": "चालू",
+    "AutosaveOnARIA": "ऑटोसेव चालू",
+    "Off": "बंद",
+    "AutosaveOffARIA": "ऑटोसेव बंद",
+    "AutocloseBracketsQuotes": "ऑटोक्लोज ब्रैकिट और क्वोट",
+    "AutocloseBracketsQuotesOnARIA": "ऑटोक्लोज ब्रैकिट और क्वोट चालू",
+    "AutocloseBracketsQuotesOffARIA": "ऑटोक्लोज ब्रैकिट और क्वोट बंद",
+    "AutocompleteHinter": "ऑटोकम्प्लीट हिंटर",
+    "AutocompleteHinterOnARIA": "ऑटोकम्प्लीट हिंटर चालू",
+    "AutocompleteHinterOffARIA": "ऑटोकम्प्लीट हिंटर बंद",
+    "WordWrap": "वर्ड रैप",
+    "WordWrapOnARIA": "वर्डरैप चालू",
+    "WordWrapOffARIA": "वर्डरैप बंद",
+    "LineNumbers": "लाइन नम्बर्ज़",
+    "LineNumbersOnARIA": "लाइन नम्बर्ज़ चालू",
+    "LineNumbersOffARIA": "लाइन नम्बर्ज़ बंद",
+    "LintWarningSound": "लिन्ट वॉर्निंग साउन्ड",
+    "LintWarningOnARIA": "लिन्ट वॉर्निंग चालू",
+    "LintWarningOffARIA": "लिन्ट वॉर्निंग बंद",
+    "PreviewSound": "प्रीव्यू साउन्ड",
+    "PreviewSoundARIA": "प्रीव्यू साउन्ड",
+    "AccessibleTextBasedCanvas": "ऐक्सेसबल टेक्स्ट-आधारित कैन्वस",
+    "UsedScreenReader": "स्क्रीन रीडर के साथ उपयोग किया",
+    "PlainText": "प्लेन-टेक्स्ट",
+    "TextOutputARIA": "टेक्स्ट आउटपुट चालू",
+    "TableText": "टेबल-टेक्स्ट",
+    "TableOutputARIA": "टेबल आउटपुट चालू",
+    "LibraryVersion": "p5.js संस्करण",
+    "LibraryVersionInfo": "p5.js का एक [नया 2.0 संस्करण](https://github.com/processing/p5.js/releases/) उपलब्ध है! यह अगस्त 2026 में डिफ़ॉल्ट बन जाएगा, इसलिए इस समय का उपयोग इसे आज़माने और बग्स की रिपोर्ट करने के लिए करें। क्या आप 1.x से 2.0 में स्केच को स्थानांतरित करने में रुचि रखते हैं? [संगतता और स्थानांतरण संसाधनों](https://github.com/processing/p5.js-compatibility) को देखें।",
+    "SoundAddon": "p5.sound.js Add-on लाइब्रेरी",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on लाइब्रेरी — प्रीलोड",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on लाइब्रेरी — आकार",
+    "DataAddon": "p5.js 1.x Compatibility Add-on लाइब्रेरी — डेटा संरचनाएँ",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
+  },
+  "KeyboardShortcuts": {
+    "Title": " कीबोर्ड शॉर्टकट",
+    "ShortcutsFollow": "कोड संपादन कीबोर्ड शॉर्टकट अनुसरण करते हैं",
+    "SublimeText": "सबलाइम टेक्स्ट शॉर्टकट",
+    "CodeEditing": {
+      "Tidy": "साफ",
+      "FindText": "शब्द ढूंढे",
+      "FindNextMatch": "अगला मिलान खोजें",
+      "FindPrevMatch": "पिछला मिलान ढूंढें",
+      "ReplaceTextMatch": "शब्द मिलान बदलें",
+      "IndentCodeLeft": "इंडेंट कोड लेफ्ट",
+      "IndentCodeRight": "इंडेंट कोड राइट",
+      "CommentLine": "टिप्पणी लाइन",
+      "FindNextTextMatch": "अगला शब्द मिलान खोजें",
+      "FindPreviousTextMatch": "पिछला शब्द मिलान खोजें",
+      "CodeEditing": "कोड संपादन",
+      "ColorPicker": "इनलाइन कलर पिकर दिखाएँ",
+      "CreateNewFile": "नया फ़ाइल बनाएँ",
+      "RenameVariable": "Rename Variable"
+    },
+    "General": "सामान्य",
+    "GeneralSelection": {
+      "StartSketch": "स्केच शुरू करें",
+      "StopSketch": "स्केच रोकें",
+      "TurnOnAccessibleOutput": "सुलभ आउटपुट चालू करें",
+      "TurnOffAccessibleOutput": "सुलभ आउटपुट बंद करें",
+      "Reference": "हिंटर में चुने गए आइटम के लिए रेफरेंस जाएँ"
+    }
+  },
+  "Sidebar": {
+    "Title": "स्केच फ़ाइलें",
+    "ToggleARIA": "खुले / बंद स्केच विकल्प टॉगल करें",
+    "AddFolder": "फ़ोल्डर बनाएँ",
+    "AddFolderARIA": "फ़ोल्डर जोड़ें",
+    "AddFile": "फ़ाइल बनाएँ",
+    "AddFileARIA": "फ़ाइल जोड़ें",
+    "UploadFile": "फ़ाइल अपलोड करें",
+    "UploadFileARIA": "फ़ाइल अपलोड करें",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
+  },
+  "FileNode": {
+    "OpenFolderARIA": "फ़ोल्डर सामग्री खोलें",
+    "CloseFolderARIA": "फ़ोल्डर सामग्री बंद करें",
+    "ToggleFileOptionsARIA": "खुले / बंद फ़ाइल विकल्प टॉगल करें",
+    "AddFolder": "फ़ोल्डर बनाएँ",
+    "AddFolderARIA": "फ़ोल्डर जोड़ें",
+    "AddFile": "फ़ाइल बनाएँ",
+    "AddFileARIA": "फ़ाइल जोड़ें",
+    "UploadFile": "फ़ाइल अपलोड करें",
+    "UploadFileARIA": "फ़ाइल अपलोड करें",
+    "Rename": "नाम बदलने",
+    "Delete": "मिटाना"
+  },
+  "Common": {
+    "SiteName": "p5.js वेब एडिटर",
+    "Error": "ग़लती",
+    "ErrorARIA": "ग़लती",
+    "Save": "सेव",
+    "p5logoARIA": "p5.js लोगो",
+    "DeleteConfirmation": "क्या आप पक्का {{name}} को डिलीट करना चाहते हैं?"
+  },
+  "IDEView": {
+    "SubmitFeedback": "प्रतिपुष्टि दें",
+    "SubmitFeedbackARIA": "प्रतिपुष्टि दें",
+    "AddCollectionTitle": "संग्रह में जोड़े",
+    "AddCollectionARIA": "संग्रह में जोड़े",
+    "ShareTitle": "शेयर",
+    "ShareARIA": "शेयर"
+  },
+  "NewFileModal": {
+    "Title": "फ़ाइल बनाएँ",
+    "CloseButtonARIA": "नई फ़ाइल मोडल बंद करें",
+    "EnterName": "कृपया एक नाम दर्ज करें",
+    "InvalidType": "अमान्य फ़ाइल प्रकार। मान्य एक्सटेंशन हैं .js, .css, .json, .xml, .stl, .txt, .csv, .tsv, .mtl, .frag, और .vert."
+  },
+  "NewFileForm": {
+    "AddFileSubmit": "फाइल जोडें",
+    "Placeholder": "नाम"
+  },
+  "NewFolderModal": {
+    "Title": "फोल्डर बनाएं",
+    "CloseButtonARIA": "नया फ़ोल्डर मोडल बंद करें",
+    "EnterName": "कृपया नाम दर्ज करें",
+    "EmptyName": "फ़ोल्डर नाम में केवल रिक्त स्थान नहीं हो सकते",
+    "InvalidExtension": "फ़ोल्डर नाम में एक्सटेंशन नहीं हो सकता"
+  },
+  "NewFolderForm": {
+    "AddFolderSubmit": "फोल्डर जोड़ें",
+    "Placeholder": "नाम"
+  },
+  "ResetPasswordForm": {
+    "Email": "रेजिस्ट्रेशन के लिए उपयोग किया गया ईमेल",
+    "EmailARIA": "ईमेल",
+    "Submit": "पासवर्ड रीसेट ईमेल भेजें"
+  },
+  "ResetPasswordView": {
+    "Title": "p5.js वेब एडिटर | रीसेट पासवर्ड",
+    "Reset": "अपना पासवर्ड रीसेट करें",
+    "Submitted": "आपका पासवर्ड रीसेट ईमेल शीघ्र ही आ जाना चाहिए। यदि ईमेल ना दिखे, तो अपने स्पैम फ़ोल्डर जांचें।",
+    "Login": "लॉग इन",
+    "LoginOr": "या",
+    "SignUp": "साइन अप"
+  },
+  "ReduxFormUtils": {
+    "errorInvalidEmail": "कृपया वैध ईमेल एड्रेस लिखें",
+    "errorEmptyEmail": "कृपया ईमेल एड्रेस लिखें",
+    "errorPasswordMismatch": "पासवर्डों को मेल खाना अनिवार्य है",
+    "errorEmptyPassword": "कृपया पासवर्ड लिखें",
+    "errorShortPassword": "पासवर्ड कम से कम ६ अक्षरों का होना चाहिए",
+    "errorConfirmPassword": "कृपया पासवर्ड कान्फर्मेशन दर्ज करें",
+    "errorNewPassword": "कृपया एक नया पासवर्ड दर्ज करें या वर्तमान पासवर्ड को खाली छोड़ दें।",
+    "errorEmptyUsername": "कृपया यूजरनेम लिखें",
+    "errorLongUsername": "यूजरनेम २० अक्षरों से कम होना चाहिए।",
+    "errorValidUsername": "यूजरनेम में केवल संख्या, अक्षर, पिरीअड्, डैश और अंडरस्कोर शामिल होना चाहिए।",
+    "errorNewPasswordRepeat": "नया पासवर्ड वर्तमान पासवर्ड से भिन्न होना चाहिए।.",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
+  },
+  "NewPasswordView": {
+    "Title": "p5.js वेब एडिटर | नया पासवर्ड",
+    "Description": "नया पासवर्ड सेट करें",
+    "TokenInvalidOrExpired": "पासवर्ड रीसेट टोकन अमान्य है या एक्सपायर हो गया है।",
+    "EmptyPassword": "कृपया पासवर्ड दर्ज करें",
+    "PasswordConfirmation": "कृपया पासवर्ड कान्फर्मेशन दर्ज करें",
+    "PasswordMismatch": "पासवर्डों को मेल खाना अनिवार्य है"
+  },
+  "AccountForm": {
+    "Email": "ईमेल",
+    "EmailARIA": "ईमेल",
+    "Unconfirmed": "कन्फर्म नहीं है",
+    "EmailSent": "कान्फर्मेशन भेज दिया, अपना ईमेल देखें",
+    "Resend": "कान्फर्मेशन ईमेल दोबारा भेजें",
+    "UserName": "यूजरनेम",
+    "UserNameARIA": "यूजरनेम",
+    "CurrentPassword": "वर्तमान पासवर्ड",
+    "CurrentPasswordARIA": "वर्तमान पासवर्ड",
+    "NewPassword": "नया पासवर्ड",
+    "NewPasswordARIA": "नया पासवर्ड",
+    "SaveAccountDetails": "खाता विवरण सहेजें"
+  },
+  "AccountView": {
+    "SocialLogin": "सामाजिक लॉग इन",
+    "SocialLoginDescription": "p5.js वेब संपादक में लॉग इन करने के लिए अपने GitHub या Google खाते का उपयोग करें।",
+    "Title": "p5.js वेब संपादक | खाता सेटिंग्स",
+    "Settings": "मेरा खाता",
+    "AccountTab": "खाता",
+    "AccessTokensTab": "टोकन का उपयोग"
+  },
+  "APIKeyForm": {
+    "ConfirmDelete": "क्या आप वाकई {{key_label}} को डिलीट करना चाहते हैं ?",
+    "Summary": "पर्सनल एक्सेस टोकन पासवर्ड की तरह काम करते हैं और ऑटोमेटिड स्क्रिप्ट को एडिटर API की अनुमति देते हैं।\n प्रत्येक स्क्रिप्ट जिसे एक्सेस की आवश्यकता है, उसके लिए एक टोकन बनाएं।",
+    "CreateToken": "नया टोकन बनाएं",
+    "TokenLabel": "यह टोकन किस लिए है?",
+    "TokenPlaceholder": "यह टोकन किस लिए है? उदाहरण इम्पोर्ट स्क्रिप्ट",
+    "CreateTokenSubmit": "बनाएँ",
+    "NoTokens": "आपके पास कोई मौजूदा टोकन नहीं है।",
+    "NewTokenTitle": "आपका नया एक्सेस टोकन",
+    "NewTokenInfo": "अपना नया पर्सनल एक्सेस टोकन कॉपी करना सुनिश्चित करें।\n आप इसे फिर से नहीं देख पाएंगे!",
+    "ExistingTokensTitle": "मौजूदा टोकन"
+  },
+  "APIKeyList": {
+    "Name": "नाम",
+    "Created": "बनाने की तारीख",
+    "LastUsed": "आखरी इस्तेमाल",
+    "Actions": "ऐक्शन्ज़",
+    "Never": "कभी नहीं",
+    "DeleteARIA": "डिलीट API Key"
+  },
+  "NewPasswordForm": {
+    "Title": "पासवर्ड",
+    "TitleARIA": "पासवर्ड",
+    "ConfirmPassword": "कन्फर्म पासवर्ड",
+    "ConfirmPasswordARIA": "कन्फर्म पासवर्ड",
+    "SubmitSetNewPassword": "नया पासवर्ड सेट करें"
+  },
+  "SignupForm": {
+    "Title": "यूजरनेम",
+    "TitleARIA": "यूजरनेम",
+    "Email": "ईमेल",
+    "EmailARIA": "ईमेल",
+    "Password": "पासवर्ड",
+    "PasswordARIA": "पासवर्ड",
+    "ConfirmPassword": "कन्फर्म पासवर्ड",
+    "ConfirmPasswordARIA": "कन्फर्म पासवर्ड",
+    "SubmitSignup": "साइन अप",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
+  },
+  "SignupView": {
+    "Title": "p5.js वेब एडिटर | साइन अप",
+    "Description": "साइन अप",
+    "Or": "या",
+    "AlreadyHave": "पहले से ही अकाउंट है?",
+    "Login": "लॉग इन",
+    "Warning": "साइन अप करके, आप p5.js संपादक की उपयोग की <0>शर्तों</0> और <1>गोपनीयता नीति</1> से सहमत होते हैं।"
+  },
+  "EmailVerificationView": {
+    "Title": "p5.js वेब एडिटर | ईमेल वेरीफिकेशन",
+    "Verify": "अपना ईमेल व्हेरिफाय करें",
+    "InvalidTokenNull": "वह लिंक अमान्य है।",
+    "Checking": "टोकन की पुष्टि की जा रही है, कृपया प्रतीक्षा करें...",
+    "Verified": "सबकुछ ठीक है। आपके ईमेल का पुष्टीकरण हो चुका है।",
+    "InvalidState": "टोकन अमान्य है या समाप्त हो गया है।"
+  },
+  "AssetList": {
+    "Title": "p5.js वेब एडिटर | मेरे ऐसेट",
+    "ToggleOpenCloseARIA": "टॉगल ओपेन/क्लोज़ ऐसेट ऑप्शन्ज़",
+    "Delete": "डिलीट",
+    "OpenNewTab": "नये टैब में खोलें",
+    "NoUploadedAssets": "कोई ऐसेट अपलोड नही की।",
+    "HeaderName": "नाम",
+    "HeaderSize": "साइज़",
+    "HeaderSketch": "स्केच",
+    "maximum": "Maximum"
+  },
+  "Edit": {
+    "Title": "संपादित करे",
+    "TidyCode": "कोड साफ़ करें",
+    "Find": "खोज",
+    "Replace": "बदली करें"
+  },
+  "Sketch": {
+    "Title": "चित्र",
+    "AddFile": "फाइल जोड़ें",
+    "AddFolder": "फोल्डर जोड़ें",
+    "Run": "चलाएं",
+    "Stop": "रोकें"
+  },
+  "BackEditor": "एडिटर पर वापस जाएं",
+  "WarningUnsavedChanges": "क्या आप इस पेज को छोड़ना चाहते हैं? आपके पास अनसेव्ड परिवर्तन हैं।",
+  "Login": "लॉग इन",
+  "LoginOr": "या",
+  "SignUp": "साइन अप",
+  "Auth": {
+    "Hello": "नमस्ते",
+    "MyAccount": "मेरा अकाउंट",
+    "MySketches": "मेरे स्केच",
+    "MyCollections": "मेरे संग्रह",
+    "MyAssets": "मेरे ऐसेट",
+    "LogOut": "लॉग आउट"
+  },
+  "Feedback": {
+    "Title": "p5.js वेब एडिटर | फीडबैक",
+    "ViaGithubHeader": "Via Github Issues",
+    "ViaGithubDescription": "If you're familiar with Github, this is our preferred method for receiving bug reports and feedback.",
+    "GoToGithub": "Go to Github",
+    "ViaGoogleHeader": "Via Google Form",
+    "ViaGoogleDescription": "You can also submit this quick form.",
+    "GoToForm": "Go to Form"
   },
   "Searchbar": {
     "SearchSketch": "सर्च स्केच...",
@@ -522,11 +550,15 @@
     "DirectionAscendingARIA": "आरोही",
     "DirectionDescendingARIA": "अवरोही",
     "ButtonLabelAscendingARIA": "{{displayName}} आरोही क्रम में।",
-    "ButtonLabelDescendingARIA": "{{displayName}} अवरोही क्रम में।"
+    "ButtonLabelDescendingARIA": "{{displayName}} अवरोही क्रम में।",
+    "RemoveFromCollection": "Remove from Collection",
+    "Description": "description",
+    "NumSketches_plural": "{{count}} sketches"
   },
   "AddToCollectionList": {
     "Title": "p5.js वेब एडिटर | मेरे संग्रह",
-    "Empty": "कोई संग्रह नहीं"
+    "Empty": "कोई संग्रह नहीं",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s collections"
   },
   "CollectionCreate": {
     "Title": "p5.js वेब एडिटर | संग्रह बनाएँ",
@@ -562,7 +594,10 @@
     "DirectionDescendingARIA": "अवरोही",
     "ButtonLabelAscendingARIA": "{{displayName}} आरोही क्रम में।",
     "ButtonLabelDescendingARIA": "{{displayName}} अवरोही क्रम में।",
-    "AddSketch": "स्केच जोड़ें"
+    "AddSketch": "स्केच जोड़ें",
+    "HeaderCreatedAt_mobile": "Created",
+    "HeaderUpdatedAt_mobile": "Updated",
+    "HeaderNumItems_mobile": "# sketches"
   },
   "CollectionListRow": {
     "ToggleCollectionOptionsARIA": "संग्रह ओपेन/क्लोज़ टॉगल ऑप्शन्ज़",
@@ -603,11 +638,15 @@
     "HeaderName": "स्केच",
     "HeaderCreatedAt": "बनाने की तारीख",
     "HeaderUpdatedAt": "अपडेट करने की तारिख",
-    "NoSketches": "कोई स्केच नहीं"
+    "NoSketches": "कोई स्केच नहीं",
+    "View": "View",
+    "HeaderCreatedAt_mobile": "Created",
+    "HeaderUpdatedAt_mobile": "Updated"
   },
   "AddToCollectionSketchList": {
     "Title": "p5.js वेब एडिटर | मेरे स्केच",
-    "NoCollections": "कोई संग्रह नहीं"
+    "NoCollections": "कोई संग्रह नहीं",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s sketches"
   },
   "Editor": {
     "OpenSketchARIA": "स्केच फ़ाइलों का नेविगेशन खोलें",
@@ -630,7 +669,8 @@
     "Ago": "{{timeAgo}} पहले"
   },
   "CopyableInput": {
-    "CopiedARIA": "क्लिपबोर्ड पर कॉपी किया!"
+    "CopiedARIA": "क्लिपबोर्ड पर कॉपी किया!",
+    "OpenViewTabARIA": "Open {{label}} view in new tab"
   },
   "EditableInput": {
     "EditValue": "एडीट {{display}} वैल्यू",
@@ -643,7 +683,24 @@
   "MobilePreferences": {
     "Settings": "सेटिंग्स",
     "Preferences": "प्राथमिकताएँ",
-    "Language": "भाषा"
+    "Language": "भाषा",
+    "SelectLanguage": "भाषा चुनें",
+    "GeneralSettings": "General settings",
+    "Accessibility": "Accessibility",
+    "AccessibleOutput": "Accessible Output",
+    "Theme": "Theme",
+    "LightTheme": "Light",
+    "DarkTheme": "Dark",
+    "HighContrastTheme": "High Contrast",
+    "Autosave": "Autosave",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "WordWrap": "Word Wrap",
+    "LineNumbers": "Line numbers",
+    "LintWarningSound": "Lint warning sound",
+    "UsedScreenReader": "Used with screen reader",
+    "PlainText": "Plain-text",
+    "TableText": "Table-text",
+    "Sound": "Sound"
   },
   "PreferenceCreators": {
     "On": "ऑन",
@@ -677,5 +734,21 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "CollectionView": {
+    "TitleCreate": "Create collection",
+    "TitleDefault": "collection"
+  },
+  "MobileDashboardView": {
+    "Examples": "Examples",
+    "Sketches": "Sketches",
+    "Collections": "Collections",
+    "Assets": "Assets",
+    "MyStuff": "मेरी सामग्री",
+    "CreateSketch": "Create Sketch",
+    "CreateCollection": "Create Collection"
+  },
+  "Explorer": {
+    "Files": "Files"
   }
 }

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -8,7 +8,13 @@
       "Open": "Apri",
       "Download": "Scarica",
       "AddToCollection": "Aggiungi a Collezione",
-      "Examples": "Esempi"
+      "Examples": "Esempi",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "Modifica",
@@ -27,7 +33,10 @@
       "Title": "Aiuto",
       "KeyboardShortcuts": "Scorciatoie tastiera",
       "Reference": "Riferimenti",
-      "About": "Informazioni"
+      "About": "Informazioni",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
     "Lang": "Lingua",
     "BackEditor": "Torna a Editor",
@@ -70,7 +79,12 @@
     "UsernameOrEmailARIA": "Email o Nome utente",
     "Password": "Password",
     "PasswordARIA": "Password",
-    "Submit": "Accedi"
+    "Submit": "Accedi",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
   },
   "LoginView": {
     "Title": "p5.js redattore web | Accesso",
@@ -107,7 +121,34 @@
     "Examples": "Esempi",
     "PrivacyPolicy": "Privacy Policy",
     "TermsOfUse": "Termini di utilizzo",
-    "CodeOfConduct": "Codice di comportamento"
+    "CodeOfConduct": "Codice di comportamento",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
+    },
+    "Contact": "Contact Us"
   },
   "Toast": {
     "OpenedNewSketch": "Aperto nuovo sketch.",
@@ -116,7 +157,12 @@
     "AutosaveEnabled": "Auto-salvataggio abilitato.",
     "LangChange": "Lingua cambiata",
     "SettingsSaved": "Impostazioni salvate.",
-    "CloseAlertARIA": "Close Alert"
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
   },
   "Toolbar": {
     "Preview": "Anteprima",
@@ -128,7 +174,10 @@
     "EditSketchARIA": "Modifica nome sketch",
     "NewSketchNameARIA": "Nome nuovo sketch",
     "By": " da ",
-    "SelectVersionARIA": "Select p5.js version"
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
   },
   "Console": {
     "Title": "Terminale",
@@ -188,7 +237,18 @@
     "SoundAddon": "p5.sound.js Add-on",
     "PreloadAddon": "p5.js 1.x Compatibility Add-on Library — Precaricamento",
     "ShapesAddon": "p5.js 1.x Compatibility Add-on Library — Forme",
-    "DataAddon": "p5.js 1.x Compatibility Add-on Library — Strutture di dati"
+    "DataAddon": "p5.js 1.x Compatibility Add-on Library — Strutture di dati",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "AutocompleteHinterOnARIA": "autocomplete hinter on",
+    "AutocompleteHinterOffARIA": "autocomplete hinter off",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
   },
   "KeyboardShortcuts": {
     "Title": " Scorciatoie tastiera",
@@ -206,14 +266,18 @@
       "FindNextTextMatch": "Trova prossimo risultato di testo",
       "FindPreviousTextMatch": "Trova precedente risultato di testo",
       "CodeEditing": "Modifica del codice",
-      "ColorPicker": "Mostra selettore colore in linea"
+      "ColorPicker": "Mostra selettore colore in linea",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
     },
     "GeneralSelection": {
       "StartSketch": "Avvia Sketch",
       "StopSketch": "Ferma Sketch",
       "TurnOnAccessibleOutput": "Attiva Output accessibile",
-      "TurnOffAccessibleOutput": "Spegni Output accessibile"
-    }
+      "TurnOffAccessibleOutput": "Spegni Output accessibile",
+      "Reference": "Go to Reference for Selected Item in Hinter"
+    },
+    "General": "General"
   },
   "Sidebar": {
     "Title": "Sketch File",
@@ -223,7 +287,8 @@
     "AddFile": "Crea file",
     "AddFileARIA": "aggiungi file",
     "UploadFile": "Carica file",
-    "UploadFileARIA": "carica file"
+    "UploadFileARIA": "carica file",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "Apri cartella contenuti",
@@ -299,7 +364,8 @@
     "errorNewPasswordRepeat": "Your New Password must differ from the current one.",
     "errorEmptyUsername": "Per favore inserisci un nome utente.",
     "errorLongUsername": "Il nome utente deve avere meno di 20 caratteri.",
-    "errorValidUsername": "Il nome utente dev'essere composto solo da numeri, lettere, must only consist of numbers, letters, punti, trattini e trattini bassi."
+    "errorValidUsername": "Il nome utente dev'essere composto solo da numeri, lettere, must only consist of numbers, letters, punti, trattini e trattini bassi.",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
   },
   "NewPasswordView": {
     "Title": "p5.js redattore web | Nuova password",
@@ -321,7 +387,9 @@
     "CurrentPasswordARIA": "Password attuale",
     "NewPassword": "Nuova Password",
     "NewPasswordARIA": "Nuova Password",
-    "SubmitSaveAllSettings": "Salva tutte le impostazioni"
+    "SubmitSaveAllSettings": "Salva tutte le impostazioni",
+    "UserName": "User Name",
+    "SaveAccountDetails": "Save Account Details"
   },
   "AccountView": {
     "SocialLogin": "Accesso ai social",
@@ -367,14 +435,19 @@
     "PasswordARIA": "password",
     "ConfirmPassword": "Conferma Password",
     "ConfirmPasswordARIA": "Conferma Password",
-    "SubmitSignup": "Registrati"
+    "SubmitSignup": "Registrati",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": "p5.js redattore web | Registrazione",
     "Description": "Registrati",
     "Or": "o",
     "AlreadyHave": "Hai già un account?",
-    "Login": "Accedi"
+    "Login": "Accedi",
+    "Warning": "By signing up, you agree to the p5.js Editor's <0>Terms of Use</0> and <1>Privacy Policy.</1>"
   },
   "EmailVerificationView": {
     "Title": "p5.js redattore web | Verifica email",
@@ -392,7 +465,8 @@
     "NoUploadedAssets": "Nessuna risorsa caricata.",
     "HeaderName": "Nome",
     "HeaderSize": "Dimensione",
-    "HeaderSketch": "Sketch"
+    "HeaderSketch": "Sketch",
+    "maximum": "Maximum"
   },
   "Feedback": {
     "Title": "p5.js redattore web | Feedback",
@@ -459,7 +533,8 @@
     "DirectionAscendingARIA": "Ascendente",
     "DirectionDescendingARIA": "Discendente",
     "ButtonLabelAscendingARIA": "Ordine per {{displayName}} ascendente.",
-    "ButtonLabelDescendingARIA": "Ordine per {{displayName}} discendente."
+    "ButtonLabelDescendingARIA": "Ordine per {{displayName}} discendente.",
+    "RemoveFromCollection": "Remove from Collection"
   },
   "AddToCollectionList": {
     "Title": "p5.js redattore web | Le mie collezioni",
@@ -602,7 +677,11 @@
     "UsedScreenReader": "Utilizzati dal lettore di schermo",
     "PlainText": "Testo normale",
     "TableText": "Testo in tabella",
-    "Sound": "Suoni"
+    "Sound": "Suoni",
+    "SelectLanguage": "Seleziona lingua",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "Preferences": "Preferences",
+    "Language": "Language"
   },
   "PreferenceCreators": {
     "On": "On",
@@ -633,5 +712,20 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
 }

--- a/translations/locales/ja/translations.json
+++ b/translations/locales/ja/translations.json
@@ -1,617 +1,704 @@
 {
-    "Nav": {
-      "File": {
-        "Title": "ファイル",
-        "New": "新規作成",
-        "Share": "共有",
-        "Duplicate": "別名で保存",
-        "Open": "開く",
-        "Download": "ダウンロード",
-        "AddToCollection": "コレクションへ追加",
-        "Examples": "サンプルを開く"
-      },
-      "Edit": {
-        "Title": "編集",
-        "TidyCode": "コード整形",
-        "Find": "検索",
-        "Replace": "置換"
-      },
-      "Sketch": {
-        "Title": "スケッチ",
-        "AddFile": "ファイルを追加",
-        "AddFolder": "フォルダを追加",
-        "Run": "実行",
-        "Stop": "停止"
-      },
-      "Help": {
-        "Title": "ヘルプ",
-        "KeyboardShortcuts": "キーボードショートカット",
-        "Reference": "リファレンス（英語）",
-        "About": "ウェブエディタについて"
-      },
-      "Lang": "言語",
-      "BackEditor": "エディタに戻る",
-      "WarningUnsavedChanges": "このページを離れてもよろしいですか？未保存の変更があります。",
-      "Login": "ログイン",
-      "LoginOr": "もしくは",
-      "SignUp": "アカウント作成",
-      "Auth": {
-        "Welcome": "ようこそ",
-        "Hello": "こんにちは",
-        "MyAccount": "マイアカウント",
-        "My": "My",
-        "MySketches": "マイスケッチ",
-        "MyCollections": "マイコレクション",
-        "Asset": "アセット",
-        "MyAssets": "マイアセット",
-        "LogOut": "ログアウト"
-      }
-    },
-    "Banner": {
-      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
-    },
-    "CodemirrorFindAndReplace": {
-      "ToggleReplace": "置換の切り替え",
-      "Find": "検索",
-      "FindPlaceholder": "ファイル内検索",
-      "Replace": "置換",
-      "ReplaceAll": "全て置換",
-      "ReplacePlaceholder": "置換するテキスト",
-      "Regex": "正規表現",
-      "CaseSensitive": "大文字小文字を区別する",
-      "WholeWords": "全単語",
-      "Previous": "前へ",
-      "Next": "次へ",
-      "NoResults": "該当なし",
-      "Close": "閉じる"
-    },
-    "LoginForm": {
-      "UsernameOrEmail": "メールアドレスもしくはユーザー名",
-      "UsernameOrEmailARIA": "メールアドレスもしくはユーザー名",
-      "Password": "パスワード",
-      "PasswordARIA": "パスワード",
-      "Submit": "ログイン"
-    },
-    "LoginView": {
-      "Title": "p5.js ウェブエディタ | ログイン",
-      "Login": "ログイン",
-      "LoginOr": "もしくは",
-      "SignUp": "アカウントを作成してください",
-      "Email": "メールアドレス",
-      "Username": "ユーザー名",
-      "DontHaveAccount": "ユーザー登録してない場合",
-      "ForgotPassword": "パスワードを忘れた場合",
-      "ResetPassword": "パスワードを再設定してください"
-    },
-    "SocialAuthButton": {
-      "Connect": "{{serviceauth}} アカウントへ接続",
-      "Unlink": "{{serviceauth}} アカウントへの接続解除",
-      "Login": "{{serviceauth}} でログイン",
-      "LogoARIA": "{{serviceauth}} ロゴ"
-    },
-    "About": {
-      "Title": "ウェブエディタについて",
-      "TitleHelmet": "p5.js ウェブエディター | ウェブエディタについて",
-      "Contribute": "コントリビュート",
-      "NewP5": "p5.jsは初めてですか?",
-      "Report": "バグレポート",
-      "Learn": "p5.jsを学ぶ",
-      "Twitter": "Twitter",
-      "Home": "ホーム",
-      "Instagram": "Instagram",
-      "Discord": "Discord",
-      "WebEditor": "ウェブエディタ",
-      "Resources": "参考資料",
-      "Libraries": "ライブラリ",
-      "Forum": "フォーラム",
-      "Examples": "サンプルを開く",
-      "PrivacyPolicy": "プライバシーポリシー",
-      "TermsOfUse": "利用規約",
-      "CodeOfConduct": "行動規範"
-    },
-    "Toast": {
-      "OpenedNewSketch": "新しいスケッチを開きました",
-      "SketchSaved": "スケッチを保存しました",
-      "SketchFailedSave": "スケッチの保存に失敗しました",
-      "AutosaveEnabled": "自動保存を有効にしました",
-      "LangChange": "言語を変更しました",
-      "SettingsSaved": "設定を保存しました",
-      "CloseAlertARIA": "Close Alert"
-    },
-    "Toolbar": {
-      "Preview": "プレビュー",
-      "Auto-refresh": "自動更新",
-      "OpenPreferencesARIA": "設定を開く",
-      "PlaySketchARIA": "スケッチを実行",
-      "PlayOnlyVisualSketchARIA": "ビジュアルスケッチのみ実行",
-      "StopSketchARIA": "スケッチを停止",
-      "EditSketchARIA": "スケッチ名を編集",
-      "NewSketchNameARIA": "新しいスケッチ名",
-      "By": " by ",
-      "SelectVersionARIA": "Select p5.js version"
-    },
-    "Console": {
-      "Title": "コンソール",
-      "Clear": "クリア",
-      "ClearARIA": "コンソールをクリア",
-      "Close": "閉じる",
-      "CloseARIA": "コンソールを閉じる",
-      "Open": "開く",
-      "OpenARIA": "コンソールを開く"
-    },
-    "Preferences": {
-      "Settings": "設定",
-      "GeneralSettings": "一般設定",
-      "Accessibility": "アクセシビリティ",
-      "Theme": "テーマ",
-      "LightTheme": "ライト",
-      "LightThemeARIA": "ライトテーマ オン",
-      "DarkTheme": "ダーク",
-      "DarkThemeARIA": "ダークテーマ オン",
-      "HighContrastTheme": "ハイコントラスト",
-      "HighContrastThemeARIA": "ハイコントラストテーマ オン",
-      "TextSize": "フォントサイズ",
-      "DecreaseFont": "小さく",
-      "DecreaseFontARIA": "フォントサイズを小さくする",
-      "IncreaseFont": "大きく",
-      "IncreaseFontARIA": "フォントサイズを大きくする",
-      "Autosave": "自動保存",
-      "On": "オン",
-      "AutosaveOnARIA": "自動保存 オン",
-      "Off": "オフ",
-      "AutosaveOffARIA": "自動保存 オフ",
-      "AutocloseBracketsQuotes": "括弧を自動的に閉じる",
-      "AutocloseBracketsQuotesOnARIA": "括弧を自動的に閉じる オン",
-      "AutocloseBracketsQuotesOffARIA": "括弧を自動的に閉じる オフ",
-      "WordWrap": "ワードラップ",
-      "WordWrapOnARIA": "ラインラップ オン",
-      "WordWrapOffARIA": "ラインラップ オフ",
-      "LineNumbers": "行番号",
-      "LineNumbersOnARIA": "行番号 表示",
-      "LineNumbersOffARIA": "行番号 非表示",
-      "LintWarningSound": "リント警告音",
-      "LintWarningOnARIA": "リント オン",
-      "LintWarningOffARIA": "リント オフ",
-      "PreviewSound": "プレビューサウンド",
-      "PreviewSoundARIA": "プレビューサウンド",
-      "AccessibleTextBasedCanvas": "アクセシビリティ用テキストベースのキャンバス",
-      "UsedScreenReader": "スクリーンリーダーと併用",
-      "PlainText": "プレーンテキスト",
-      "TextOutputARIA": "テキスト出力 オン",
-      "TableText": "テーブルテキスト",
-      "TableOutputARIA": "テーブルテキスト出力 オン"
-    },
-    "KeyboardShortcuts": {
-      "Title": " キーボードショートカット",
-      "ShortcutsFollow": "エディタのショートカットは以下の通りです",
-      "SublimeText": "Sublime Text ショートカット",
-      "CodeEditing": {
-        "Tidy": "整形",
-        "FindText": "テキスト検索",
-        "FindNextMatch": "次の一致を検索",
-        "FindPrevMatch": "前の一致を検索",
-        "ReplaceTextMatch": "一致するテキストの置換",
-        "IndentCodeLeft": "インデント左揃え",
-        "IndentCodeRight": "インデント右揃え",
-        "CommentLine": "コメントアウト",
-        "FindNextTextMatch": "次の一致するテキストを検索",
-        "FindPreviousTextMatch": "前の一致するテキストを検索",
-        "CodeEditing": "コード編集"
-      },
-      "GeneralSelection": {
-        "StartSketch": "スケッチを実行",
-        "StopSketch": "スケッチを停止",
-        "TurnOnAccessibleOutput": "アクセシビリティ出力を有効にする",
-        "TurnOffAccessibleOutput": "アクセシビリティ出力を無効にする"
-      }
-    },
-    "Sidebar": {
-      "Title": "スケッチファイル",
-      "ToggleARIA": "スケッチファイルオプションの開く/閉じるを切り替える",
-      "AddFolder": "フォルダを作成",
-      "AddFolderARIA": "フォルダを追加",
-      "AddFile": "ファイルを作成",
-      "AddFileARIA": "ファイルを追加",
-      "UploadFile": "ファイルアップロード",
-      "UploadFileARIA": "ファイルアップロード"
-    },
-    "FileNode": {
-      "OpenFolderARIA": "フォルダ内のコンテンツを開く",
-      "CloseFolderARIA": "フォルダ内のコンテンツを閉じる",
-      "ToggleFileOptionsARIA": "ファイルオプションの開く/閉じるを切り替える",
-      "AddFolder": "フォルダを作成",
-      "AddFolderARIA": "フォルダを追加",
-      "AddFile": "ファイル作成",
-      "AddFileARIA": "ファイルを追加",
-      "UploadFile": "ファイルアップロード",
-      "UploadFileARIA": "ファイルアップロード",
-      "Rename": "名前を変更",
-      "Delete": "削除"
-    },
-    "Common": {
-      "SiteName": "p5.js Web Editor",
-      "Error": "エラー",
-      "ErrorARIA": "エラー",
-      "Save": "保存",
-      "p5logoARIA": "p5.js ロゴ",
-      "DeleteConfirmation": "{{name}}を削除してもよろしいですか？"
-    },
-    "IDEView": {
-      "SubmitFeedback": "フィードバック送信",
-      "SubmitFeedbackARIA": "フィードバックを送信",
-      "AddCollectionTitle": "コレクション追加",
-      "AddCollectionARIA":"コレクションに追加する",
-      "ShareTitle": "共有",
-      "ShareARIA":"共有する"
-    },
-    "NewFileModal": {
-      "Title": "ファイル作成",
-      "CloseButtonARIA": "新規ファイルモーダルを閉じる",
-      "EnterName": "ファイル名を入力してください",
-      "InvalidType": "ファイルタイプが無効です。有効な拡張子は、.js、.css、.json、.xml、.stl、.txt、.csv、.tsv、.mtl、.frag、.vertです。"
-    },
-    "NewFileForm": {
-      "AddFileSubmit": "ファイルを追加",
-      "Placeholder": "ファイル名"
-    },
-    "NewFolderModal": {
-      "Title": "フォルダ作成",
-      "CloseButtonARIA": "新しいフォルダモーダルを閉じる",
-      "EnterName": "フォルダ名を入力してください",
-      "EmptyName": "スペースのみのフォルダ名は無効です",
-      "InvalidExtension": "フォルダ名に拡張子を含めることはできません"
-    },
-    "NewFolderForm": {
-      "AddFolderSubmit": "フォルダを追加",
-      "Placeholder": "フォルダ名"
-    },
-    "ResetPasswordForm": {
-      "Email": "登録に使用したメールアドレス",
-      "EmailARIA": "メールアドレス",
-      "Submit": "パスワードリセットのメールを送信する"
-    },
-    "ResetPasswordView": {
-      "Title": "p5.js ウェブエディター | パスワードリセット",
-      "Reset": "パスワードをリセットする",
-      "Submitted": "パスワードリセットのメールを送信しました。もし、見当たらない場合は\n            迷惑メールフォルダに入っている可能性がありますので、確認してください。",
-      "Login": "ログイン",
-      "LoginOr": "もしくは",
-      "SignUp": "アカウントを作成する"
-    },
-    "ReduxFormUtils": {
-      "errorInvalidEmail": "無効なメールアドレスを入力してください",
-      "errorEmptyEmail": "メールアドレスを入力してください",
-      "errorPasswordMismatch": "パスワードが一致しません",
-      "errorEmptyPassword": "パスワードを入力してください",
-      "errorShortPassword": "パスワードは6文字以上にしてください",
-      "errorConfirmPassword": "確認用のパスワードを入力してください",
-      "errorNewPassword": "新しいパスワードを入力するか、現在のパスワードを空欄のままにしてください。",
-      "errorNewPasswordRepeat":"Your New Password must differ from the current one.",
-      "errorEmptyUsername": "ユーザー名を入力してください。",
-      "errorLongUsername": "ユーザー名は20文字以内にしてください。",
-      "errorValidUsername": "ユーザー名は、英数字、ピリオド(.)、ダッシュ(-)、アンダースコア(_)のみで構成されている必要があります。"
-    },
-    "NewPasswordView": {
-      "Title": "p5.js ウェブエディター | 新しいパスワード",
-      "Description": "新しいパスワードの設定",
-      "TokenInvalidOrExpired": "パスワードリセットトークンが無効か、有効期限が切れています。",
-      "EmptyPassword": "パスワードを入力してください",
-      "PasswordConfirmation": "確認用のパスワードを入力してください",
-      "PasswordMismatch": "パスワードは一致している必要があります"
-    },
-    "AccountForm": {
-      "Email": "メールアドレス",
-      "EmailARIA": "メールアドレス",
-      "Unconfirmed": "未確認。",
-      "EmailSent": "確認メールが送信されましたので、メールを確認してください。",
-      "Resend": "確認メールを再送する",
-      "UserName": "ユーザー名",
-      "UserNameARIA": "ユーザー名",
-      "CurrentPassword": "現在のパスワード",
-      "CurrentPasswordARIA": "現在のパスワード",
-      "NewPassword": "新しいパスワード",
-      "NewPasswordARIA": "新しいパスワード",
-      "SubmitSaveAllSettings": "すべての設定を保存"
-    },
-    "AccountView": {
-      "SocialLogin": "ソーシャルログイン",
-      "SocialLoginDescription": "GitHubやGoogleアカウントを使って、p5.js ウェブエディターにログインできます。",
-      "Title": "p5.js ウェブエディター | アカウント設定",
-      "Settings": "アカウント設定",
-      "AccountTab": "アカウント",
-      "AccessTokensTab": "アクセストークン"
-    },
-    "APIKeyForm": {
-      "ConfirmDelete": "本当に{{key_label}}を削除しますか?",
-      "Summary": "パーソナルアクセストークンは、自動スクリプトがエディタAPIにアクセスできるようにするための\n          パスワードのような役割を果たします。\n          アクセスを必要とするスクリプトごとにトークンを作成します。",
-      "CreateToken": "新しいトークンを作成",
-      "TokenLabel": "このトークンはなんのため?",
-      "TokenPlaceholder": "このトークンはなんのため?  例：インポートスクリプト",
-      "CreateTokenSubmit": "作成",
-      "NoTokens": "既存のトークンはありません。",
-      "NewTokenTitle": "新しいアクセストークン",
-      "NewTokenInfo": "新しいパーソナルアクセストークンをコピーしてください。\n                  トークンをもう1度と見ることはできません!",
-      "ExistingTokensTitle": "既存のトークン"
-    },
-    "APIKeyList": {
-      "Name": "名前",
-      "Created": "作成日時",
-      "LastUsed": "最後に使用した日時",
-      "Actions": "アクション",
-      "Never": "一度も使用されていません",
-      "DeleteARIA": "APIキーを削除"
-    },
-    "NewPasswordForm": {
-      "Title": "パスワード",
-      "TitleARIA": "パスワード",
-      "ConfirmPassword": "確認用パスワード",
-      "ConfirmPasswordARIA": "確認用パスワード",
-      "SubmitSetNewPassword": "新しいパスワードを設定"
-    },
-    "SignupForm": {
-      "Title": "ユーザー名",
-      "TitleARIA": "ユーザー名",
-      "Email": "メールアドレス",
-      "EmailARIA": "メールアドレス",
-      "Password": "パスワード",
-      "PasswordARIA": "パスワード",
-      "ConfirmPassword": "確認用パスワード",
-      "ConfirmPasswordARIA": "確認用パスワード",
-      "SubmitSignup": "アカウント作成"
-    },
-    "SignupView": {
-      "Title": "p5.js ウェブエディター | ユーザー登録",
-      "Description": "ユーザー登録",
-      "Or": "もしくは",
-      "AlreadyHave": "既にアカウントをお持ちですか？",
-      "Login": "ログイン",
-      "Warning": "アカウント作成をすると、p5.js エディターの <0>利用規約</0> と <1>プライバシー ポリシー</1> に同意したことになります。"
-    },
-    "EmailVerificationView": {
-      "Title": "p5.js ウェブエディター | メールアドレス認証",
-      "Verify": "メールアドレスを確認してください",
-      "InvalidTokenNull": "そのリンクは無効です。",
-      "Checking": "トークンを検証中です、お待ちください...",
-      "Verified": "すべて完了しました、あなたのメールアドレスは確認されました。",
-      "InvalidState": "何か問題が発生しました。"
-    },
-    "AssetList": {
-      "Title": "p5.js ウェブエディター | マイアセット",
-      "ToggleOpenCloseARIA": "アセットオプションの開閉を切り替え",
-      "Delete": "削除",
-      "OpenNewTab": "新しいタブで開く",
-      "NoUploadedAssets": "アップロードされたアセットはありません。",
-      "HeaderName": "Name",
-      "HeaderSize": "サイズ",
-      "HeaderSketch": "スケッチ"
-    },
-    "Feedback": {
-      "Title": "p5.js ウェブエディター | フィードバック",
-      "ViaGithubHeader": "Github Issuesを利用",
-      "ViaGithubDescription": "Githubに詳しい方は、バグレポートやフィードバックのために、こちらからお願いします。",
-      "GoToGithub": "Githubへアクセスする",
-      "ViaGoogleHeader": "Google Formを利用",
-      "ViaGoogleDescription": "こちらのフォームから報告することもできます。",
-      "GoToForm": "フォームへアクセスする"
-    },
-    "Searchbar": {
-      "SearchSketch": "スケッチを検索...",
-      "SearchCollection": "コレクションを検索...",
-      "ClearTerm": "clear"
-    },
-    "UploadFileModal": {
-      "Title": "アップロードファイル",
-      "CloseButtonARIA": "アップロードファイルモーダルを閉じる",
-      "SizeLimitError": "エラー: これ以上ファイルをアップロードすることはできません。{{sizeLimit}}の合計サイズの上限に達しました。\n                もっとアップロードしたい場合は、もう使っていないものを削除してください。 "
-    },
-    "FileUploader": {
-      "DictDefaultMessage": "ここにファイルをドロップするか、クリックしてファイルブラウザを使用してください"
-    },
-    "ErrorModal": {
-      "MessageLogin": "スケッチを保存するにはログインが必要です。ログインしてください。 ",
-      "Login": "ログイン",
-      "LoginOr": " もしくは ",
-      "SignUp": "アカウントを作成してください",
-      "MessageLoggedOut": "ログアウトされたようです。ログインしてください。 ",
-      "LogIn": "ログイン",
-      "SavedDifferentWindow": "保存しようとしたプロジェクトが別のウィンドウから保存されました。\n        最新版をご覧になるにはページを更新してください。",
-      "LinkTitle": "アカウント接続エラー",
-      "LinkMessage": "あなたの {{serviceauth}} アカウントとp5.js ウェブエディターアカウントの接続に問題がありました。 あなたの {{serviceauth}} アカウントは、すでに別のp5.js ウェブエディターアカウントに接続されています。"
-    },
-    "ShareModal": {
-      "Embed": "埋め込み",
-      "Present": "プレゼンモード",
-      "Fullscreen": "フルスクリーン",
-      "Edit": "共同編集"
-    },
-    "CollectionView": {
-      "TitleCreate": "コレクション作成",
-      "TitleDefault": "コレクション"
-    },
-    "Collection": {
-      "Title": "p5.js ウェブエディター | マイコレクション",
-      "AnothersTitle": "p5.js ウェブエディター | {{anotheruser}} のコレクション",
+  "Nav": {
+    "File": {
+      "Title": "ファイル",
+      "New": "新規作成",
       "Share": "共有",
-      "URLLink": "コレクションのリンク",
-      "AddSketch": "スケッチを追加する",
-      "DeleteFromCollection": "このコレクションから {{name_sketch}} を削除してもよろしいですか？",
-      "SketchDeleted": "スケッチが削除されました",
-      "SketchRemoveARIA": "コレクションからスケッチを削除する",
-      "DescriptionPlaceholder": "スケッチについて記述する",
-      "Description": "コレクションについて",
-      "NumSketches": "{{count}} スケッチ",
-      "NumSketches_plural": "{{count}} スケッチ",
-      "By":"作成者 ",
-      "NoSketches": "コレクション内にスケッチがありません",
-      "TableSummary": "全コレクションのテーブル",
-      "HeaderName": "名前",
-      "HeaderCreatedAt": "追加日時",
-      "HeaderUser": "所有者",
-      "DirectionAscendingARIA": "昇順",
-      "DirectionDescendingARIA": "降順",
-      "ButtonLabelAscendingARIA": "昇順に{{displayName}}で並び替えます。",
-      "ButtonLabelDescendingARIA": "降順に{{displayName}}で並び替えます。"
+      "Duplicate": "別名で保存",
+      "Open": "開く",
+      "Download": "ダウンロード",
+      "AddToCollection": "コレクションへ追加",
+      "Examples": "サンプルを開く",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
-    "AddToCollectionList": {
-      "Title": "p5.js ウェブエディター | マイコレクション",
-      "AnothersTitle": "p5.js ウェブエディター | {{anotheruser}}のコレクション",
-      "Empty": "コレクションは空です"
+    "Edit": {
+      "Title": "編集",
+      "TidyCode": "コード整形",
+      "Find": "検索",
+      "Replace": "置換"
     },
-    "CollectionCreate": {
-      "Title": "p5.js ウェブエディター | コレクション作成",
-      "FormError": "コレクションを作成することが出来ませんでした",
-      "FormLabel": "コレクション名",
-      "FormLabelARIA": "名前",
-      "NameRequired": "コレクション名は必須です",
-      "Description": "コレクションについて (任意)",
-      "DescriptionARIA": "スケッチについて",
-      "DescriptionPlaceholder": "お気に入りスケッチ",
-      "SubmitCollectionCreate": "コレクションを作成"
+    "Sketch": {
+      "Title": "スケッチ",
+      "AddFile": "ファイルを追加",
+      "AddFolder": "フォルダを追加",
+      "Run": "実行",
+      "Stop": "停止"
     },
-    "DashboardView": {
-      "CreateCollection": "コレクションを作成",
-      "NewSketch": "新しいスケッチ",
-      "CreateCollectionOverlay": "コレクションを作成"
+    "Help": {
+      "Title": "ヘルプ",
+      "KeyboardShortcuts": "キーボードショートカット",
+      "Reference": "リファレンス（英語）",
+      "About": "ウェブエディタについて",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
-    "DashboardTabSwitcher": {
-      "Sketches": "スケッチ",
-      "Collections": "コレクション",
-      "Assets": "アセット"
+    "Lang": "言語",
+    "BackEditor": "エディタに戻る",
+    "WarningUnsavedChanges": "このページを離れてもよろしいですか？未保存の変更があります。",
+    "Login": "ログイン",
+    "LoginOr": "もしくは",
+    "SignUp": "アカウント作成",
+    "Auth": {
+      "Welcome": "ようこそ",
+      "Hello": "こんにちは",
+      "MyAccount": "マイアカウント",
+      "My": "My",
+      "MySketches": "マイスケッチ",
+      "MyCollections": "マイコレクション",
+      "Asset": "アセット",
+      "MyAssets": "マイアセット",
+      "LogOut": "ログアウト"
+    }
+  },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
+  "CodemirrorFindAndReplace": {
+    "ToggleReplace": "置換の切り替え",
+    "Find": "検索",
+    "FindPlaceholder": "ファイル内検索",
+    "Replace": "置換",
+    "ReplaceAll": "全て置換",
+    "ReplacePlaceholder": "置換するテキスト",
+    "Regex": "正規表現",
+    "CaseSensitive": "大文字小文字を区別する",
+    "WholeWords": "全単語",
+    "Previous": "前へ",
+    "Next": "次へ",
+    "NoResults": "該当なし",
+    "Close": "閉じる"
+  },
+  "LoginForm": {
+    "UsernameOrEmail": "メールアドレスもしくはユーザー名",
+    "UsernameOrEmailARIA": "メールアドレスもしくはユーザー名",
+    "Password": "パスワード",
+    "PasswordARIA": "パスワード",
+    "Submit": "ログイン",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
+  },
+  "LoginView": {
+    "Title": "p5.js ウェブエディタ | ログイン",
+    "Login": "ログイン",
+    "LoginOr": "もしくは",
+    "SignUp": "アカウントを作成してください",
+    "Email": "メールアドレス",
+    "Username": "ユーザー名",
+    "DontHaveAccount": "ユーザー登録してない場合",
+    "ForgotPassword": "パスワードを忘れた場合",
+    "ResetPassword": "パスワードを再設定してください"
+  },
+  "SocialAuthButton": {
+    "Connect": "{{serviceauth}} アカウントへ接続",
+    "Unlink": "{{serviceauth}} アカウントへの接続解除",
+    "Login": "{{serviceauth}} でログイン",
+    "LogoARIA": "{{serviceauth}} ロゴ"
+  },
+  "About": {
+    "Title": "ウェブエディタについて",
+    "TitleHelmet": "p5.js ウェブエディター | ウェブエディタについて",
+    "Contribute": "コントリビュート",
+    "NewP5": "p5.jsは初めてですか?",
+    "Report": "バグレポート",
+    "Learn": "p5.jsを学ぶ",
+    "Twitter": "Twitter",
+    "Home": "ホーム",
+    "Instagram": "Instagram",
+    "Discord": "Discord",
+    "WebEditor": "ウェブエディタ",
+    "Resources": "参考資料",
+    "Libraries": "ライブラリ",
+    "Forum": "フォーラム",
+    "Examples": "サンプルを開く",
+    "PrivacyPolicy": "プライバシーポリシー",
+    "TermsOfUse": "利用規約",
+    "CodeOfConduct": "行動規範",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
     },
-    "CollectionList": {
-      "Title": "p5.js ウェブエディター | マイコレクション",
-      "AnothersTitle": "p5.js ウェブエディター | {{anotheruser}}のコレクション",
-      "NoCollections": "コレクションがありません。",
-      "TableSummary": "全コレクションのテーブル",
-      "HeaderName": "名前",
-      "HeaderCreatedAt": "作成日",
-      "HeaderCreatedAt_mobile": "作成",
-      "HeaderUpdatedAt": "更新日",
-      "HeaderUpdatedAt_mobile": "更新",
-      "HeaderNumItems": "スケッチ No.",
-      "HeaderNumItems_mobile": "スケッチ No.",
-      "DirectionAscendingARIA": "昇順",
-      "DirectionDescendingARIA": "降順",
-      "ButtonLabelAscendingARIA": "昇順に{{displayName}}で並び替えます。",
-      "ButtonLabelDescendingARIA": "降順に{{displayName}}で並び替えます。",
-      "AddSketch": "スケッチを追加"
+    "Contact": "Contact Us"
+  },
+  "Toast": {
+    "OpenedNewSketch": "新しいスケッチを開きました",
+    "SketchSaved": "スケッチを保存しました",
+    "SketchFailedSave": "スケッチの保存に失敗しました",
+    "AutosaveEnabled": "自動保存を有効にしました",
+    "LangChange": "言語を変更しました",
+    "SettingsSaved": "設定を保存しました",
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
+  },
+  "Toolbar": {
+    "Preview": "プレビュー",
+    "Auto-refresh": "自動更新",
+    "OpenPreferencesARIA": "設定を開く",
+    "PlaySketchARIA": "スケッチを実行",
+    "PlayOnlyVisualSketchARIA": "ビジュアルスケッチのみ実行",
+    "StopSketchARIA": "スケッチを停止",
+    "EditSketchARIA": "スケッチ名を編集",
+    "NewSketchNameARIA": "新しいスケッチ名",
+    "By": " by ",
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
+  },
+  "Console": {
+    "Title": "コンソール",
+    "Clear": "クリア",
+    "ClearARIA": "コンソールをクリア",
+    "Close": "閉じる",
+    "CloseARIA": "コンソールを閉じる",
+    "Open": "開く",
+    "OpenARIA": "コンソールを開く"
+  },
+  "Preferences": {
+    "Settings": "設定",
+    "GeneralSettings": "一般設定",
+    "Accessibility": "アクセシビリティ",
+    "Theme": "テーマ",
+    "LightTheme": "ライト",
+    "LightThemeARIA": "ライトテーマ オン",
+    "DarkTheme": "ダーク",
+    "DarkThemeARIA": "ダークテーマ オン",
+    "HighContrastTheme": "ハイコントラスト",
+    "HighContrastThemeARIA": "ハイコントラストテーマ オン",
+    "TextSize": "フォントサイズ",
+    "DecreaseFont": "小さく",
+    "DecreaseFontARIA": "フォントサイズを小さくする",
+    "IncreaseFont": "大きく",
+    "IncreaseFontARIA": "フォントサイズを大きくする",
+    "Autosave": "自動保存",
+    "On": "オン",
+    "AutosaveOnARIA": "自動保存 オン",
+    "Off": "オフ",
+    "AutosaveOffARIA": "自動保存 オフ",
+    "AutocloseBracketsQuotes": "括弧を自動的に閉じる",
+    "AutocloseBracketsQuotesOnARIA": "括弧を自動的に閉じる オン",
+    "AutocloseBracketsQuotesOffARIA": "括弧を自動的に閉じる オフ",
+    "WordWrap": "ワードラップ",
+    "WordWrapOnARIA": "ラインラップ オン",
+    "WordWrapOffARIA": "ラインラップ オフ",
+    "LineNumbers": "行番号",
+    "LineNumbersOnARIA": "行番号 表示",
+    "LineNumbersOffARIA": "行番号 非表示",
+    "LintWarningSound": "リント警告音",
+    "LintWarningOnARIA": "リント オン",
+    "LintWarningOffARIA": "リント オフ",
+    "PreviewSound": "プレビューサウンド",
+    "PreviewSoundARIA": "プレビューサウンド",
+    "AccessibleTextBasedCanvas": "アクセシビリティ用テキストベースのキャンバス",
+    "UsedScreenReader": "スクリーンリーダーと併用",
+    "PlainText": "プレーンテキスト",
+    "TextOutputARIA": "テキスト出力 オン",
+    "TableText": "テーブルテキスト",
+    "TableOutputARIA": "テーブルテキスト出力 オン",
+    "LibraryManagement": "Library Management",
+    "FontSize": "Font Size",
+    "SetFontSize": "set font size",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "AutocompleteHinterOnARIA": "autocomplete hinter on",
+    "AutocompleteHinterOffARIA": "autocomplete hinter off",
+    "LibraryVersion": "p5.js Version",
+    "LibraryVersionInfo": "There's a [new 2.0 release](https://github.com/processing/p5.js/releases/) of p5.js available! It will become default in August, 2026, so take this time to test it out and report bugs. Interested in transitioning sketches from 1.x to 2.0? Check out the [compatibility & transition resources.](https://github.com/processing/p5.js-compatibility)",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "SoundAddon": "p5.sound.js Add-on Library",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on Library — Preload",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on Library — Shapes",
+    "DataAddon": "p5.js 1.x Compatibility Add-on Library — Data & Events",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
+  },
+  "KeyboardShortcuts": {
+    "Title": " キーボードショートカット",
+    "ShortcutsFollow": "エディタのショートカットは以下の通りです",
+    "SublimeText": "Sublime Text ショートカット",
+    "CodeEditing": {
+      "Tidy": "整形",
+      "FindText": "テキスト検索",
+      "FindNextMatch": "次の一致を検索",
+      "FindPrevMatch": "前の一致を検索",
+      "ReplaceTextMatch": "一致するテキストの置換",
+      "IndentCodeLeft": "インデント左揃え",
+      "IndentCodeRight": "インデント右揃え",
+      "CommentLine": "コメントアウト",
+      "FindNextTextMatch": "次の一致するテキストを検索",
+      "FindPreviousTextMatch": "前の一致するテキストを検索",
+      "CodeEditing": "コード編集",
+      "ColorPicker": "Show Inline Color Picker",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
     },
-    "CollectionListRow": {
-      "ToggleCollectionOptionsARIA": "開く/閉じるコレクションのオプションを切り替え",
-      "AddSketch": "スケッチを追加",
-      "Delete": "削除",
-      "Rename": "名前を変更"
+    "GeneralSelection": {
+      "StartSketch": "スケッチを実行",
+      "StopSketch": "スケッチを停止",
+      "TurnOnAccessibleOutput": "アクセシビリティ出力を有効にする",
+      "TurnOffAccessibleOutput": "アクセシビリティ出力を無効にする",
+      "Reference": "Go to Reference for Selected Item in Hinter"
     },
-    "Overlay": {
-      "AriaLabel": "{{title}} オーバーレイを閉じる"
-    },
-    "QuickAddList":{
-      "ButtonRemoveARIA": "コレクションから削除",
-      "ButtonAddToCollectionARIA": "コレクションへ追加",
-      "View": "表示"
-    },
-    "Pagination": {
-      "Next": "Next",
-      "Previous": "Previous",
-      "Of": "of",
-      "PreviousPageARIA": "Previous Page",
-      "NextPageARIA": "Next Page"
-    },
-    "SketchList": {
-      "View": "表示",
-      "Title": "p5.js ウェブエディター | マイスケッチ",
-      "AnothersTitle": "p5.js ウェブエディター | {{anotheruser}} のスケッチ",
-      "ToggleLabelARIA": "開く/閉じるスケッチ オプションの切り替え",
-      "DropdownRename": "名前変更",
-      "DropdownDownload": "ダウンロード",
-      "DropdownDuplicate": "別名で保存",
-      "DropdownAddToCollection": "コレクションへ追加",
-      "DropdownDelete": "削除",
-      "DirectionAscendingARIA": "昇順",
-      "DirectionDescendingARIA": "降順",
-      "ButtonLabelAscendingARIA": "昇順に{{displayName}}で並び替えます。",
-      "ButtonLabelDescendingARIA": "降順に{{displayName}}で並び替えます。",
-      "AddToCollectionOverlayTitle": "コレクションへ追加",
-      "TableSummary": "保存されたすべてのプロジェクトを含むテーブル",
-      "HeaderName": "スケッチ",
-      "HeaderCreatedAt": "作成日",
-      "HeaderCreatedAt_mobile": "作成",
-      "HeaderUpdatedAt": "更新日",
-      "HeaderUpdatedAt_mobile": "更新",
-      "NoSketches": "スケッチがありません"
-    },
-    "AddToCollectionSketchList": {
-      "Title": "p5.js ウェブエディター | マイスケッチ",
-      "AnothersTitle": "p5.js ウェブエディター | {{anotheruser}} のスケッチ",
-      "NoCollections": "コレクションがありません。"
-    },
-    "Editor": {
-      "OpenSketchARIA": "スケッチファイルのナビゲーションを開く",
-      "CloseSketchARIA": "スケッチファイルのナビゲーションを閉じる",
-      "UnsavedChangesARIA": "スケッチに未保存の変更があります",
-      "KeyUpLineNumber": "{{lineNumber}} 行"
-    },
-    "EditorAccessibility": {
-      "NoLintMessages": "リントメッセージはありません",
-      "CurrentLine": "現在の行"
-    },
-    "Timer": {
-      "SavedAgo": "保存されました: {{timeAgo}}"
-    },
-    "formatDate": {
-      "JustNow": "たった今",
-      "15Seconds": "15秒前",
-      "25Seconds": "25秒前",
-      "35Seconds": "35秒前",
-      "Ago": "{{timeAgo}}前"
-    },
-    "CopyableInput": {
-      "CopiedARIA": "クリップボードへコピーしました！",
-      "OpenViewTabARIA": "新しいタブで {{label}} ビューを開く"
-    },
-    "EditableInput": {
-      "EditValue": "{{display}} 値を編集",
-      "EmptyPlaceholder": "値がありません"
-    },
-    "PreviewNav": {
-      "EditSketchARIA": "スケッチを編集する",
-      "ByUser": "によって"
-    },
-    "MobilePreferences": {
-      "Settings": "設定",
-      "GeneralSettings": "一般設定",
-      "Accessibility": "アクセシビリティ",
-      "AccessibleOutput": "アクセシビリティ出力",
-      "Theme": "テーマ",
-      "LightTheme": "ライト",
-      "DarkTheme": "ダーク",
-      "HighContrastTheme": "ハイコントラスト",
-      "Autosave": "自動保存",
-      "WordWrap": "ワードラップ",
-      "LineNumbers": "行番号",
-      "LintWarningSound": "リント警告音",
-      "UsedScreenReader": "スクリーンリーダーと併用",
-      "PlainText": "プレーンテキスト",
-      "TableText": "テーブルテキスト",
-      "Sound": "サウンド"
-    },
-    "PreferenceCreators": {
-      "On": "オン",
-      "Off": "オフ"
-    },
-    "MobileDashboardView": {
-      "Examples": "サンプル",
-      "Sketches": "スケッチ",
-      "Collections": "コレクション",
-      "Assets": "アセット",
-      "MyStuff": "マイスタッフ",
-      "CreateSketch": "スケッチ作成",
-      "CreateCollection": "コレクション作成"
-    },
-    "Explorer": {
-      "Files": "ファイル"
-    },
-    "Cookies": {
+    "General": "General"
+  },
+  "Sidebar": {
+    "Title": "スケッチファイル",
+    "ToggleARIA": "スケッチファイルオプションの開く/閉じるを切り替える",
+    "AddFolder": "フォルダを作成",
+    "AddFolderARIA": "フォルダを追加",
+    "AddFile": "ファイルを作成",
+    "AddFileARIA": "ファイルを追加",
+    "UploadFile": "ファイルアップロード",
+    "UploadFileARIA": "ファイルアップロード",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
+  },
+  "FileNode": {
+    "OpenFolderARIA": "フォルダ内のコンテンツを開く",
+    "CloseFolderARIA": "フォルダ内のコンテンツを閉じる",
+    "ToggleFileOptionsARIA": "ファイルオプションの開く/閉じるを切り替える",
+    "AddFolder": "フォルダを作成",
+    "AddFolderARIA": "フォルダを追加",
+    "AddFile": "ファイル作成",
+    "AddFileARIA": "ファイルを追加",
+    "UploadFile": "ファイルアップロード",
+    "UploadFileARIA": "ファイルアップロード",
+    "Rename": "名前を変更",
+    "Delete": "削除"
+  },
+  "Common": {
+    "SiteName": "p5.js Web Editor",
+    "Error": "エラー",
+    "ErrorARIA": "エラー",
+    "Save": "保存",
+    "p5logoARIA": "p5.js ロゴ",
+    "DeleteConfirmation": "{{name}}を削除してもよろしいですか？"
+  },
+  "IDEView": {
+    "SubmitFeedback": "フィードバック送信",
+    "SubmitFeedbackARIA": "フィードバックを送信",
+    "AddCollectionTitle": "コレクション追加",
+    "AddCollectionARIA": "コレクションに追加する",
+    "ShareTitle": "共有",
+    "ShareARIA": "共有する"
+  },
+  "NewFileModal": {
+    "Title": "ファイル作成",
+    "CloseButtonARIA": "新規ファイルモーダルを閉じる",
+    "EnterName": "ファイル名を入力してください",
+    "InvalidType": "ファイルタイプが無効です。有効な拡張子は、.js、.css、.json、.xml、.stl、.txt、.csv、.tsv、.mtl、.frag、.vertです。"
+  },
+  "NewFileForm": {
+    "AddFileSubmit": "ファイルを追加",
+    "Placeholder": "ファイル名"
+  },
+  "NewFolderModal": {
+    "Title": "フォルダ作成",
+    "CloseButtonARIA": "新しいフォルダモーダルを閉じる",
+    "EnterName": "フォルダ名を入力してください",
+    "EmptyName": "スペースのみのフォルダ名は無効です",
+    "InvalidExtension": "フォルダ名に拡張子を含めることはできません"
+  },
+  "NewFolderForm": {
+    "AddFolderSubmit": "フォルダを追加",
+    "Placeholder": "フォルダ名"
+  },
+  "ResetPasswordForm": {
+    "Email": "登録に使用したメールアドレス",
+    "EmailARIA": "メールアドレス",
+    "Submit": "パスワードリセットのメールを送信する"
+  },
+  "ResetPasswordView": {
+    "Title": "p5.js ウェブエディター | パスワードリセット",
+    "Reset": "パスワードをリセットする",
+    "Submitted": "パスワードリセットのメールを送信しました。もし、見当たらない場合は\n            迷惑メールフォルダに入っている可能性がありますので、確認してください。",
+    "Login": "ログイン",
+    "LoginOr": "もしくは",
+    "SignUp": "アカウントを作成する"
+  },
+  "ReduxFormUtils": {
+    "errorInvalidEmail": "無効なメールアドレスを入力してください",
+    "errorEmptyEmail": "メールアドレスを入力してください",
+    "errorPasswordMismatch": "パスワードが一致しません",
+    "errorEmptyPassword": "パスワードを入力してください",
+    "errorShortPassword": "パスワードは6文字以上にしてください",
+    "errorConfirmPassword": "確認用のパスワードを入力してください",
+    "errorNewPassword": "新しいパスワードを入力するか、現在のパスワードを空欄のままにしてください。",
+    "errorNewPasswordRepeat": "Your New Password must differ from the current one.",
+    "errorEmptyUsername": "ユーザー名を入力してください。",
+    "errorLongUsername": "ユーザー名は20文字以内にしてください。",
+    "errorValidUsername": "ユーザー名は、英数字、ピリオド(.)、ダッシュ(-)、アンダースコア(_)のみで構成されている必要があります。",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
+  },
+  "NewPasswordView": {
+    "Title": "p5.js ウェブエディター | 新しいパスワード",
+    "Description": "新しいパスワードの設定",
+    "TokenInvalidOrExpired": "パスワードリセットトークンが無効か、有効期限が切れています。",
+    "EmptyPassword": "パスワードを入力してください",
+    "PasswordConfirmation": "確認用のパスワードを入力してください",
+    "PasswordMismatch": "パスワードは一致している必要があります"
+  },
+  "AccountForm": {
+    "Email": "メールアドレス",
+    "EmailARIA": "メールアドレス",
+    "Unconfirmed": "未確認。",
+    "EmailSent": "確認メールが送信されましたので、メールを確認してください。",
+    "Resend": "確認メールを再送する",
+    "UserName": "ユーザー名",
+    "UserNameARIA": "ユーザー名",
+    "CurrentPassword": "現在のパスワード",
+    "CurrentPasswordARIA": "現在のパスワード",
+    "NewPassword": "新しいパスワード",
+    "NewPasswordARIA": "新しいパスワード",
+    "SubmitSaveAllSettings": "すべての設定を保存",
+    "SaveAccountDetails": "Save Account Details"
+  },
+  "AccountView": {
+    "SocialLogin": "ソーシャルログイン",
+    "SocialLoginDescription": "GitHubやGoogleアカウントを使って、p5.js ウェブエディターにログインできます。",
+    "Title": "p5.js ウェブエディター | アカウント設定",
+    "Settings": "アカウント設定",
+    "AccountTab": "アカウント",
+    "AccessTokensTab": "アクセストークン"
+  },
+  "APIKeyForm": {
+    "ConfirmDelete": "本当に{{key_label}}を削除しますか?",
+    "Summary": "パーソナルアクセストークンは、自動スクリプトがエディタAPIにアクセスできるようにするための\n          パスワードのような役割を果たします。\n          アクセスを必要とするスクリプトごとにトークンを作成します。",
+    "CreateToken": "新しいトークンを作成",
+    "TokenLabel": "このトークンはなんのため?",
+    "TokenPlaceholder": "このトークンはなんのため?  例：インポートスクリプト",
+    "CreateTokenSubmit": "作成",
+    "NoTokens": "既存のトークンはありません。",
+    "NewTokenTitle": "新しいアクセストークン",
+    "NewTokenInfo": "新しいパーソナルアクセストークンをコピーしてください。\n                  トークンをもう1度と見ることはできません!",
+    "ExistingTokensTitle": "既存のトークン"
+  },
+  "APIKeyList": {
+    "Name": "名前",
+    "Created": "作成日時",
+    "LastUsed": "最後に使用した日時",
+    "Actions": "アクション",
+    "Never": "一度も使用されていません",
+    "DeleteARIA": "APIキーを削除"
+  },
+  "NewPasswordForm": {
+    "Title": "パスワード",
+    "TitleARIA": "パスワード",
+    "ConfirmPassword": "確認用パスワード",
+    "ConfirmPasswordARIA": "確認用パスワード",
+    "SubmitSetNewPassword": "新しいパスワードを設定"
+  },
+  "SignupForm": {
+    "Title": "ユーザー名",
+    "TitleARIA": "ユーザー名",
+    "Email": "メールアドレス",
+    "EmailARIA": "メールアドレス",
+    "Password": "パスワード",
+    "PasswordARIA": "パスワード",
+    "ConfirmPassword": "確認用パスワード",
+    "ConfirmPasswordARIA": "確認用パスワード",
+    "SubmitSignup": "アカウント作成",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
+  },
+  "SignupView": {
+    "Title": "p5.js ウェブエディター | ユーザー登録",
+    "Description": "ユーザー登録",
+    "Or": "もしくは",
+    "AlreadyHave": "既にアカウントをお持ちですか？",
+    "Login": "ログイン",
+    "Warning": "アカウント作成をすると、p5.js エディターの <0>利用規約</0> と <1>プライバシー ポリシー</1> に同意したことになります。"
+  },
+  "EmailVerificationView": {
+    "Title": "p5.js ウェブエディター | メールアドレス認証",
+    "Verify": "メールアドレスを確認してください",
+    "InvalidTokenNull": "そのリンクは無効です。",
+    "Checking": "トークンを検証中です、お待ちください...",
+    "Verified": "すべて完了しました、あなたのメールアドレスは確認されました。",
+    "InvalidState": "何か問題が発生しました。"
+  },
+  "AssetList": {
+    "Title": "p5.js ウェブエディター | マイアセット",
+    "ToggleOpenCloseARIA": "アセットオプションの開閉を切り替え",
+    "Delete": "削除",
+    "OpenNewTab": "新しいタブで開く",
+    "NoUploadedAssets": "アップロードされたアセットはありません。",
+    "HeaderName": "Name",
+    "HeaderSize": "サイズ",
+    "HeaderSketch": "スケッチ",
+    "maximum": "Maximum"
+  },
+  "Feedback": {
+    "Title": "p5.js ウェブエディター | フィードバック",
+    "ViaGithubHeader": "Github Issuesを利用",
+    "ViaGithubDescription": "Githubに詳しい方は、バグレポートやフィードバックのために、こちらからお願いします。",
+    "GoToGithub": "Githubへアクセスする",
+    "ViaGoogleHeader": "Google Formを利用",
+    "ViaGoogleDescription": "こちらのフォームから報告することもできます。",
+    "GoToForm": "フォームへアクセスする"
+  },
+  "Searchbar": {
+    "SearchSketch": "スケッチを検索...",
+    "SearchCollection": "コレクションを検索...",
+    "ClearTerm": "clear"
+  },
+  "UploadFileModal": {
+    "Title": "アップロードファイル",
+    "CloseButtonARIA": "アップロードファイルモーダルを閉じる",
+    "SizeLimitError": "エラー: これ以上ファイルをアップロードすることはできません。{{sizeLimit}}の合計サイズの上限に達しました。\n                もっとアップロードしたい場合は、もう使っていないものを削除してください。 "
+  },
+  "FileUploader": {
+    "DictDefaultMessage": "ここにファイルをドロップするか、クリックしてファイルブラウザを使用してください"
+  },
+  "ErrorModal": {
+    "MessageLogin": "スケッチを保存するにはログインが必要です。ログインしてください。 ",
+    "Login": "ログイン",
+    "LoginOr": " もしくは ",
+    "SignUp": "アカウントを作成してください",
+    "MessageLoggedOut": "ログアウトされたようです。ログインしてください。 ",
+    "LogIn": "ログイン",
+    "SavedDifferentWindow": "保存しようとしたプロジェクトが別のウィンドウから保存されました。\n        最新版をご覧になるにはページを更新してください。",
+    "LinkTitle": "アカウント接続エラー",
+    "LinkMessage": "あなたの {{serviceauth}} アカウントとp5.js ウェブエディターアカウントの接続に問題がありました。 あなたの {{serviceauth}} アカウントは、すでに別のp5.js ウェブエディターアカウントに接続されています。"
+  },
+  "ShareModal": {
+    "Embed": "埋め込み",
+    "Present": "プレゼンモード",
+    "Fullscreen": "フルスクリーン",
+    "Edit": "共同編集"
+  },
+  "CollectionView": {
+    "TitleCreate": "コレクション作成",
+    "TitleDefault": "コレクション"
+  },
+  "Collection": {
+    "Title": "p5.js ウェブエディター | マイコレクション",
+    "AnothersTitle": "p5.js ウェブエディター | {{anotheruser}} のコレクション",
+    "Share": "共有",
+    "URLLink": "コレクションのリンク",
+    "AddSketch": "スケッチを追加する",
+    "DeleteFromCollection": "このコレクションから {{name_sketch}} を削除してもよろしいですか？",
+    "SketchDeleted": "スケッチが削除されました",
+    "SketchRemoveARIA": "コレクションからスケッチを削除する",
+    "DescriptionPlaceholder": "スケッチについて記述する",
+    "Description": "コレクションについて",
+    "NumSketches": "{{count}} スケッチ",
+    "NumSketches_plural": "{{count}} スケッチ",
+    "By": "作成者 ",
+    "NoSketches": "コレクション内にスケッチがありません",
+    "TableSummary": "全コレクションのテーブル",
+    "HeaderName": "名前",
+    "HeaderCreatedAt": "追加日時",
+    "HeaderUser": "所有者",
+    "DirectionAscendingARIA": "昇順",
+    "DirectionDescendingARIA": "降順",
+    "ButtonLabelAscendingARIA": "昇順に{{displayName}}で並び替えます。",
+    "ButtonLabelDescendingARIA": "降順に{{displayName}}で並び替えます。",
+    "RemoveFromCollection": "Remove from Collection"
+  },
+  "AddToCollectionList": {
+    "Title": "p5.js ウェブエディター | マイコレクション",
+    "AnothersTitle": "p5.js ウェブエディター | {{anotheruser}}のコレクション",
+    "Empty": "コレクションは空です"
+  },
+  "CollectionCreate": {
+    "Title": "p5.js ウェブエディター | コレクション作成",
+    "FormError": "コレクションを作成することが出来ませんでした",
+    "FormLabel": "コレクション名",
+    "FormLabelARIA": "名前",
+    "NameRequired": "コレクション名は必須です",
+    "Description": "コレクションについて (任意)",
+    "DescriptionARIA": "スケッチについて",
+    "DescriptionPlaceholder": "お気に入りスケッチ",
+    "SubmitCollectionCreate": "コレクションを作成"
+  },
+  "DashboardView": {
+    "CreateCollection": "コレクションを作成",
+    "NewSketch": "新しいスケッチ",
+    "CreateCollectionOverlay": "コレクションを作成"
+  },
+  "DashboardTabSwitcher": {
+    "Sketches": "スケッチ",
+    "Collections": "コレクション",
+    "Assets": "アセット"
+  },
+  "CollectionList": {
+    "Title": "p5.js ウェブエディター | マイコレクション",
+    "AnothersTitle": "p5.js ウェブエディター | {{anotheruser}}のコレクション",
+    "NoCollections": "コレクションがありません。",
+    "TableSummary": "全コレクションのテーブル",
+    "HeaderName": "名前",
+    "HeaderCreatedAt": "作成日",
+    "HeaderCreatedAt_mobile": "作成",
+    "HeaderUpdatedAt": "更新日",
+    "HeaderUpdatedAt_mobile": "更新",
+    "HeaderNumItems": "スケッチ No.",
+    "HeaderNumItems_mobile": "スケッチ No.",
+    "DirectionAscendingARIA": "昇順",
+    "DirectionDescendingARIA": "降順",
+    "ButtonLabelAscendingARIA": "昇順に{{displayName}}で並び替えます。",
+    "ButtonLabelDescendingARIA": "降順に{{displayName}}で並び替えます。",
+    "AddSketch": "スケッチを追加"
+  },
+  "CollectionListRow": {
+    "ToggleCollectionOptionsARIA": "開く/閉じるコレクションのオプションを切り替え",
+    "AddSketch": "スケッチを追加",
+    "Delete": "削除",
+    "Rename": "名前を変更"
+  },
+  "Overlay": {
+    "AriaLabel": "{{title}} オーバーレイを閉じる"
+  },
+  "QuickAddList": {
+    "ButtonRemoveARIA": "コレクションから削除",
+    "ButtonAddToCollectionARIA": "コレクションへ追加",
+    "View": "表示"
+  },
+  "Pagination": {
+    "Next": "Next",
+    "Previous": "Previous",
+    "Of": "of",
+    "PreviousPageARIA": "Previous Page",
+    "NextPageARIA": "Next Page"
+  },
+  "SketchList": {
+    "View": "表示",
+    "Title": "p5.js ウェブエディター | マイスケッチ",
+    "AnothersTitle": "p5.js ウェブエディター | {{anotheruser}} のスケッチ",
+    "ToggleLabelARIA": "開く/閉じるスケッチ オプションの切り替え",
+    "DropdownRename": "名前変更",
+    "DropdownDownload": "ダウンロード",
+    "DropdownDuplicate": "別名で保存",
+    "DropdownAddToCollection": "コレクションへ追加",
+    "DropdownDelete": "削除",
+    "DirectionAscendingARIA": "昇順",
+    "DirectionDescendingARIA": "降順",
+    "ButtonLabelAscendingARIA": "昇順に{{displayName}}で並び替えます。",
+    "ButtonLabelDescendingARIA": "降順に{{displayName}}で並び替えます。",
+    "AddToCollectionOverlayTitle": "コレクションへ追加",
+    "TableSummary": "保存されたすべてのプロジェクトを含むテーブル",
+    "HeaderName": "スケッチ",
+    "HeaderCreatedAt": "作成日",
+    "HeaderCreatedAt_mobile": "作成",
+    "HeaderUpdatedAt": "更新日",
+    "HeaderUpdatedAt_mobile": "更新",
+    "NoSketches": "スケッチがありません"
+  },
+  "AddToCollectionSketchList": {
+    "Title": "p5.js ウェブエディター | マイスケッチ",
+    "AnothersTitle": "p5.js ウェブエディター | {{anotheruser}} のスケッチ",
+    "NoCollections": "コレクションがありません。"
+  },
+  "Editor": {
+    "OpenSketchARIA": "スケッチファイルのナビゲーションを開く",
+    "CloseSketchARIA": "スケッチファイルのナビゲーションを閉じる",
+    "UnsavedChangesARIA": "スケッチに未保存の変更があります",
+    "KeyUpLineNumber": "{{lineNumber}} 行"
+  },
+  "EditorAccessibility": {
+    "NoLintMessages": "リントメッセージはありません",
+    "CurrentLine": "現在の行"
+  },
+  "Timer": {
+    "SavedAgo": "保存されました: {{timeAgo}}"
+  },
+  "formatDate": {
+    "JustNow": "たった今",
+    "15Seconds": "15秒前",
+    "25Seconds": "25秒前",
+    "35Seconds": "35秒前",
+    "Ago": "{{timeAgo}}前"
+  },
+  "CopyableInput": {
+    "CopiedARIA": "クリップボードへコピーしました！",
+    "OpenViewTabARIA": "新しいタブで {{label}} ビューを開く"
+  },
+  "EditableInput": {
+    "EditValue": "{{display}} 値を編集",
+    "EmptyPlaceholder": "値がありません"
+  },
+  "PreviewNav": {
+    "EditSketchARIA": "スケッチを編集する",
+    "ByUser": "によって"
+  },
+  "MobilePreferences": {
+    "Settings": "設定",
+    "GeneralSettings": "一般設定",
+    "Accessibility": "アクセシビリティ",
+    "AccessibleOutput": "アクセシビリティ出力",
+    "Theme": "テーマ",
+    "LightTheme": "ライト",
+    "DarkTheme": "ダーク",
+    "HighContrastTheme": "ハイコントラスト",
+    "Autosave": "自動保存",
+    "WordWrap": "ワードラップ",
+    "LineNumbers": "行番号",
+    "LintWarningSound": "リント警告音",
+    "UsedScreenReader": "スクリーンリーダーと併用",
+    "PlainText": "プレーンテキスト",
+    "TableText": "テーブルテキスト",
+    "Sound": "サウンド",
+    "SelectLanguage": "言語を選択",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "Preferences": "Preferences",
+    "Language": "Language"
+  },
+  "PreferenceCreators": {
+    "On": "オン",
+    "Off": "オフ"
+  },
+  "MobileDashboardView": {
+    "Examples": "サンプル",
+    "Sketches": "スケッチ",
+    "Collections": "コレクション",
+    "Assets": "アセット",
+    "MyStuff": "マイスタッフ",
+    "CreateSketch": "スケッチ作成",
+    "CreateCollection": "コレクション作成"
+  },
+  "Explorer": {
+    "Files": "ファイル"
+  },
+  "Cookies": {
     "Header": "Cookies",
     "Body": "p5.jsエディターはクッキーを使用しています。 いくつかの項目はウェブサイトの機能に不可欠であり、アカウントとプリファレンスを管理することが可能です。 そのほかの項目は不可欠ではありません—それらは分析され、私たちのコミュニティについてより理解するために利用されます。 <strong> 私たちがこのデータを販売したり、広告に使用したりすることは決してありません。 </strong> あなたはどのcookiesの利用を許可するか決めることができます。詳細については私たちの<0>プライバシーポリシー<0>をご参照ください。",
     "AllowAll": "すべて許可",
@@ -624,5 +711,20 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
 }

--- a/translations/locales/ko/translations.json
+++ b/translations/locales/ko/translations.json
@@ -8,14 +8,21 @@
       "Open": "열기",
       "Download": "다운로드",
       "AddToCollection": "콜렉션 추가",
-      "Examples": "예제"
+      "Examples": "예제",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "수정",
       "TidyCode": "깔끔한 코드",
       "Find": "찾기",
       "FindNext": "다음 내용 찾기",
-      "FindPrevious": "이전 내용 찾기"
+      "FindPrevious": "이전 내용 찾기",
+      "Replace": "Replace"
     },
     "Sketch": {
       "Title": "스케치",
@@ -28,7 +35,10 @@
       "Title": "도움말",
       "KeyboardShortcuts": "단축키",
       "Reference": "레퍼런스",
-      "About": "소개"
+      "About": "소개",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
     "Lang": "언어",
     "BackEditor": "에디터로 돌아가기",
@@ -56,7 +66,12 @@
     "UsernameOrEmailARIA": "이메일 또는 아이디",
     "Password": "비밀번호",
     "PasswordARIA": "비밀번호",
-    "Submit": "로그인"
+    "Submit": "로그인",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
   },
   "LoginView": {
     "Title": "p5.js 웹에디터 | 로그인",
@@ -93,7 +108,34 @@
     "Examples": "예제",
     "PrivacyPolicy": "개인정보 처리방침",
     "TermsOfUse": "이용약관",
-    "CodeOfConduct": "행동 강령"
+    "CodeOfConduct": "행동 강령",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
+    },
+    "Contact": "Contact Us"
   },
   "Toast": {
     "OpenedNewSketch": "새 스케치 열기 완료.",
@@ -102,7 +144,12 @@
     "AutosaveEnabled": "자동 저장 활성화.",
     "LangChange": "언어 변경",
     "SettingsSaved": "설정 저장 완료.",
-    "CloseAlertARIA": "Close Alert"
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
   },
   "Toolbar": {
     "Preview": "미리보기",
@@ -114,7 +161,10 @@
     "EditSketchARIA": "스케치 이름 수정하기",
     "NewSketchNameARIA": "새로운 스케치 이름",
     "By": " 제작: ",
-    "SelectVersionARIA": "Select p5.js version"
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
   },
   "Console": {
     "Title": "콘솔",
@@ -167,7 +217,27 @@
     "TableText": "테이블 텍스트",
     "TableOutputARIA": "테이블 출력 켜기",
     "Sound": "소리",
-    "SoundOutputARIA": "소리 출력 켜기"
+    "SoundOutputARIA": "소리 출력 켜기",
+    "LibraryManagement": "Library Management",
+    "FontSize": "Font Size",
+    "SetFontSize": "set font size",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "AutocompleteHinterOnARIA": "autocomplete hinter on",
+    "AutocompleteHinterOffARIA": "autocomplete hinter off",
+    "LibraryVersion": "p5.js Version",
+    "LibraryVersionInfo": "There's a [new 2.0 release](https://github.com/processing/p5.js/releases/) of p5.js available! It will become default in August, 2026, so take this time to test it out and report bugs. Interested in transitioning sketches from 1.x to 2.0? Check out the [compatibility & transition resources.](https://github.com/processing/p5.js-compatibility)",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "SoundAddon": "p5.sound.js Add-on Library",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on Library — Preload",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on Library — Shapes",
+    "DataAddon": "p5.js 1.x Compatibility Add-on Library — Data & Events",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
   },
   "KeyboardShortcuts": {
     "Title": " 단축키",
@@ -184,14 +254,19 @@
       "CommentLine": "주석 처리",
       "FindNextTextMatch": "다음 텍스트 일치 항목 찾기",
       "FindPreviousTextMatch": "이전 텍스트 일치 항목 찾기",
-      "CodeEditing": "코드 편집"
+      "CodeEditing": "코드 편집",
+      "ColorPicker": "Show Inline Color Picker",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
     },
     "GeneralSelection": {
       "StartSketch": "스케치 시작",
       "StopSketch": "스케치 중지",
       "TurnOnAccessibleOutput": "접근 가능한 출력 활성화",
-      "TurnOffAccessibleOutput": "접근 가능한 출력 비활성화"
-    }
+      "TurnOffAccessibleOutput": "접근 가능한 출력 비활성화",
+      "Reference": "Go to Reference for Selected Item in Hinter"
+    },
+    "General": "General"
   },
   "Sidebar": {
     "Title": "Sketch Files",
@@ -201,7 +276,8 @@
     "AddFile": "Create file",
     "AddFileARIA": "add file",
     "UploadFile": "Upload file",
-    "UploadFileARIA": "upload file"
+    "UploadFileARIA": "upload file",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "Open folder contents",
@@ -277,7 +353,8 @@
     "errorNewPasswordRepeat": "Your New Password must differ from the current one.",
     "errorEmptyUsername": "Please enter a username.",
     "errorLongUsername": "Username must be less than 20 characters.",
-    "errorValidUsername": "Username must only consist of numbers, letters, periods, dashes, and underscores."
+    "errorValidUsername": "Username must only consist of numbers, letters, periods, dashes, and underscores.",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
   },
   "NewPasswordView": {
     "Title": "p5.js Web Editor | New Password",
@@ -299,7 +376,8 @@
     "CurrentPasswordARIA": "Current Password",
     "NewPassword": "New Password",
     "NewPasswordARIA": "New Password",
-    "SubmitSaveAllSettings": "Save All Settings"
+    "SubmitSaveAllSettings": "Save All Settings",
+    "SaveAccountDetails": "Save Account Details"
   },
   "AccountView": {
     "SocialLogin": "Social Login",
@@ -345,7 +423,11 @@
     "PasswordARIA": "password",
     "ConfirmPassword": "비밀번호 확인",
     "ConfirmPasswordARIA": "Confirm password",
-    "SubmitSignup": "회원가입"
+    "SubmitSignup": "회원가입",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": "p5.js 웹에디터 | 회원가입",
@@ -371,7 +453,8 @@
     "NoUploadedAssets": "No uploaded assets.",
     "HeaderName": "Name",
     "HeaderSize": "Size",
-    "HeaderSketch": "Sketch"
+    "HeaderSketch": "Sketch",
+    "maximum": "Maximum"
   },
   "Feedback": {
     "Title": "p5.js Web Editor | Feedback",
@@ -438,7 +521,8 @@
     "DirectionAscendingARIA": "Ascending",
     "DirectionDescendingARIA": "Descending",
     "ButtonLabelAscendingARIA": "Sort by {{displayName}} ascending.",
-    "ButtonLabelDescendingARIA": "Sort by {{displayName}} descending."
+    "ButtonLabelDescendingARIA": "Sort by {{displayName}} descending.",
+    "RemoveFromCollection": "Remove from Collection"
   },
   "AddToCollectionList": {
     "Title": "p5.js Web Editor | My collections",
@@ -581,7 +665,11 @@
     "UsedScreenReader": "Used with screen reader",
     "PlainText": "Plain-text",
     "TableText": "Table-text",
-    "Sound": "Sound"
+    "Sound": "Sound",
+    "SelectLanguage": "언어 선택",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "Preferences": "Preferences",
+    "Language": "Language"
   },
   "PreferenceCreators": {
     "On": "On",
@@ -601,5 +689,46 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "CodemirrorFindAndReplace": {
+    "ToggleReplace": "Toggle Replace",
+    "Find": "Find",
+    "FindPlaceholder": "Find in files",
+    "Replace": "Replace",
+    "ReplaceAll": "Replace All",
+    "ReplacePlaceholder": "Text to replace",
+    "Regex": "Regular expression",
+    "CaseSensitive": "Case sensitive",
+    "WholeWords": "Whole words",
+    "Previous": "Previous",
+    "Next": "Next",
+    "NoResults": "No results",
+    "Close": "Close"
+  },
+  "Cookies": {
+    "Header": "Cookies",
+    "Body": "The p5.js Editor uses cookies. Some are essential to the website functionality and allow you to manage an account and preferences. Others are not essential—they are used for analytics and allow us to learn more about our community. <strong> We never sell this data or use it for advertising. </strong> You can decide which cookies you would like to allow, and learn more in our <0>Privacy Policy<0>.",
+    "AllowAll": "Allow All",
+    "AllowEssential": "Allow Essential"
+  },
+  "Legal": {
+    "PrivacyPolicy": "Privacy Policy",
+    "TermsOfUse": "Terms of Use",
+    "CodeOfConduct": "Code of Conduct"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
 }

--- a/translations/locales/pt-BR/translations.json
+++ b/translations/locales/pt-BR/translations.json
@@ -8,7 +8,13 @@
       "Open": "Abrir",
       "Download": "Baixar",
       "AddToCollection": "Adicionar à Coleção",
-      "Examples": "Exemplos"
+      "Examples": "Exemplos",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "Editar",
@@ -42,8 +48,12 @@
       "MySketches": "Meus Esboços",
       "MyCollections": "Minhas Coleções",
       "MyAssets": "Meus Ativos",
-      "LogOut": "Sair"
-    }
+      "LogOut": "Sair",
+      "Welcome": "Welcome",
+      "My": "My",
+      "Asset": "Asset"
+    },
+    "Lang": "Language"
   },
   "Banner": {
     "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
@@ -60,7 +70,8 @@
     "Previous": "Anterior",
     "Next": "Próximo",
     "NoResults": "Não há resultados",
-    "Close": "Fechar"
+    "Close": "Fechar",
+    "Find": "Find"
   },
   "LoginForm": {
     "UsernameOrEmail": "Email ou Nome de Usuário",
@@ -70,7 +81,9 @@
     "Submit": "Entrar",
     "Errors": {
       "invalidCredentials": "Email ou senha inválido."
-    }
+    },
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password"
   },
   "LoginView": {
     "Title": "Editor Web p5.js | Entrar",
@@ -79,7 +92,9 @@
     "SignUp": "Registrar-se",
     "DontHaveAccount": "Não tem uma conta? ",
     "ForgotPassword": "Esqueceu sua senha? ",
-    "ResetPassword": "Recuperar sua senha"
+    "ResetPassword": "Recuperar sua senha",
+    "Email": "email",
+    "Username": "username"
   },
   "SocialAuthButton": {
     "Connect": "Conectar conta {{serviceauth}}",
@@ -130,7 +145,8 @@
       "Forum": "Expanda as possibilidades do p5.js com bibliotecas criadas pela comunidade.",
       "Discord": "Expanda as possibilidades do p5.js com bibliotecas criadas pela comunidade."
     },
-    "Contact": "Entre em Contato"
+    "Contact": "Entre em Contato",
+    "Learn": "Learn"
   },
   "Toast": {
     "OpenedNewSketch": "Novo esboço aberto.",
@@ -166,7 +182,9 @@
     "Clear": "Limpar",
     "ClearARIA": "Limpar terminal",
     "CloseARIA": "Fechar terminal",
-    "OpenARIA": "Abrir terminal"
+    "OpenARIA": "Abrir terminal",
+    "Close": "Close",
+    "Open": "Open"
   },
   "Preferences": {
     "Settings": "Configurações",
@@ -226,7 +244,9 @@
     "DataAddon": "Biblioteca adicional de Compatibilidade p5.js 1.x — Estruturas de Dados",
     "SoundReference": "Ver a referência para p5.sound compatível com p5.js {{version}}",
     "CopyToClipboardSuccess": "Copiado para a área de transferência!",
-    "CopyToClipboardFailure": "Não conseguimos copiar o texto, tente selecioná-lo e copiá-lo manualmente."
+    "CopyToClipboardFailure": "Não conseguimos copiar o texto, tente selecioná-lo e copiá-lo manualmente.",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off"
   },
   "KeyboardShortcuts": {
     "Title": " Atalhos de Teclado",
@@ -244,7 +264,9 @@
       "CodeEditing": "Edição de código",
       "ColorPicker": "Mostrar ferramenta seletora de cores",
       "CreateNewFile": "Criar novo arquivo",
-      "RenameVariable": "Renomear variável"
+      "RenameVariable": "Renomear variável",
+      "FindNextMatch": "Find Next Match",
+      "FindPrevMatch": "Find Previous Match"
     },
     "GeneralSelection": {
       "StartSketch": "Começar esboço",
@@ -263,7 +285,8 @@
     "AddFile": "Criar arquivo",
     "AddFileARIA": "adicionar arquivo",
     "UploadFile": "Carregar arquivo",
-    "UploadFileARIA": "carregar arquivo"
+    "UploadFileARIA": "carregar arquivo",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "Abrir conteúdos da pasta",
@@ -345,7 +368,10 @@
   "NewPasswordView": {
     "Title": "Editor Web p5.js | Nova Senha",
     "Description": "Definir a Nova Senha",
-    "TokenInvalidOrExpired": "O token de recuperação de senha é inválido ou expirou."
+    "TokenInvalidOrExpired": "O token de recuperação de senha é inválido ou expirou.",
+    "EmptyPassword": "Please enter a password",
+    "PasswordConfirmation": "Please confirm your password",
+    "PasswordMismatch": "Passwords must match"
   },
   "AccountForm": {
     "Email": "Email",
@@ -405,7 +431,11 @@
     "PasswordARIA": "senha",
     "ConfirmPassword": "Confirmar Senha",
     "ConfirmPasswordARIA": "Confirmar Senha",
-    "SubmitSignup": "Entrar"
+    "SubmitSignup": "Entrar",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": "Editor Web p5.js | Criar Conta",
@@ -435,7 +465,13 @@
     "maximum": "Máximo"
   },
   "Feedback": {
-    "Title": "Editor Web p5.js | Feedback"
+    "Title": "Editor Web p5.js | Feedback",
+    "ViaGithubHeader": "Via Github Issues",
+    "ViaGithubDescription": "If you're familiar with Github, this is our preferred method for receiving bug reports and feedback.",
+    "GoToGithub": "Go to Github",
+    "ViaGoogleHeader": "Via Google Form",
+    "ViaGoogleDescription": "You can also submit this quick form.",
+    "GoToForm": "Go to Form"
   },
   "Searchbar": {
     "SearchSketch": "Localizar esboços...",
@@ -487,11 +523,15 @@
     "DirectionAscendingARIA": "Ascendente",
     "DirectionDescendingARIA": "Descendente",
     "ButtonLabelAscendingARIA": "Ordenar por {{displayName}} ascendente.",
-    "ButtonLabelDescendingARIA": "Ordenar por {{displayName}} descendente."
+    "ButtonLabelDescendingARIA": "Ordenar por {{displayName}} descendente.",
+    "RemoveFromCollection": "Remove from Collection",
+    "Description": "description",
+    "NumSketches_plural": "{{count}} sketches"
   },
   "AddToCollectionList": {
     "Title": "Editor Web p5.js | Minhas coleções",
-    "Empty": "Não há coleções"
+    "Empty": "Não há coleções",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s collections"
   },
   "CollectionCreate": {
     "Title": "Editor Web p5.js | Criar coleção",
@@ -527,7 +567,10 @@
     "DirectionDescendingARIA": "Descendente",
     "ButtonLabelAscendingARIA": "Ordenar por {{displayName}} ascendente.",
     "ButtonLabelDescendingARIA": "Ordenar por {{displayName}} descendente.",
-    "AddSketch": "Adicionar esboço"
+    "AddSketch": "Adicionar esboço",
+    "HeaderCreatedAt_mobile": "Created",
+    "HeaderUpdatedAt_mobile": "Updated",
+    "HeaderNumItems_mobile": "# sketches"
   },
   "CollectionListRow": {
     "ToggleCollectionOptionsARIA": "Alternar entre abrir/fechar opções das coleções",
@@ -568,11 +611,15 @@
     "HeaderName": "Esboço",
     "HeaderCreatedAt": "Data adicionada",
     "HeaderUpdatedAt": "Data atualizada",
-    "NoSketches": "Nenhum esboço foi encontrado."
+    "NoSketches": "Nenhum esboço foi encontrado.",
+    "View": "View",
+    "HeaderCreatedAt_mobile": "Created",
+    "HeaderUpdatedAt_mobile": "Updated"
   },
   "AddToCollectionSketchList": {
     "Title": "Editor Web p5.js | Meus esboços",
-    "NoCollections": "Nenhuma coleção foi encontrada."
+    "NoCollections": "Nenhuma coleção foi encontrada.",
+    "AnothersTitle": "p5.js Web Editor | {{anotheruser}}'s sketches"
   },
   "Editor": {
     "OpenSketchARIA": "Abrir navegação de arquivos do esboço",
@@ -595,7 +642,8 @@
     "Ago": "{{timeAgo}} atrás"
   },
   "CopyableInput": {
-    "CopiedARIA": "Copiado para a Área de Transferência!"
+    "CopiedARIA": "Copiado para a Área de Transferência!",
+    "OpenViewTabARIA": "Open {{label}} view in new tab"
   },
   "EditableInput": {
     "EditValue": "Editar valor de {{display}}",
@@ -608,7 +656,24 @@
   "MobilePreferences": {
     "Settings": "Configurações",
     "Preferences": "Preferências",
-    "Language": "Idioma"
+    "Language": "Idioma",
+    "SelectLanguage": "Selecionar idioma",
+    "GeneralSettings": "General settings",
+    "Accessibility": "Accessibility",
+    "AccessibleOutput": "Accessible Output",
+    "Theme": "Theme",
+    "LightTheme": "Light",
+    "DarkTheme": "Dark",
+    "HighContrastTheme": "High Contrast",
+    "Autosave": "Autosave",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "WordWrap": "Word Wrap",
+    "LineNumbers": "Line numbers",
+    "LintWarningSound": "Lint warning sound",
+    "UsedScreenReader": "Used with screen reader",
+    "PlainText": "Plain-text",
+    "TableText": "Table-text",
+    "Sound": "Sound"
   },
   "PreferenceCreators": {
     "On": "Ligado",
@@ -642,5 +707,21 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "CollectionView": {
+    "TitleCreate": "Create collection",
+    "TitleDefault": "collection"
+  },
+  "MobileDashboardView": {
+    "Examples": "Examples",
+    "Sketches": "Sketches",
+    "Collections": "Collections",
+    "Assets": "Assets",
+    "MyStuff": "My Stuff",
+    "CreateSketch": "Create Sketch",
+    "CreateCollection": "Create Collection"
+  },
+  "Explorer": {
+    "Files": "Files"
   }
 }

--- a/translations/locales/sv/translations.json
+++ b/translations/locales/sv/translations.json
@@ -8,7 +8,13 @@
       "Open": "Öppna",
       "Download": "Ladda ner",
       "AddToCollection": "Lägg till i samling",
-      "Examples": "Exempel"
+      "Examples": "Exempel",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "Redigera",
@@ -27,7 +33,10 @@
       "Title": "Hjälp",
       "KeyboardShortcuts": "Tangentbordsgenvägar",
       "Reference": "Referens",
-      "About": "Om"
+      "About": "Om",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
     "Lang": "Språk",
     "BackEditor": "Tillbaka till editor",
@@ -70,7 +79,12 @@
     "UsernameOrEmailARIA": "E-post eller användarnamn",
     "Password": "Lösenord",
     "PasswordARIA": "Lösenord",
-    "Submit": "Logga in"
+    "Submit": "Logga in",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
   },
   "LoginView": {
     "Title": "p5.js Webb editor | Logga in",
@@ -107,7 +121,34 @@
     "Examples": "Exempel",
     "PrivacyPolicy": "Integritetspolicy",
     "TermsOfUse": "Användarvillkor",
-    "CodeOfConduct": "Uppförandekod"
+    "CodeOfConduct": "Uppförandekod",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
+    },
+    "Contact": "Contact Us"
   },
   "Toast": {
     "OpenedNewSketch": "Öppnat ny sketch.",
@@ -116,7 +157,12 @@
     "AutosaveEnabled": "Autospara aktiverat.",
     "LangChange": "Språk bytt.",
     "SettingsSaved": "Sparat inställningar.",
-    "CloseAlertARIA": "Close Alert"
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
   },
   "Toolbar": {
     "Preview": "Förhandsvisning",
@@ -128,7 +174,10 @@
     "EditSketchARIA": "Redigera sketchnamn",
     "NewSketchNameARIA": "Nytt sketchnamn",
     "By": " av ",
-    "SelectVersionARIA": "Select p5.js version"
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
   },
   "Console": {
     "Title": "Konsoll",
@@ -179,7 +228,27 @@
     "PlainText": "Oformatterad text",
     "TextOutputARIA": "text-output på",
     "TableText": "Tabelltext",
-    "TableOutputARIA": "tabell-output på"
+    "TableOutputARIA": "tabell-output på",
+    "LibraryManagement": "Library Management",
+    "FontSize": "Font Size",
+    "SetFontSize": "set font size",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "AutocompleteHinterOnARIA": "autocomplete hinter on",
+    "AutocompleteHinterOffARIA": "autocomplete hinter off",
+    "LibraryVersion": "p5.js Version",
+    "LibraryVersionInfo": "There's a [new 2.0 release](https://github.com/processing/p5.js/releases/) of p5.js available! It will become default in August, 2026, so take this time to test it out and report bugs. Interested in transitioning sketches from 1.x to 2.0? Check out the [compatibility & transition resources.](https://github.com/processing/p5.js-compatibility)",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "SoundAddon": "p5.sound.js Add-on Library",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on Library — Preload",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on Library — Shapes",
+    "DataAddon": "p5.js 1.x Compatibility Add-on Library — Data & Events",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
   },
   "KeyboardShortcuts": {
     "Title": "Tangentbordsgenvägar",
@@ -196,14 +265,19 @@
       "CommentLine": "Kommentera rad",
       "FindNextTextMatch": "Sök nästa textmatchning",
       "FindPreviousTextMatch": "Sök föregående textmatchning",
-      "CodeEditing": "kodredigering"
+      "CodeEditing": "kodredigering",
+      "ColorPicker": "Show Inline Color Picker",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
     },
     "GeneralSelection": {
       "StartSketch": "Kör sketch",
       "StopSketch": "Stoppa sketch",
       "TurnOnAccessibleOutput": "Sätt på tillgänglig output",
-      "TurnOffAccessibleOutput": "Stäng av tillgänglig output"
-    }
+      "TurnOffAccessibleOutput": "Stäng av tillgänglig output",
+      "Reference": "Go to Reference for Selected Item in Hinter"
+    },
+    "General": "General"
   },
   "Sidebar": {
     "Title": "Sketchfiler",
@@ -213,7 +287,8 @@
     "AddFile": "Skapa fil",
     "AddFileARIA": "skapa fil",
     "UploadFile": "Ladda upp fil",
-    "UploadFileARIA": "ladda upp fil"
+    "UploadFileARIA": "ladda upp fil",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "Öppna mapp",
@@ -289,7 +364,8 @@
     "errorNewPasswordRepeat": "Your New Password must differ from the current one.",
     "errorEmptyUsername": "Ange ett användarnamn.",
     "errorLongUsername": "Användarnamnet får innehålla högst 19 tecken.",
-    "errorValidUsername": "Användarnamnet får bara innehålla siffror, bokstäver, punkter, bindestreck och understreck."
+    "errorValidUsername": "Användarnamnet får bara innehålla siffror, bokstäver, punkter, bindestreck och understreck.",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
   },
   "NewPasswordView": {
     "Title": "p5.js Webb editor | Nytt lösenord",
@@ -311,7 +387,8 @@
     "CurrentPasswordARIA": "Nuvarande lösenord",
     "NewPassword": "Nytt lösenord",
     "NewPasswordARIA": "Nytt lösenord",
-    "SubmitSaveAllSettings": "Spara alla inställningar"
+    "SubmitSaveAllSettings": "Spara alla inställningar",
+    "SaveAccountDetails": "Save Account Details"
   },
   "AccountView": {
     "SocialLogin": "Social inloggning",
@@ -357,14 +434,19 @@
     "PasswordARIA": "lösenord",
     "ConfirmPassword": "Bekräfta lösenord",
     "ConfirmPasswordARIA": "Bekräfta lösenord",
-    "SubmitSignup": "Registrera dig"
+    "SubmitSignup": "Registrera dig",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": "p5.js Webb editor | Registrering",
     "Description": "Registrering",
     "Or": "Eller",
     "AlreadyHave": "Har du redan ett konto?",
-    "Login": "Logga in"
+    "Login": "Logga in",
+    "Warning": "By signing up, you agree to the p5.js Editor's <0>Terms of Use</0> and <1>Privacy Policy.</1>"
   },
   "EmailVerificationView": {
     "Title": "p5.js Webb editor | E-postbekräftelse",
@@ -382,7 +464,8 @@
     "NoUploadedAssets": "Inga uppladdade resurser.",
     "HeaderName": "Namn",
     "HeaderSize": "Storlek",
-    "HeaderSketch": "Sketch"
+    "HeaderSketch": "Sketch",
+    "maximum": "Maximum"
   },
   "Feedback": {
     "Title": "p5.js Webb editor | Feedback",
@@ -449,7 +532,8 @@
     "DirectionAscendingARIA": "Stigande",
     "DirectionDescendingARIA": "Fallande",
     "ButtonLabelAscendingARIA": "Sortera efter {{displayName}} stigande.",
-    "ButtonLabelDescendingARIA": "Sortera efter {{displayName}} fallande."
+    "ButtonLabelDescendingARIA": "Sortera efter {{displayName}} fallande.",
+    "RemoveFromCollection": "Remove from Collection"
   },
   "AddToCollectionList": {
     "Title": "p5.js Webb editor | Mina samlingar",
@@ -592,7 +676,11 @@
     "UsedScreenReader": "Använd med skärmläsare",
     "PlainText": "Oformatterad text",
     "TableText": "tabelltext",
-    "Sound": "Ljud"
+    "Sound": "Ljud",
+    "SelectLanguage": "Välj språk",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "Preferences": "Preferences",
+    "Language": "Language"
   },
   "PreferenceCreators": {
     "On": "På",
@@ -623,5 +711,20 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
 }

--- a/translations/locales/tr/translations.json
+++ b/translations/locales/tr/translations.json
@@ -8,7 +8,13 @@
       "Open": "Aç",
       "Download": "İndir",
       "AddToCollection": "Koleksiyona Ekle",
-      "Examples": "Örnekler"
+      "Examples": "Örnekler",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "Düzenle",
@@ -27,7 +33,10 @@
       "Title": "Yardım",
       "KeyboardShortcuts": "Klavye Kısayolları",
       "Reference": "Referans",
-      "About": "Hakkında"
+      "About": "Hakkında",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
     "Lang": "Dil",
     "BackEditor": "Editöre Dön",
@@ -70,7 +79,12 @@
     "UsernameOrEmailARIA": "E-posta veya Kullanıcı Adı",
     "Password": "Parola",
     "PasswordARIA": "Parola",
-    "Submit": "Giriş Yap"
+    "Submit": "Giriş Yap",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
   },
   "LoginView": {
     "Title": "p5.js Web Editör | Giriş",
@@ -107,7 +121,34 @@
     "Examples": "Örnekler",
     "PrivacyPolicy": "Gizlilik Politikası",
     "TermsOfUse": "Kullanım Şartları",
-    "CodeOfConduct": "Davranış Kuralları"
+    "CodeOfConduct": "Davranış Kuralları",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
+    },
+    "Contact": "Contact Us"
   },
   "Toast": {
     "OpenedNewSketch": "Yeni eskiz açıldı.",
@@ -116,7 +157,12 @@
     "AutosaveEnabled": "Otomatik kaydetme etkin.",
     "LangChange": "Dil değiştirildi",
     "SettingsSaved": "Ayarlar kaydedildi.",
-    "CloseAlertARIA": "Close Alert"
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
   },
   "Toolbar": {
     "Preview": "Önizleme",
@@ -128,7 +174,10 @@
     "EditSketchARIA": "Eskiz Adını Düzenle",
     "NewSketchNameARIA": "Yeni Eskiz Adı",
     "By": " tarafından ",
-    "SelectVersionARIA": "Select p5.js version"
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
   },
   "Console": {
     "Title": "Konsol",
@@ -181,7 +230,25 @@
     "PlainText": "Düz Metin",
     "TextOutputARIA": "metin çıktısı açık",
     "TableText": "Tablo Metni",
-    "TableOutputARIA": "tablo çıktısı açık"
+    "TableOutputARIA": "tablo çıktısı açık",
+    "LibraryManagement": "Library Management",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "AutocompleteHinterOnARIA": "autocomplete hinter on",
+    "AutocompleteHinterOffARIA": "autocomplete hinter off",
+    "LibraryVersion": "p5.js Version",
+    "LibraryVersionInfo": "There's a [new 2.0 release](https://github.com/processing/p5.js/releases/) of p5.js available! It will become default in August, 2026, so take this time to test it out and report bugs. Interested in transitioning sketches from 1.x to 2.0? Check out the [compatibility & transition resources.](https://github.com/processing/p5.js-compatibility)",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "SoundAddon": "p5.sound.js Add-on Library",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on Library — Preload",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on Library — Shapes",
+    "DataAddon": "p5.js 1.x Compatibility Add-on Library — Data & Events",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
   },
   "KeyboardShortcuts": {
     "Title": " Klavye Kısayolları",
@@ -199,14 +266,18 @@
       "FindNextTextMatch": "Sonraki Metin Eşleşmesini Bul",
       "FindPreviousTextMatch": "Önceki Metin Eşleşmesini Bul",
       "CodeEditing": "Kod Düzenleme",
-      "ColorPicker": "Satır İçi Renk Seçiciyi Göster"
+      "ColorPicker": "Satır İçi Renk Seçiciyi Göster",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
     },
     "GeneralSelection": {
       "StartSketch": "Eskizi Başlat",
       "StopSketch": "Eskizi Durdur",
       "TurnOnAccessibleOutput": "Erişilebilir Çıktıyı Aç",
-      "TurnOffAccessibleOutput": "Erişilebilir Çıktıyı Kapat"
-    }
+      "TurnOffAccessibleOutput": "Erişilebilir Çıktıyı Kapat",
+      "Reference": "Go to Reference for Selected Item in Hinter"
+    },
+    "General": "General"
   },
   "Sidebar": {
     "Title": "Eskiz Dosyaları",
@@ -216,7 +287,8 @@
     "AddFile": "Dosya Oluştur",
     "AddFileARIA": "dosya ekle",
     "UploadFile": "Dosya Yükle",
-    "UploadFileARIA": "dosya yükle"
+    "UploadFileARIA": "dosya yükle",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "Klasör İçeriğini Aç",
@@ -292,7 +364,8 @@
     "errorNewPasswordRepeat": "Your New Password must differ from the current one.",
     "errorEmptyUsername": "Lütfen bir kullanıcı adı girin.",
     "errorLongUsername": "Kullanıcı adı 20 karakterden az olmalıdır.",
-    "errorValidUsername": "Kullanıcı adı sadece sayılar, harfler, noktalar, tireler ve alt çizgilerden oluşmalıdır."
+    "errorValidUsername": "Kullanıcı adı sadece sayılar, harfler, noktalar, tireler ve alt çizgilerden oluşmalıdır.",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
   },
   "NewPasswordView": {
     "Title": "p5.js Web Düzenleyici | Yeni Şifre",
@@ -314,7 +387,8 @@
     "CurrentPasswordARIA": "Mevcut Şifre",
     "NewPassword": "Yeni Şifre",
     "NewPasswordARIA": "Yeni Şifre",
-    "SubmitSaveAllSettings": "Tüm Ayarları Kaydet"
+    "SubmitSaveAllSettings": "Tüm Ayarları Kaydet",
+    "SaveAccountDetails": "Save Account Details"
   },
   "AccountView": {
     "SocialLogin": "Sosyal Giriş",
@@ -360,7 +434,11 @@
     "PasswordARIA": "şifre",
     "ConfirmPassword": "Şifreyi Onayla",
     "ConfirmPasswordARIA": "şifreyi onayla",
-    "SubmitSignup": "Kaydol"
+    "SubmitSignup": "Kaydol",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": "p5.js Web Düzenleyicisi | Kaydol",
@@ -386,7 +464,8 @@
     "NoUploadedAssets": "Yüklenen varlık yok.",
     "HeaderName": "Adı",
     "HeaderSize": "Boyutu",
-    "HeaderSketch": "Eskiz"
+    "HeaderSketch": "Eskiz",
+    "maximum": "Maximum"
   },
   "Feedback": {
     "Title": "p5.js Web Düzenleyicisi | Geri Bildirim",
@@ -453,7 +532,8 @@
     "DirectionAscendingARIA": "Artan sıralama",
     "DirectionDescendingARIA": "Azalan sıralama",
     "ButtonLabelAscendingARIA": "{{displayName}} artan sıralama.",
-    "ButtonLabelDescendingARIA": "{{displayName}} azalan sıralama."
+    "ButtonLabelDescendingARIA": "{{displayName}} azalan sıralama.",
+    "RemoveFromCollection": "Remove from Collection"
   },
   "AddToCollectionList": {
     "Title": "p5.js Web Düzenleyicisi | Benim koleksiyonlarım",
@@ -596,7 +676,11 @@
     "UsedScreenReader": "Ekran Okuyucu ile kullanıldı",
     "PlainText": "Düz Metin",
     "TableText": "Tablo Metni",
-    "Sound": "Ses"
+    "Sound": "Ses",
+    "SelectLanguage": "Dil Seçin",
+    "AutocompleteHinter": "Autocomplete Hinter",
+    "Preferences": "Preferences",
+    "Language": "Language"
   },
   "PreferenceCreators": {
     "On": "Açık",
@@ -627,5 +711,20 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
 }

--- a/translations/locales/uk-UA/translations.json
+++ b/translations/locales/uk-UA/translations.json
@@ -8,7 +8,13 @@
       "Open": "Відкрити",
       "Download": "Завантажити",
       "AddToCollection": "Додати у колекцію",
-      "Examples": "Приклади"
+      "Examples": "Приклади",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "Редагувати",
@@ -27,7 +33,10 @@
       "Title": "Довідка",
       "KeyboardShortcuts": "Сполучення клавіш",
       "Reference": "Довідник з функцій",
-      "About": "Про p5.js"
+      "About": "Про p5.js",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
     "Lang": "Мова",
     "BackEditor": "Повернутися в редактор",
@@ -73,7 +82,9 @@
     "Submit": "Увійти",
     "Errors": {
       "invalidCredentials": "Неправильна електронна пошта або пароль."
-    }
+    },
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password"
   },
   "LoginView": {
     "Title": "p5.js вебредактор | Вхід",
@@ -95,11 +106,11 @@
   "About": {
     "Title": "Про редактор",
     "TitleHelmet": "p5.js вебредактор | Про редактор",
-	"Headline": "Створюй, поширюй та реміксуй скетчі p5.js за допомогою редактора p5.js.",
+    "Headline": "Створюй, поширюй та реміксуй скетчі p5.js за допомогою редактора p5.js.",
     "Contribute": "Внесок",
-	"IntroDescription1": "p5.js — це безплатна бібліотека JavaScript з відкритим кодом для навчання програмуванню та створення мистецтва. За допомогою редактора p5.js ви можете створювати, поширювати та реміксувати скетчі p5.js без потреби щось завантажувати чи налаштовувати.",
+    "IntroDescription1": "p5.js — це безплатна бібліотека JavaScript з відкритим кодом для навчання програмуванню та створення мистецтва. За допомогою редактора p5.js ви можете створювати, поширювати та реміксувати скетчі p5.js без потреби щось завантажувати чи налаштовувати.",
     "IntroDescription2": "Ми хочемо, щоб програмування та інструменти для його вивчення були відкритими й доступними. Підтримайте p5.js, зробивши внесок на користь Processing Foundation — це допоможе розвивати бібліотеку, створювати навчальні матеріали та проводити події для спільноти.",
-	"Donate": "Підтримати",
+    "Donate": "Підтримати",
     "NewP5": "Початківець в p5.js?",
     "Report": "Повідомити про помилку",
     "Learn": "Посібники",
@@ -107,21 +118,21 @@
     "Home": "Головна",
     "Instagram": "Instagram",
     "Discord": "Discord",
-	"DiscordCTA": "Доєднуйтесь у Discord",
-	"Youtube": "Youtube",
+    "DiscordCTA": "Доєднуйтесь у Discord",
+    "Youtube": "Youtube",
     "Github": "Github",
     "GetInvolved": "Долучитися",
     "WebEditor": "Вебредактор",
     "Resources": "Ресурси",
-	"Reference": "Довідка",
+    "Reference": "Довідка",
     "Libraries": "Бібліотеки",
     "Forum": "Форум",
-	"ForumCTA": "Приєднатися до форуму",
+    "ForumCTA": "Приєднатися до форуму",
     "Examples": "Приклади",
     "PrivacyPolicy": "Політика конфіденційності",
     "TermsOfUse": "Умови використання",
     "CodeOfConduct": "Кодекс поведінки",
-	"Email": "Електронна пошта",
+    "Email": "Електронна пошта",
     "EmailAddress": "hello@p5js.org",
     "Socials": "Соціальні мережі",
     "LinkDescriptions": {
@@ -135,7 +146,8 @@
       "Report": "Повідомте про помилку в редакторі p5.js.",
       "Forum": "Розширте можливості p5.js за допомогою бібліотек, створених спільнотою.",
       "Discord": "Розширте можливості p5.js за допомогою бібліотек, створених спільнотою."
-    }
+    },
+    "Contact": "Contact Us"
   },
   "Toast": {
     "OpenedNewSketch": "Відкрито новий скетч.",
@@ -144,7 +156,7 @@
     "AutosaveEnabled": "Автозбереження увімкнено.",
     "LangChange": "Мова змінена",
     "SettingsSaved": "Налаштування збережено.",
-	"EmptyCurrentPass": "Ви не ввели пароль.",
+    "EmptyCurrentPass": "Ви не ввели пароль.",
     "IncorrectCurrentPass": "Поточний пароль неправильний",
     "DefaultError": "Щось пішло не так",
     "UserNotFound": "Користувача не знайдено",
@@ -161,7 +173,7 @@
     "EditSketchARIA": "Редагувати ім'я скетча",
     "NewSketchNameARIA": "Нове ім'я скетча",
     "By": " користувачем ",
-	"CustomLibraryVersion": "Вибрана версія p5.js",
+    "CustomLibraryVersion": "Вибрана версія p5.js",
     "VersionPickerARIA": "Вибір версії",
     "NewVersionPickerARIA": "Вибір версії",
     "SelectVersionARIA": "Select p5.js version"
@@ -179,7 +191,7 @@
     "Settings": "Налаштування",
     "GeneralSettings": "Загальні налаштування",
     "Accessibility": "Інші параметри",
-	"LibraryManagement": "Управління бібліотекою",
+    "LibraryManagement": "Управління бібліотекою",
     "Theme": "Тема",
     "LightTheme": "Світла",
     "LightThemeARIA": "світла тема на",
@@ -192,7 +204,7 @@
     "DecreaseFontARIA": "зменшити розмір шрифту",
     "IncreaseFont": "Збільшити",
     "IncreaseFontARIA": "збільшити розмір шрифту",
-	"FontSize": "Розмір шрифту",
+    "FontSize": "Розмір шрифту",
     "SetFontSize": "встановити розмір шрифту",
     "Autosave": "Автозбереження",
     "On": "Так",
@@ -202,7 +214,7 @@
     "AutocloseBracketsQuotes": "Автоматичне закриття дужок та лапок",
     "AutocloseBracketsQuotesOnARIA": "автоматично закривати дужки та лапки",
     "AutocloseBracketsQuotesOffARIA": "автоматично закривати дужки та лапки",
-	"AutocompleteHinter": "Автозаповнення коду",
+    "AutocompleteHinter": "Автозаповнення коду",
     "AutocompleteHinterOnARIA": "автозаповнення коду увімкено",
     "AutocompleteHinterOffARIA": "автозаповнення коду вимкнено",
     "WordWrap": "Перенесення слів",
@@ -222,12 +234,12 @@
     "TextOutputARIA": "текст виводиться на",
     "TableText": "Таблиця",
     "TableOutputARIA": "виведення таблиці на",
-	"LibraryVersion": "Версія p5.js",
+    "LibraryVersion": "Версія p5.js",
     "LibraryVersionInfo": "Доступний [новий реліз 2.0](https://github.com/processing/p5.js/releases/) p5.js! Він стане стандартним у серпні 2026 року, тож скористайтеся цим часом, щоб протестувати його та повідомити про помилки. Зацікавлені в переході скетчів з 1.x на 2.0? Перегляньте [ресурсів сумісності та переходу.](https://github.com/processing/p5.js-compatibility)",
     "CustomVersionTitle": "Керувати власними бібліотеками? Чудово!",
     "CustomVersionInfo": "Версія p5.js наразі керується у коді файлу index.html. Це означає, що її не можна змінити з цієї вкладки.",
     "CustomVersionReset": "Якщо ви хочете використовувати стандартні бібліотеки, замініть теги <script> у файлі index.html на наступні:",
-	"SoundAddon": "p5.sound.js Add-on Library",
+    "SoundAddon": "p5.sound.js Add-on Library",
     "PreloadAddon": "p5.js 1.x Compatibility Add-on Library — Preload",
     "ShapesAddon": "p5.js 1.x Compatibility Add-on Library — Shapes",
     "DataAddon": "p5.js 1.x Compatibility Add-on Library — Data Structures",
@@ -253,16 +265,17 @@
       "FindNextTextMatch": "Знайти наступний збіг тексту",
       "FindPreviousTextMatch": "Знайти попередній збіг тексту",
       "CodeEditing": "Редагування коду",
-	  "ColorPicker": "Вибір кольору",
-      "CreateNewFile": "Створити новий файл"
+      "ColorPicker": "Вибір кольору",
+      "CreateNewFile": "Створити новий файл",
+      "RenameVariable": "Rename Variable"
     },
-	"General": "Загальне",
+    "General": "Загальне",
     "GeneralSelection": {
       "StartSketch": "Запустити",
       "StopSketch": "Зупинити",
       "TurnOnAccessibleOutput": "Увімкнути доступне виведення",
       "TurnOffAccessibleOutput": "Вимкнути доступне виведення",
-	  "Reference": "Перейти до довідки для обраного елемента"
+      "Reference": "Перейти до довідки для обраного елемента"
     }
   },
   "Sidebar": {
@@ -273,7 +286,8 @@
     "AddFile": "Додати файл",
     "AddFileARIA": "додати файл",
     "UploadFile": "Завантажити файл",
-    "UploadFileARIA": "завантажити файл"
+    "UploadFileARIA": "завантажити файл",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "Показати вміст теки",
@@ -341,7 +355,7 @@
   "ReduxFormUtils": {
     "errorInvalidEmail": "Будь ласка, введіть дійсну адресу електронної пошти",
     "errorEmptyEmail": "Введіть адресу електронної пошти",
-	"errorEmptyEmailorUserName": "Будь ласка, введіть електронну пошту або ім'я користувача",
+    "errorEmptyEmailorUserName": "Будь ласка, введіть електронну пошту або ім'я користувача",
     "errorPasswordMismatch": "Паролі повинні збігатися",
     "errorEmptyPassword": "Введіть пароль",
     "errorShortPassword": "Пароль повинен містити щонайменше 6 символів",
@@ -372,7 +386,8 @@
     "CurrentPasswordARIA": "Поточний пароль",
     "NewPassword": "Новий пароль",
     "NewPasswordARIA": "Новий пароль",
-    "SubmitSaveAllSettings": "Зберегти всі налаштування"
+    "SubmitSaveAllSettings": "Зберегти всі налаштування",
+    "SaveAccountDetails": "Save Account Details"
   },
   "AccountView": {
     "SocialLogin": "Увійти через соціальну мережу",
@@ -418,7 +433,11 @@
     "PasswordARIA": "пароль",
     "ConfirmPassword": "Підтвердити пароль",
     "ConfirmPasswordARIA": "Підтвердити пароль",
-    "SubmitSignup": "Зареєструватися"
+    "SubmitSignup": "Зареєструватися",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": "p5.js вебредактор | Реєстрація",
@@ -426,7 +445,7 @@
     "Or": "Або",
     "AlreadyHave": "Ви вже маєте акаунт? ",
     "Login": "Увійти",
-	"Warning": "Реєструючись, ви погоджуєтеся з <0>Умовами використання</0> та <1>Політикою конфіденційності редактора p5.js.</1>"
+    "Warning": "Реєструючись, ви погоджуєтеся з <0>Умовами використання</0> та <1>Політикою конфіденційності редактора p5.js.</1>"
   },
   "EmailVerificationView": {
     "Title": "p5.js вебредактор | Підтвердження електронної пошти",
@@ -444,7 +463,8 @@
     "NoUploadedAssets": "Файли відсутні.",
     "HeaderName": "Ім'я",
     "HeaderSize": "Обсяг",
-    "HeaderSketch": "Скетч"
+    "HeaderSketch": "Скетч",
+    "maximum": "Maximum"
   },
   "Feedback": {
     "Title": "p5.js вебредактор | Зворотний зв'язок",
@@ -511,7 +531,8 @@
     "DirectionAscendingARIA": "За зростанням",
     "DirectionDescendingARIA": "За спаданням",
     "ButtonLabelAscendingARIA": "Сортувати {{displayName}} за зростанням.",
-    "ButtonLabelDescendingARIA": "Сортувати {{displayName}} за спаданням."
+    "ButtonLabelDescendingARIA": "Сортувати {{displayName}} за спаданням.",
+    "RemoveFromCollection": "Remove from Collection"
   },
   "AddToCollectionList": {
     "Title": "p5.js вебредактор | Мої колекції",
@@ -648,14 +669,17 @@
     "DarkTheme": "Темна",
     "HighContrastTheme": "Високий контраст",
     "Autosave": "Автозбереження",
-	"AutocompleteHinter": "Автозаповнення коду",
+    "AutocompleteHinter": "Автозаповнення коду",
     "WordWrap": "Переноси слів",
     "LineNumbers": "Номери рядків",
     "LintWarningSound": "Звук попередження",
     "UsedScreenReader": "Використовується з програмою зчитування з екрана",
     "PlainText": "Простий текст",
     "TableText": "Текст у таблиці",
-    "Sound": "Звук"
+    "Sound": "Звук",
+    "SelectLanguage": "Виберіть мову",
+    "Preferences": "Preferences",
+    "Language": "Language"
   },
   "PreferenceCreators": {
     "On": "Так",
@@ -689,5 +713,17 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
 }

--- a/translations/locales/ur/translations.json
+++ b/translations/locales/ur/translations.json
@@ -1,630 +1,729 @@
 {
-    "Nav": {
-      "File": {
-        "Title": "فائل",
-        "New": "نئی",
-        "Share": "بانٹیں",
-        "Duplicate": "نقل",
-        "Open": "کھولیں۔",
-        "Download": "ڈاؤن لوڈ کریں",
-        "AddToCollection": "مجموعہ میں شامل کریں۔",
-        "Examples": "مثالیں"
-      },
-      "Edit": {
-        "Title": "ترمیم",
-        "TidyCode": "کوڈ کو صاف و ستھرا کریں",
-        "Find": "تلاش کریں",
-        "Replace": "بدل دیں"
-      },      
-      "Sketch": {
-        "Title": "خاکہ",
-        "AddFile": "فائل شامل کریں",
-        "AddFolder": "فولڈر بنائیں",
-        "Run": "رن",
-        "Stop": "رک جائیں"
-      },          
-      "Help": {
-        "Title": "مدد",
-        "KeyboardShortcuts": "کی بورڈ شارٹ کٹس",
-        "Reference": "حوالہ",
-        "About": "کے بارے میں"
-      },
-      "Lang": "زبان",
-      "BackEditor": "واپس ایڈیٹر پر",
-      "WarningUnsavedChanges": "کیا آپ واقعی یہ صفحہ چھوڑنا چاہتے ہیں؟ ",
-      "Login": "لاگ ان کریں",
-      "LoginOr": "یا",
-      "SignUp": "سائن اپ",
-      "Auth": {
-        "Welcome": "خوش آمدید",
-        "Hello": "ہیلو",
-        "MyAccount": "میرا اکاونٹ",
-        "My": "میرا",
-        "MySketches": "میرے خاکے",
-        "MyCollections": "میرے مجموعے",
-        "Asset": "اثاثہ",
-        "MyAssets": "میرے اثاثے",
-        "LogOut": "لاگ آوٹ"
-      }
-    },
-    "Banner": {
-      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
-    },
-    "CodemirrorFindAndReplace": {
-      "ToggleReplace": "تبدیل کرنے کو ٹوگل کریں۔",
-      "Find": "تلاش کریں",
-      "FindPlaceholder": "فائلوں میں تلاش کریں۔",
-      "Replace": "بدل دیں۔",
-      "ReplaceAll": "سبھی کو تبدیل کریں۔",
-      "ReplacePlaceholder": "تبدیل کرنے کے لیے متن",
-      "Regex": "باقاعدہ اظہار",
-      "CaseSensitive": "حساس کیس",
-      "WholeWords": "پورے الفاظ",
-      "Previous": "پچھلا",
-      "Next": "اگلے",
-      "NoResults": "کوئی نتیجہ نہیں نکلا۔",
-      "Close": "بند کریں"
-    },
-    "LoginForm": {
-      "UsernameOrEmail": "ای میل یا اسم صارف",
-      "UsernameOrEmailARIA": "ای میل یا اسم صارف",
-      "Password": "پاس ورڈ",
-      "PasswordARIA": "پاس ورڈ",
-      "Submit": "لاگ ان کریں"
-    },
-    "LoginView": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "Login": "لاگ ان کریں",
-      "LoginOr": "یا",
-      "SignUp": "سائن اپ",
-      "Email": "ای میل",
-      "Username": "صارف نام",
-      "DontHaveAccount": "اکاؤنٹ نہیں ہے؟ ",
-      "ForgotPassword": "اپنا پاس ورڈ بھول گئے؟ ",
-      "ResetPassword": "آپ کا پاس ورڈ دوبارہ ترتیب دیں"
-    },
-    "SocialAuthButton": {
-      "Connect": "جڑیں۔ {{serviceauth}} کھاتہ",
-      "Unlink": "لنک ختم کریں۔ {{serviceauth}} کھاتہ",
-      "Login": "کے ساتھ لاگ ان {{serviceauth}}",
-      "LogoARIA": "{{serviceauth}} لوگو"
-    },
-    "About": {
-      "Title": "کے بارے میں",
-      "TitleHelmet": "p5.js ویب ایڈیٹر | ",
-      "Contribute": "تعاون کریں۔",
-      "NewP5": "p5.js میں نئے ہیں؟",
-      "Report": "ایک بگ کی اطلاع دیں۔",
-      "Learn": "سیکھیں۔",
-      "Resources": "حوالہ جات",
-      "Libraries": "لائبریریاں",
-      "Forum": "فورم",
-      "Examples": "مثالیں",
-      "PrivacyPolicy": "رازداری کی پالیسی",
-      "TermsOfUse": "استعمال کرنے کی شرائط",
-      "CodeOfConduct": "ضابطہ اخلاق"
-    },
-    "Toast": {
-      "OpenedNewSketch": "نیا خاکہ کھولا۔",
-      "SketchSaved": "خاکہ محفوظ ہو گیا۔",
-      "SketchFailedSave": "خاکہ محفوظ کرنے میں ناکام۔",
-      "AutosaveEnabled": "خودکار محفوظ کرنا فعال ہے۔",
-      "LangChange": "زبان بدل گئی۔",
-      "SettingsSaved": "ترتیبات محفوظ ہو گئیں۔",
-      "CloseAlertARIA": "Close Alert"
-    },
-    "Toolbar": {
-        "Preview": "پیش نظارہ",
-        "Auto-refresh": "آٹو ریفریش",
-        "OpenPreferencesARIA": "ترجیحات کھولیں۔",
-        "PlaySketchARIA": "خاکہ چلائیں۔",
-        "PlayOnlyVisualSketchARIA": "صرف بصری خاکہ چلائیں۔",
-        "StopSketchARIA": "خاکہ بنانا بند کریں",
-        "EditSketchARIA": "خاکے کے نام میں ترمیم کریں۔",
-        "NewSketchNameARIA": "خاکے کا نیا نام",
-        "By": " کی طرف سے ",
-        "SelectVersionARIA": "Select p5.js version"
-      },      
-    "Console": {
-      "Title": "تسلی",
-      "Clear": "صاف",
-      "ClearARIA": "کنسول صاف کریں۔",
-      "Close": "بند کریں",
-      "CloseARIA": "کنسول بند کریں۔",
-      "Open": "کھولیں۔",
-      "OpenARIA": "کنسول کھولیں۔"
-    },
-    "Preferences": {
-      "Settings": "ترتیبات",
-      "GeneralSettings": "عام ترتیبات",
-      "Accessibility": "رسائی",
-      "Theme": "خیالیہ",
-      "LightTheme": "روشنی",
-      "LightThemeARIA": "ہلکی تھیم آن",
-      "DarkTheme": "اندھیرا",
-      "DarkThemeARIA": "سیاہ تھیم آن",
-      "HighContrastTheme": "ہائی کنٹراسٹ",
-      "HighContrastThemeARIA": "ہائی کنٹراسٹ تھیم آن",
-      "TextSize": "متن کا سائز",
-      "DecreaseFont": "کمی",
-      "DecreaseFontARIA": "فونٹ کا سائز کم کریں۔",
-      "IncreaseFont": "اضافہ",
-      "IncreaseFontARIA": "فونٹ سائز میں اضافہ کریں",
-      "FontSize": "حرف کا سائز",
-      "SetFontSize": "فونٹ کا سائز مقرر کریں",
-      "Autosave": "خودبخود محفوظ کریں۔",
-      "On": "پر",
-      "AutosaveOnARIA": "خودبخود محفوظ کریں",
-      "Off": "بند",
-      "AutosaveOffARIA": "خود کار طریقے سے محفوظ کریں",
-      "AutocloseBracketsQuotes": "خودکار بند بریکٹ اور اقتباسات",
-      "AutocloseBracketsQuotesOnARIA": "خودکار بند بریکٹ اور کوٹس آن",
-      "AutocloseBracketsQuotesOffARIA": "خودکار بند بریکٹ اور کوٹس آف",
-      "AutocompleteHinter": "خودکار تکمیل اشارہ",
-      "AutocompleteHinterOnARIA": "خودکار تکمیل اشارہ آن",
-      "AutocompleteHinterOffARIA": "خود کار طریقے سے اشارہ بند",
-      "WordWrap": "لفظ لفاف",
-      "WordWrapOnARIA": "لائن لپیٹنا",
-      "WordWrapOffARIA": "لائن لپیٹنا",
-      "LineNumbers": "لائن نمبرز",
-      "LineNumbersOnARIA": "لائن نمبر آن",
-      "LineNumbersOffARIA": "لائن نمبر بند",
-      "LintWarningSound": "لنٹ وارننگ کی آواز",
-      "LintWarningOnARIA": "لنٹ وارننگ آن",
-      "LintWarningOffARIA": "لنٹ انتباہ بند",
-      "PreviewSound": "پیش نظارہ آواز",
-      "PreviewSoundARIA": "پیش نظارہ آواز",
-      "AccessibleTextBasedCanvas": "قابل رسائی متن پر مبنی کینوس",
-      "UsedScreenReader": "اسکرین ریڈر کے ساتھ استعمال کیا جاتا ہے۔",
-      "PlainText": "سادہ متن",
-      "TextOutputARIA": "ٹیکسٹ آؤٹ پٹ آن",
-      "TableText": "ٹیبل ٹیکسٹ",
-      "TableOutputARIA": "ٹیبل آؤٹ پٹ آن"
-    },
-    "KeyboardShortcuts": {
-      "Title": " کی بورڈ شارٹ کٹس",
-      "ShortcutsFollow": "کوڈ ایڈیٹنگ کی بورڈ شارٹ کٹس فالو کرتے ہیں۔",
-      "SublimeText": "شاندار ٹیکسٹ شارٹ کٹس",
-      "CodeEditing": {
-        "Tidy": "صاف ستھرا",
-        "FindText": "متن تلاش کریں۔",
-        "FindNextMatch": "اگلا میچ تلاش کریں۔",
-        "FindPrevMatch": "پچھلا میچ تلاش کریں۔",
-        "ReplaceTextMatch": "ٹیکسٹ میچ کو تبدیل کریں۔",
-        "IndentCodeLeft": "انڈینٹ کوڈ بائیں",
-        "IndentCodeRight": "انڈینٹ کوڈ دائیں",
-        "CommentLine": "تبصرہ لائن",
-        "FindNextTextMatch": "اگلا ٹیکسٹ میچ تلاش کریں۔",
-        "FindPreviousTextMatch": "پچھلا ٹیکسٹ میچ تلاش کریں۔",
-        "CodeEditing": "کوڈ ایڈیٹنگ",
-        "ColorPicker": "ان لائن رنگ چنندہ دکھائیں۔"
-      },
-      "GeneralSelection": {
-        "StartSketch": "خاکہ شروع کریں۔",
-        "StopSketch": "خاکہ بند کریں",
-        "TurnOnAccessibleOutput": "قابل رسائی آؤٹ پٹ کو آن کریں۔",
-        "TurnOffAccessibleOutput": "قابل رسائی آؤٹ پٹ کو آف کریں۔"
-      }
-    },
-    "Sidebar": {
-      "Title": "اسکیچ فائلز",
-      "ToggleARIA": "اسکیچ فائل کے اختیارات کھولیں/بند کریں۔",
-      "AddFolder": "فولڈر بنائیں",
-      "AddFolderARIA": "فولڈر بناؤ",
-      "AddFile": "فائل بنائیں",
-      "AddFileARIA": "فائل شامل کریں",
-      "UploadFile": "اپ لوڈ فائل",
-      "UploadFileARIA": "اپ لوڈ فائل"
-    },
-    "FileNode": {
-      "OpenFolderARIA": "فولڈر کے مواد کو کھولیں۔",
-      "CloseFolderARIA": "فولڈر کے مواد کو بند کریں۔",
-      "ToggleFileOptionsARIA": "اوپن/کلز فائل آپشنز کو ٹوگل کریں۔",
-      "AddFolder": "فولڈر بنائیں",
-      "AddFolderARIA": "فولڈر بناؤ",
-      "AddFile": "فائل بنائیں",
-      "AddFileARIA": "فائل شامل کریں",
-      "UploadFile": "اپ لوڈ فائل",
-      "UploadFileARIA": "اپ لوڈ فائل",
-      "Rename": "نام تبدیل کریں۔",
-      "Delete": "حذف کریں۔"
-    },
-    "Common": {
-      "SiteName": "p5.js ویب ایڈیٹر",
-      "Error": "خرابی",
-      "ErrorARIA": "خرابی",
-      "Save": "محفوظ کریں۔",
-      "p5logoARIA": "p5.js لوگو",
-      "DeleteConfirmation": "کیا آپ واقعی حذف کرنا چاہتے ہیں۔ {{name}}?"
-    },
-    "IDEView": {
-      "SubmitFeedback": "تاثرات جمع کروائیں۔",
-      "SubmitFeedbackARIA": "رائے جمع کروائیں",
-      "AddCollectionTitle": "مجموعہ میں شامل کریں۔",
-      "AddCollectionARIA": "مجموعہ میں شامل کریں",
-      "ShareTitle": "بانٹیں",
-      "ShareARIA": "بانٹیں"
-    },
-    "NewFileModal": {
-      "Title": "فائل بنائیں",
-      "CloseButtonARIA": "نیا فائل موڈل بند کریں۔",
-      "EnterName": "براہ کرم ایک نام درج کریں۔",
-      "InvalidType": "غلط فائل کی قسم۔ "
-    },
-    "NewFileForm": {
-      "AddFileSubmit": "فائل شامل کریں",
-      "Placeholder": "نام"
-    },
-    "NewFolderModal": {
-      "Title": "فولڈر بنائیں",
-      "CloseButtonARIA": "نیا فولڈر موڈل بند کریں۔",
-      "EnterName": "براہ کرم ایک نام درج کریں۔",
-      "EmptyName": "فولڈر کا نام صرف خالی جگہوں پر مشتمل نہیں ہو سکتا",
-      "InvalidExtension": "فولڈر کے نام میں توسیع نہیں ہو سکتی"
-    },
-    "NewFolderForm": {
-      "AddFolderSubmit": "فولڈر بناؤ",
-      "Placeholder": "نام"
-    },
-    "ResetPasswordForm": {
-      "Email": "رجسٹریشن کے لیے استعمال ہونے والی ای میل",
-      "EmailARIA": "ای میل",
-      "Submit": "پاس ورڈ ری سیٹ ای میل بھیجیں۔"
-    },
-    "ResetPasswordView": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "Reset": "آپ کا پاس ورڈ دوبارہ ترتیب دیں",
-      "Submitted": "آپ کا پاس ورڈ دوبارہ ترتیب دینے والی ای میل جلد ہی پہنچ جائے گی۔ ",
-      "Login": "لاگ ان کریں",
-      "LoginOr": "یا",
-      "SignUp": "سائن اپ"
-    },
-    "ReduxFormUtils": {
-      "errorInvalidEmail": "برائے مہربانی قابل قبول ای میل ایڈریس لکھیں",
-      "errorEmptyEmail": "براہ کرم ایک ای میل درج کریں۔",
-      "errorPasswordMismatch": "پاس ورڈز مماثل ہونا چاہیے",
-      "errorEmptyPassword": "براہ کرم پاس ورڈ درج کریں۔",
-      "errorShortPassword": "پاس ورڈ کم از کم 6 حروف کا ہونا چاہیے۔",
-      "errorConfirmPassword": "براہ کرم اپنے پاس ورڈ کی تصدیق کریں۔",
-      "errorNewPassword": "براہ کرم نیا پاس ورڈ درج کریں یا موجودہ پاس ورڈ کو خالی چھوڑ دیں۔",
-      "errorNewPasswordRepeat":"Your New Password must differ from the current one.",
-      "errorEmptyUsername": "براہ کرم ایک صارف نام درج کریں۔",
-      "errorLongUsername": "صارف کا نام 20 حروف سے کم ہونا چاہیے۔",
-      "errorValidUsername": "صارف کا نام صرف نمبرز، حروف، پیریڈز، ڈیشز اور انڈر سکور پر مشتمل ہونا چاہیے۔"
-    },
-    "NewPasswordView": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "Description": "نیا پاس ورڈ سیٹ کریں۔",
-      "TokenInvalidOrExpired": "پاس ورڈ ری سیٹ ٹوکن غلط ہے یا ختم ہو گیا ہے۔",
-      "EmptyPassword": "براہ کرم پاس ورڈ درج کریں۔",
-      "PasswordConfirmation": "براہ کرم اپنے پاس ورڈ کی تصدیق کریں۔",
-      "PasswordMismatch": "پاس ورڈز مماثل ہونا چاہیے"
-    },
-    "AccountForm": {
-      "Email": "ای میل",
-      "EmailARIA": "ای میل",
-      "Unconfirmed": "غیر تصدیق شدہ۔",
-      "EmailSent": "تصدیق بھیجی گئی، اپنا ای میل چیک کریں۔",
-      "Resend": "دوبارہ تصدیقی میل بھیجیں",
-      "UserName": "صارف کا نام",
-      "UserNameARIA": "صارف نام",
-      "CurrentPassword": "موجودہ خفیہ لفظ",
-      "CurrentPasswordARIA": "موجودہ خفیہ لفظ",
-      "NewPassword": "نیا پاس ورڈ",
-      "NewPasswordARIA": "نیا پاس ورڈ",
-      "SubmitSaveAllSettings": "تمام ترتیبات کو محفوظ کریں۔"
-    },
-    "AccountView": {
-      "SocialLogin": "سماجی لاگ ان",
-      "SocialLoginDescription": "p5.js ویب ایڈیٹر میں لاگ ان کرنے کے لیے اپنا GitHub یا Google اکاؤنٹ استعمال کریں۔",
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "Settings": "اکاؤنٹ کی ترتیبات",
-      "AccountTab": "کھاتہ",
-      "AccessTokensTab": "ٹوکنز تک رسائی حاصل کریں۔"
-    },
-    "APIKeyForm": {
-      "ConfirmDelete": "کیا آپ واقعی حذف کرنا چاہتے ہیں۔ {{key_label}}?",
-      "Summary": "ذاتی رسائی کے ٹوکنز خودکار اجازت دینے کے لیے آپ کے پاس ورڈ کی طرح کام کرتے ہیں۔\n          ",
-      "CreateToken": "نیا ٹوکن بنائیں",
-      "TokenLabel": "یہ نشان کس لیے ہے؟",
-      "TokenPlaceholder": "یہ نشان کس لیے ہے؟ ",
-      "CreateTokenSubmit": "بنانا",
-      "NoTokens": "آپ کے پاس کوئی موجودہ ٹوکن نہیں ہے۔",
-      "NewTokenTitle": "آپ کا نیا رسائی ٹوکن",
-      "NewTokenInfo": "اپنا نیا ذاتی رسائی ٹوکن ابھی کاپی کرنا یقینی بنائیں۔\n                  ",
-      "ExistingTokensTitle": "موجودہ ٹوکنز"
-    },
-    "APIKeyList": {
-      "Name": "نام",
-      "Created": "پر بنایا",
-      "LastUsed": "آخری بار استعمال کیا گیا۔",
-      "Actions": "اعمال",
-      "Never": "کبھی نہیں",
-      "DeleteARIA": "API کلید کو حذف کریں۔"
-    },
-    "NewPasswordForm": {
-      "Title": "پاس ورڈ",
-      "TitleARIA": "پاس ورڈ",
-      "ConfirmPassword": "پاس ورڈ کی تصدیق کریں۔",
-      "ConfirmPasswordARIA": "پاس ورڈ کی تصدیق کریں۔",
-      "SubmitSetNewPassword": "نیا پاس ورڈ سیٹ کریں۔"
-    },
-    "SignupForm": {
-      "Title": "صارف کا نام",
-      "TitleARIA": "صارف نام",
-      "Email": "ای میل",
-      "EmailARIA": "ای میل",
-      "Password": "پاس ورڈ",
-      "PasswordARIA": "پاس ورڈ",
-      "ConfirmPassword": "پاس ورڈ کی تصدیق کریں۔",
-      "ConfirmPasswordARIA": "پاس ورڈ کی تصدیق کریں۔",
-      "SubmitSignup": "سائن اپ"
-    },
-    "SignupView": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "Description": "سائن اپ",
-      "Or": "یا",
-      "AlreadyHave": "پہلے سے ہی اکاؤنٹ ہے؟",
-      "Login": "لاگ ان کریں"
-    },
-    "EmailVerificationView": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "Verify": "اپنے ای میل کی تصدیق کریں۔",
-      "InvalidTokenNull": "وہ لنک غلط ہے۔",
-      "Checking": "ٹوکن کی توثیق ہو رہی ہے، براہ کرم انتظار کریں...",
-      "Verified": "سب ہو گیا، آپ کے ای میل ایڈریس کی تصدیق ہو گئی ہے۔",
-      "InvalidState": "کچھ غلط ہو گیا."
-    },
-    "AssetList": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "ToggleOpenCloseARIA": "اثاثہ جات کے اختیارات کھولیں / بند کریں۔",
-      "Delete": "حذف کریں۔",
-      "OpenNewTab": "نئے ٹیب میں کھولیں۔",
-      "NoUploadedAssets": "کوئی اپ لوڈ کردہ اثاثے نہیں ہیں۔",
-      "HeaderName": "نام",
-      "HeaderSize": "سائز",
-      "HeaderSketch": "خاکہ"
-    },
-    "Feedback": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "ViaGithubHeader": "گیتھب ایشوز کے ذریعے",
-      "ViaGithubDescription": "اگر آپ Github سے واقف ہیں، تو یہ بگ رپورٹس اور تاثرات حاصل کرنے کا ہمارا ترجیحی طریقہ ہے۔",
-      "GoToGithub": "گیتھب پر جائیں۔",
-      "ViaGoogleHeader": "گوگل فارم کے ذریعے",
-      "ViaGoogleDescription": "آپ یہ فوری فارم بھی جمع کرا سکتے ہیں۔",
-      "GoToForm": "فارم پر جائیں۔"
-    },
-    "Searchbar": {
-      "SearchSketch": "خاکے تلاش کریں...",
-      "SearchCollection": "مجموعے تلاش کریں...",
-      "ClearTerm": "صاف"
-    },
-    "UploadFileModal": {
-      "Title": "اپ لوڈ فائل",
-      "CloseButtonARIA": "اپ لوڈ فائل موڈل بند کریں۔",
-      "SizeLimitError": "خرابی: آپ مزید فائلیں اپ لوڈ نہیں کر سکتے۔  {{sizeLimit}}.\n                 "
-    },
-    "FileUploader": {
-      "DictDefaultMessage": "فائلیں یہاں ڈراپ کریں یا فائل براؤزر استعمال کرنے کے لیے کلک کریں۔"
-    },
-    "ErrorModal": {
-      "MessageLogin": "خاکے محفوظ کرنے کے لیے، آپ کو لاگ اِن ہونا چاہیے۔ براہِ کرم ",
-      "Login": "لاگ ان کریں",
-      "LoginOr": " یا ",
-      "SignUp": "سائن اپ",
-      "MessageLoggedOut": "ایسا لگتا ہے کہ آپ لاگ آؤٹ ہو گئے ہیں۔  ",
-      "LogIn": "لاگ ان کریں",
-      "SavedDifferentWindow": "آپ نے جس پروجیکٹ کو محفوظ کرنے کی کوشش کی ہے اسے دوسری ونڈو سے محفوظ کر لیا گیا ہے۔\n        ",
-      "LinkTitle": "اکاؤنٹ لنک کرنے میں خرابی۔",
-      "LinkMessage": "آپ کے لنک کرنے میں ایک مسئلہ تھا۔ {{serviceauth}} اپنے p5.js ویب ایڈیٹر اکاؤنٹ میں اکاؤنٹ۔  {{serviceauth}} اکاؤنٹ پہلے ہی دوسرے p5.js ویب ایڈیٹر اکاؤنٹ سے منسلک ہے۔"
-    },
-    "ShareModal": {
-      "Embed": "ایمبیڈ",
-      "Present": "موجودہ",
-      "Fullscreen": "مکمل اسکرین یا بڑی اسکرین",
-      "Edit": "ترمیم"
-    },
-    "CollectionView": {
-      "TitleCreate": "مجموعہ بنائیں",
-      "TitleDefault": "مجموعہ"
-    },
-    "Collection": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "AnothersTitle": "p5.js ویب ایڈیٹر | {{anotheruser}}کے مجموعے",
+  "Nav": {
+    "File": {
+      "Title": "فائل",
+      "New": "نئی",
       "Share": "بانٹیں",
-      "URLLink": "مجموعہ سے لنک",
-      "AddSketch": "خاکہ شامل کریں۔",
-      "DeleteFromCollection": "کیا آپ واقعی ہٹانا چاہتے ہیں {{name_sketch}} اس مجموعہ سے؟",
-      "SketchDeleted": "خاکہ حذف کر دیا گیا۔",
-      "SketchRemoveARIA": "مجموعہ سے خاکہ کو ہٹا دیں۔",
-      "DescriptionPlaceholder": "تفصیل شامل کریں۔",
-      "Description": "تفصیل",
-      "NumSketches": "{{count}} خاکہ",
-      "NumSketches_plural": "{{count}} خاکے",
-      "By": "کی طرف سے مجموعہ ",
-      "NoSketches": "مجموعہ میں کوئی خاکہ نہیں۔",
-      "TableSummary": "تمام مجموعوں پر مشتمل میز",
-      "HeaderName": "نام",
-      "HeaderCreatedAt": "شامل کرنے کی تاریخ",
-      "HeaderUser": "مالک",
-      "DirectionAscendingARIA": "صعودی",
-      "DirectionDescendingARIA": "نزول",
-      "ButtonLabelAscendingARIA": "ترتیب دیں {{displayName}} چڑھتے ہوئے",
-      "ButtonLabelDescendingARIA": "ترتیب دیں {{displayName}} نزول"
-    },
-    "AddToCollectionList": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "AnothersTitle": "p5.js ویب ایڈیٹر | {{anotheruser}}کے مجموعے",
-      "Empty": "کوئی مجموعہ نہیں۔"
-    },
-    "CollectionCreate": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "FormError": "مجموعہ نہیں بنایا جا سکا",
-      "FormLabel": "مجموعہ کا نام",
-      "FormLabelARIA": "نام",
-      "NameRequired": "مجموعہ کا نام درکار ہے۔",
-      "Description": "تفصیل (اختیاری)",
-      "DescriptionARIA": "تفصیل",
-      "DescriptionPlaceholder": "میرے پسندیدہ خاکے",
-      "SubmitCollectionCreate": "مجموعہ بنائیں"
-    },
-    "DashboardView": {
-      "CreateCollection": "مجموعہ بنائیں",
-      "NewSketch": "نیا خاکہ",
-      "CreateCollectionOverlay": "مجموعہ بنائیں"
-    },
-    "DashboardTabSwitcher": {
-      "Sketches": "خاکے",
-      "Collections": "مجموعے",
-      "Assets": "اثاثے"
-    },
-    "CollectionList": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "AnothersTitle": "p5.js ویب ایڈیٹر | {{anotheruser}}کے مجموعے",
-      "NoCollections": "کوئی مجموعہ نہیں۔",
-      "TableSummary": "تمام مجموعوں پر مشتمل میز",
-      "HeaderName": "نام",
-      "HeaderCreatedAt": "تاریخ تخلیق",
-      "HeaderCreatedAt_mobile": "بنایا",
-      "HeaderUpdatedAt": "تاریخ کی تازہ کاری",
-      "HeaderUpdatedAt_mobile": "تازہ کاری",
-      "HeaderNumItems": "",
-      "HeaderNumItems_mobile": "",
-      "DirectionAscendingARIA": "صعودی",
-      "DirectionDescendingARIA": "نزول",
-      "ButtonLabelAscendingARIA": "ترتیب دیں {{displayName}} چڑھتے ہوئے",
-      "ButtonLabelDescendingARIA": "ترتیب دیں {{displayName}} نزول",
-      "AddSketch": "خاکہ شامل کریں۔"
-    },
-    "CollectionListRow": {
-      "ToggleCollectionOptionsARIA": "اوپن/کلوز کلیکشن آپشنز کو ٹوگل کریں۔",
-      "AddSketch": "خاکہ شامل کریں۔",
-      "Delete": "حذف کریں۔",
-      "Rename": "نام تبدیل کریں۔"
-    },
-    "Overlay": {
-      "AriaLabel": "بند کریں {{title}} اوورلے"
-    },
-    "QuickAddList": {
-      "ButtonRemoveARIA": "مجموعہ سے ہٹا دیں۔",
-      "ButtonAddToCollectionARIA": "مجموعہ میں شامل کریں۔",
-      "View": "دیکھیں"
-    },
-    "Pagination": {
-      "Next": "Next",
-      "Previous": "Previous",
-      "Of": "of",
-      "PreviousPageARIA": "Previous Page",
-      "NextPageARIA": "Next Page"
-    },
-    "SketchList": {
-      "View": "دیکھیں",
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "AnothersTitle": "p5.js ویب ایڈیٹر | {{anotheruser}}کے خاکے",
-      "ToggleLabelARIA": "اوپن/کلوز اسکیچ آپشنز کو ٹوگل کریں۔",
-      "DropdownRename": "نام تبدیل کریں۔",
-      "DropdownDownload": "ڈاؤن لوڈ کریں",
-      "DropdownDuplicate": "نقل",
-      "DropdownAddToCollection": "مجموعہ میں شامل کریں۔",
-      "DropdownDelete": "حذف کریں۔",
-      "DirectionAscendingARIA": "صعودی",
-      "DirectionDescendingARIA": "نزول",
-      "ButtonLabelAscendingARIA": "ترتیب دیں {{displayName}} چڑھتے ہوئے",
-      "ButtonLabelDescendingARIA": "ترتیب دیں {{displayName}} نزول",
-      "AddToCollectionOverlayTitle": "مجموعہ میں شامل کریں۔",
-      "TableSummary": "تمام محفوظ شدہ منصوبوں پر مشتمل ٹیبل",
-      "HeaderName": "خاکہ",
-      "HeaderCreatedAt": "تاریخ تخلیق",
-      "HeaderCreatedAt_mobile": "بنایا",
-      "HeaderUpdatedAt": "تاریخ کی تازہ کاری",
-      "HeaderUpdatedAt_mobile": "تازہ کاری",
-      "NoSketches": "کوئی خاکے نہیں۔"
-    },
-    "AddToCollectionSketchList": {
-      "Title": "p5.js ویب ایڈیٹر | ",
-      "AnothersTitle": "p5.js ویب ایڈیٹر | {{anotheruser}}کے خاکے",
-      "NoCollections": "کوئی مجموعہ نہیں۔"
-    },
-    "Editor": {
-      "OpenSketchARIA": "اسکیچ فائلز نیویگیشن کھولیں۔",
-      "CloseSketchARIA": "اسکیچ فائلز نیویگیشن بند کریں۔",
-      "UnsavedChangesARIA": "اسکیچ میں غیر محفوظ شدہ تبدیلیاں ہیں۔",
-      "KeyUpLineNumber": "لائن {{lineNumber}}"
-    },
-    "EditorAccessibility": {
-      "NoLintMessages": "کوئی لنٹ پیغامات نہیں ہیں۔",
-      "CurrentLine": "موجودہ لائن"
-    },
-    "Timer": {
-      "SavedAgo": "محفوظ کیا گیا: {{timeAgo}}"
-    },
-    "formatDate": {
-      "JustNow": "ابھی ابھی",
-      "15Seconds": "15 سیکنڈ پہلے",
-      "25Seconds": "25 سیکنڈ پہلے",
-      "35Seconds": "35 سیکنڈ پہلے",
-      "Ago": "{{timeAgo}} پہلے"
-    },
-    "CopyableInput": {
-      "CopiedARIA": "کلپ بورڈ پر کاپی ہو گیا!",
-      "OpenViewTabARIA": "کھولیں۔ {{label}} نئے ٹیب میں دیکھیں"
-    },
-    "EditableInput": {
-      "EditValue": "ترمیم {{display}} قدر",
-      "EmptyPlaceholder": "کوئی قدر نہیں"
-    },
-    "PreviewNav": {
-      "EditSketchARIA": "خاکہ میں ترمیم کریں۔",
-      "ByUser": "کی طرف سے"
-    },
-    "MobilePreferences": {
-      "Settings": "ترتیبات",
-      "GeneralSettings": "عام ترتیبات",
-      "Accessibility": "رسائی",
-      "AccessibleOutput": "قابل رسائی آؤٹ پٹ",
-      "Theme": "خیالیہ",
-      "LightTheme": "روشنی",
-      "DarkTheme": "اندھیرا",
-      "HighContrastTheme": "ہائی کنٹراسٹ",
-      "Autosave": "خودبخود محفوظ کریں۔",
-      "AutocompleteHinter": "خودکار تکمیل اشارہ",
-      "WordWrap": "لفظ لفاف",
-      "LineNumbers": "لائن نمبرز",
-      "LintWarningSound": "لنٹ وارننگ کی آواز",
-      "UsedScreenReader": "اسکرین ریڈر کے ساتھ استعمال کیا جاتا ہے۔",
-      "PlainText": "سادہ متن",
-      "TableText": "ٹیبل ٹیکسٹ",
-      "Sound": "آواز"
-    },
-    "PreferenceCreators": {
-      "On": "پر",
-      "Off": "بند"
-    },
-    "MobileDashboardView": {
+      "Duplicate": "نقل",
+      "Open": "کھولیں۔",
+      "Download": "ڈاؤن لوڈ کریں",
+      "AddToCollection": "مجموعہ میں شامل کریں۔",
       "Examples": "مثالیں",
-      "Sketches": "خاکے",
-      "Collections": "مجموعے",
-      "Assets": "اثاثے",
-      "MyStuff": "میرا سامان",
-      "CreateSketch": "خاکہ بنائیں",
-      "CreateCollection": "مجموعہ بنائیں"
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
-    "Explorer": {
-      "Files": "فائلوں"
+    "Edit": {
+      "Title": "ترمیم",
+      "TidyCode": "کوڈ کو صاف و ستھرا کریں",
+      "Find": "تلاش کریں",
+      "Replace": "بدل دیں"
     },
-    "Cookies": {
-      "Header": "کوکیز",
-      "Body": "p5.js ایڈیٹر کوکیز استعمال کرتا ہے۔  <strong> ہم اس ڈیٹا کو کبھی فروخت نہیں کرتے اور نہ ہی اسے اشتہارات کے لیے استعمال کرتے ہیں۔ </strong> آپ فیصلہ کر سکتے ہیں کہ آپ کن کوکیز کی اجازت دینا چاہیں گے، اور ہماری میں مزید جانیں۔ <0>رازداری کی پالیسی<0>.",
-      "AllowAll": "سب کو اجازت دیں۔",
-      "AllowEssential": "ضروری کی اجازت دیں۔"
+    "Sketch": {
+      "Title": "خاکہ",
+      "AddFile": "فائل شامل کریں",
+      "AddFolder": "فولڈر بنائیں",
+      "Run": "رن",
+      "Stop": "رک جائیں"
     },
-    "Legal": {
-      "PrivacyPolicy": "رازداری کی پالیسی",
-      "TermsOfUse": "استعمال کرنے کی شرائط",
-      "CodeOfConduct": "ضابطہ اخلاق"
+    "Help": {
+      "Title": "مدد",
+      "KeyboardShortcuts": "کی بورڈ شارٹ کٹس",
+      "Reference": "حوالہ",
+      "About": "کے بارے میں",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
-    "TextArea": {
-      "CopyARIA": "Copy"
+    "Lang": "زبان",
+    "BackEditor": "واپس ایڈیٹر پر",
+    "WarningUnsavedChanges": "کیا آپ واقعی یہ صفحہ چھوڑنا چاہتے ہیں؟ ",
+    "Login": "لاگ ان کریں",
+    "LoginOr": "یا",
+    "SignUp": "سائن اپ",
+    "Auth": {
+      "Welcome": "خوش آمدید",
+      "Hello": "ہیلو",
+      "MyAccount": "میرا اکاونٹ",
+      "My": "میرا",
+      "MySketches": "میرے خاکے",
+      "MyCollections": "میرے مجموعے",
+      "Asset": "اثاثہ",
+      "MyAssets": "میرے اثاثے",
+      "LogOut": "لاگ آوٹ"
     }
+  },
+  "Banner": {
+    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+  },
+  "CodemirrorFindAndReplace": {
+    "ToggleReplace": "تبدیل کرنے کو ٹوگل کریں۔",
+    "Find": "تلاش کریں",
+    "FindPlaceholder": "فائلوں میں تلاش کریں۔",
+    "Replace": "بدل دیں۔",
+    "ReplaceAll": "سبھی کو تبدیل کریں۔",
+    "ReplacePlaceholder": "تبدیل کرنے کے لیے متن",
+    "Regex": "باقاعدہ اظہار",
+    "CaseSensitive": "حساس کیس",
+    "WholeWords": "پورے الفاظ",
+    "Previous": "پچھلا",
+    "Next": "اگلے",
+    "NoResults": "کوئی نتیجہ نہیں نکلا۔",
+    "Close": "بند کریں"
+  },
+  "LoginForm": {
+    "UsernameOrEmail": "ای میل یا اسم صارف",
+    "UsernameOrEmailARIA": "ای میل یا اسم صارف",
+    "Password": "پاس ورڈ",
+    "PasswordARIA": "پاس ورڈ",
+    "Submit": "لاگ ان کریں",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
+  },
+  "LoginView": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "Login": "لاگ ان کریں",
+    "LoginOr": "یا",
+    "SignUp": "سائن اپ",
+    "Email": "ای میل",
+    "Username": "صارف نام",
+    "DontHaveAccount": "اکاؤنٹ نہیں ہے؟ ",
+    "ForgotPassword": "اپنا پاس ورڈ بھول گئے؟ ",
+    "ResetPassword": "آپ کا پاس ورڈ دوبارہ ترتیب دیں"
+  },
+  "SocialAuthButton": {
+    "Connect": "جڑیں۔ {{serviceauth}} کھاتہ",
+    "Unlink": "لنک ختم کریں۔ {{serviceauth}} کھاتہ",
+    "Login": "کے ساتھ لاگ ان {{serviceauth}}",
+    "LogoARIA": "{{serviceauth}} لوگو"
+  },
+  "About": {
+    "Title": "کے بارے میں",
+    "TitleHelmet": "p5.js ویب ایڈیٹر | ",
+    "Contribute": "تعاون کریں۔",
+    "NewP5": "p5.js میں نئے ہیں؟",
+    "Report": "ایک بگ کی اطلاع دیں۔",
+    "Learn": "سیکھیں۔",
+    "Resources": "حوالہ جات",
+    "Libraries": "لائبریریاں",
+    "Forum": "فورم",
+    "Examples": "مثالیں",
+    "PrivacyPolicy": "رازداری کی پالیسی",
+    "TermsOfUse": "استعمال کرنے کی شرائط",
+    "CodeOfConduct": "ضابطہ اخلاق",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "Home": "p5.js Home",
+    "Instagram": "Instagram",
+    "Discord": "Discord",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "WebEditor": "Web Editor",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
+    },
+    "Contact": "Contact Us"
+  },
+  "Toast": {
+    "OpenedNewSketch": "نیا خاکہ کھولا۔",
+    "SketchSaved": "خاکہ محفوظ ہو گیا۔",
+    "SketchFailedSave": "خاکہ محفوظ کرنے میں ناکام۔",
+    "AutosaveEnabled": "خودکار محفوظ کرنا فعال ہے۔",
+    "LangChange": "زبان بدل گئی۔",
+    "SettingsSaved": "ترتیبات محفوظ ہو گئیں۔",
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
+  },
+  "Toolbar": {
+    "Preview": "پیش نظارہ",
+    "Auto-refresh": "آٹو ریفریش",
+    "OpenPreferencesARIA": "ترجیحات کھولیں۔",
+    "PlaySketchARIA": "خاکہ چلائیں۔",
+    "PlayOnlyVisualSketchARIA": "صرف بصری خاکہ چلائیں۔",
+    "StopSketchARIA": "خاکہ بنانا بند کریں",
+    "EditSketchARIA": "خاکے کے نام میں ترمیم کریں۔",
+    "NewSketchNameARIA": "خاکے کا نیا نام",
+    "By": " کی طرف سے ",
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
+  },
+  "Console": {
+    "Title": "تسلی",
+    "Clear": "صاف",
+    "ClearARIA": "کنسول صاف کریں۔",
+    "Close": "بند کریں",
+    "CloseARIA": "کنسول بند کریں۔",
+    "Open": "کھولیں۔",
+    "OpenARIA": "کنسول کھولیں۔"
+  },
+  "Preferences": {
+    "Settings": "ترتیبات",
+    "GeneralSettings": "عام ترتیبات",
+    "Accessibility": "رسائی",
+    "Theme": "خیالیہ",
+    "LightTheme": "روشنی",
+    "LightThemeARIA": "ہلکی تھیم آن",
+    "DarkTheme": "اندھیرا",
+    "DarkThemeARIA": "سیاہ تھیم آن",
+    "HighContrastTheme": "ہائی کنٹراسٹ",
+    "HighContrastThemeARIA": "ہائی کنٹراسٹ تھیم آن",
+    "TextSize": "متن کا سائز",
+    "DecreaseFont": "کمی",
+    "DecreaseFontARIA": "فونٹ کا سائز کم کریں۔",
+    "IncreaseFont": "اضافہ",
+    "IncreaseFontARIA": "فونٹ سائز میں اضافہ کریں",
+    "FontSize": "حرف کا سائز",
+    "SetFontSize": "فونٹ کا سائز مقرر کریں",
+    "Autosave": "خودبخود محفوظ کریں۔",
+    "On": "پر",
+    "AutosaveOnARIA": "خودبخود محفوظ کریں",
+    "Off": "بند",
+    "AutosaveOffARIA": "خود کار طریقے سے محفوظ کریں",
+    "AutocloseBracketsQuotes": "خودکار بند بریکٹ اور اقتباسات",
+    "AutocloseBracketsQuotesOnARIA": "خودکار بند بریکٹ اور کوٹس آن",
+    "AutocloseBracketsQuotesOffARIA": "خودکار بند بریکٹ اور کوٹس آف",
+    "AutocompleteHinter": "خودکار تکمیل اشارہ",
+    "AutocompleteHinterOnARIA": "خودکار تکمیل اشارہ آن",
+    "AutocompleteHinterOffARIA": "خود کار طریقے سے اشارہ بند",
+    "WordWrap": "لفظ لفاف",
+    "WordWrapOnARIA": "لائن لپیٹنا",
+    "WordWrapOffARIA": "لائن لپیٹنا",
+    "LineNumbers": "لائن نمبرز",
+    "LineNumbersOnARIA": "لائن نمبر آن",
+    "LineNumbersOffARIA": "لائن نمبر بند",
+    "LintWarningSound": "لنٹ وارننگ کی آواز",
+    "LintWarningOnARIA": "لنٹ وارننگ آن",
+    "LintWarningOffARIA": "لنٹ انتباہ بند",
+    "PreviewSound": "پیش نظارہ آواز",
+    "PreviewSoundARIA": "پیش نظارہ آواز",
+    "AccessibleTextBasedCanvas": "قابل رسائی متن پر مبنی کینوس",
+    "UsedScreenReader": "اسکرین ریڈر کے ساتھ استعمال کیا جاتا ہے۔",
+    "PlainText": "سادہ متن",
+    "TextOutputARIA": "ٹیکسٹ آؤٹ پٹ آن",
+    "TableText": "ٹیبل ٹیکسٹ",
+    "TableOutputARIA": "ٹیبل آؤٹ پٹ آن",
+    "LibraryManagement": "Library Management",
+    "LibraryVersion": "p5.js Version",
+    "LibraryVersionInfo": "There's a [new 2.0 release](https://github.com/processing/p5.js/releases/) of p5.js available! It will become default in August, 2026, so take this time to test it out and report bugs. Interested in transitioning sketches from 1.x to 2.0? Check out the [compatibility & transition resources.](https://github.com/processing/p5.js-compatibility)",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "SoundAddon": "p5.sound.js Add-on Library",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on Library — Preload",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on Library — Shapes",
+    "DataAddon": "p5.js 1.x Compatibility Add-on Library — Data & Events",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
+  },
+  "KeyboardShortcuts": {
+    "Title": " کی بورڈ شارٹ کٹس",
+    "ShortcutsFollow": "کوڈ ایڈیٹنگ کی بورڈ شارٹ کٹس فالو کرتے ہیں۔",
+    "SublimeText": "شاندار ٹیکسٹ شارٹ کٹس",
+    "CodeEditing": {
+      "Tidy": "صاف ستھرا",
+      "FindText": "متن تلاش کریں۔",
+      "FindNextMatch": "اگلا میچ تلاش کریں۔",
+      "FindPrevMatch": "پچھلا میچ تلاش کریں۔",
+      "ReplaceTextMatch": "ٹیکسٹ میچ کو تبدیل کریں۔",
+      "IndentCodeLeft": "انڈینٹ کوڈ بائیں",
+      "IndentCodeRight": "انڈینٹ کوڈ دائیں",
+      "CommentLine": "تبصرہ لائن",
+      "FindNextTextMatch": "اگلا ٹیکسٹ میچ تلاش کریں۔",
+      "FindPreviousTextMatch": "پچھلا ٹیکسٹ میچ تلاش کریں۔",
+      "CodeEditing": "کوڈ ایڈیٹنگ",
+      "ColorPicker": "ان لائن رنگ چنندہ دکھائیں۔",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
+    },
+    "GeneralSelection": {
+      "StartSketch": "خاکہ شروع کریں۔",
+      "StopSketch": "خاکہ بند کریں",
+      "TurnOnAccessibleOutput": "قابل رسائی آؤٹ پٹ کو آن کریں۔",
+      "TurnOffAccessibleOutput": "قابل رسائی آؤٹ پٹ کو آف کریں۔",
+      "Reference": "Go to Reference for Selected Item in Hinter"
+    },
+    "General": "General"
+  },
+  "Sidebar": {
+    "Title": "اسکیچ فائلز",
+    "ToggleARIA": "اسکیچ فائل کے اختیارات کھولیں/بند کریں۔",
+    "AddFolder": "فولڈر بنائیں",
+    "AddFolderARIA": "فولڈر بناؤ",
+    "AddFile": "فائل بنائیں",
+    "AddFileARIA": "فائل شامل کریں",
+    "UploadFile": "اپ لوڈ فائل",
+    "UploadFileARIA": "اپ لوڈ فائل",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
+  },
+  "FileNode": {
+    "OpenFolderARIA": "فولڈر کے مواد کو کھولیں۔",
+    "CloseFolderARIA": "فولڈر کے مواد کو بند کریں۔",
+    "ToggleFileOptionsARIA": "اوپن/کلز فائل آپشنز کو ٹوگل کریں۔",
+    "AddFolder": "فولڈر بنائیں",
+    "AddFolderARIA": "فولڈر بناؤ",
+    "AddFile": "فائل بنائیں",
+    "AddFileARIA": "فائل شامل کریں",
+    "UploadFile": "اپ لوڈ فائل",
+    "UploadFileARIA": "اپ لوڈ فائل",
+    "Rename": "نام تبدیل کریں۔",
+    "Delete": "حذف کریں۔"
+  },
+  "Common": {
+    "SiteName": "p5.js ویب ایڈیٹر",
+    "Error": "خرابی",
+    "ErrorARIA": "خرابی",
+    "Save": "محفوظ کریں۔",
+    "p5logoARIA": "p5.js لوگو",
+    "DeleteConfirmation": "کیا آپ واقعی حذف کرنا چاہتے ہیں۔ {{name}}?"
+  },
+  "IDEView": {
+    "SubmitFeedback": "تاثرات جمع کروائیں۔",
+    "SubmitFeedbackARIA": "رائے جمع کروائیں",
+    "AddCollectionTitle": "مجموعہ میں شامل کریں۔",
+    "AddCollectionARIA": "مجموعہ میں شامل کریں",
+    "ShareTitle": "بانٹیں",
+    "ShareARIA": "بانٹیں"
+  },
+  "NewFileModal": {
+    "Title": "فائل بنائیں",
+    "CloseButtonARIA": "نیا فائل موڈل بند کریں۔",
+    "EnterName": "براہ کرم ایک نام درج کریں۔",
+    "InvalidType": "غلط فائل کی قسم۔ "
+  },
+  "NewFileForm": {
+    "AddFileSubmit": "فائل شامل کریں",
+    "Placeholder": "نام"
+  },
+  "NewFolderModal": {
+    "Title": "فولڈر بنائیں",
+    "CloseButtonARIA": "نیا فولڈر موڈل بند کریں۔",
+    "EnterName": "براہ کرم ایک نام درج کریں۔",
+    "EmptyName": "فولڈر کا نام صرف خالی جگہوں پر مشتمل نہیں ہو سکتا",
+    "InvalidExtension": "فولڈر کے نام میں توسیع نہیں ہو سکتی"
+  },
+  "NewFolderForm": {
+    "AddFolderSubmit": "فولڈر بناؤ",
+    "Placeholder": "نام"
+  },
+  "ResetPasswordForm": {
+    "Email": "رجسٹریشن کے لیے استعمال ہونے والی ای میل",
+    "EmailARIA": "ای میل",
+    "Submit": "پاس ورڈ ری سیٹ ای میل بھیجیں۔"
+  },
+  "ResetPasswordView": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "Reset": "آپ کا پاس ورڈ دوبارہ ترتیب دیں",
+    "Submitted": "آپ کا پاس ورڈ دوبارہ ترتیب دینے والی ای میل جلد ہی پہنچ جائے گی۔ ",
+    "Login": "لاگ ان کریں",
+    "LoginOr": "یا",
+    "SignUp": "سائن اپ"
+  },
+  "ReduxFormUtils": {
+    "errorInvalidEmail": "برائے مہربانی قابل قبول ای میل ایڈریس لکھیں",
+    "errorEmptyEmail": "براہ کرم ایک ای میل درج کریں۔",
+    "errorPasswordMismatch": "پاس ورڈز مماثل ہونا چاہیے",
+    "errorEmptyPassword": "براہ کرم پاس ورڈ درج کریں۔",
+    "errorShortPassword": "پاس ورڈ کم از کم 6 حروف کا ہونا چاہیے۔",
+    "errorConfirmPassword": "براہ کرم اپنے پاس ورڈ کی تصدیق کریں۔",
+    "errorNewPassword": "براہ کرم نیا پاس ورڈ درج کریں یا موجودہ پاس ورڈ کو خالی چھوڑ دیں۔",
+    "errorNewPasswordRepeat": "Your New Password must differ from the current one.",
+    "errorEmptyUsername": "براہ کرم ایک صارف نام درج کریں۔",
+    "errorLongUsername": "صارف کا نام 20 حروف سے کم ہونا چاہیے۔",
+    "errorValidUsername": "صارف کا نام صرف نمبرز، حروف، پیریڈز، ڈیشز اور انڈر سکور پر مشتمل ہونا چاہیے۔",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
+  },
+  "NewPasswordView": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "Description": "نیا پاس ورڈ سیٹ کریں۔",
+    "TokenInvalidOrExpired": "پاس ورڈ ری سیٹ ٹوکن غلط ہے یا ختم ہو گیا ہے۔",
+    "EmptyPassword": "براہ کرم پاس ورڈ درج کریں۔",
+    "PasswordConfirmation": "براہ کرم اپنے پاس ورڈ کی تصدیق کریں۔",
+    "PasswordMismatch": "پاس ورڈز مماثل ہونا چاہیے"
+  },
+  "AccountForm": {
+    "Email": "ای میل",
+    "EmailARIA": "ای میل",
+    "Unconfirmed": "غیر تصدیق شدہ۔",
+    "EmailSent": "تصدیق بھیجی گئی، اپنا ای میل چیک کریں۔",
+    "Resend": "دوبارہ تصدیقی میل بھیجیں",
+    "UserName": "صارف کا نام",
+    "UserNameARIA": "صارف نام",
+    "CurrentPassword": "موجودہ خفیہ لفظ",
+    "CurrentPasswordARIA": "موجودہ خفیہ لفظ",
+    "NewPassword": "نیا پاس ورڈ",
+    "NewPasswordARIA": "نیا پاس ورڈ",
+    "SubmitSaveAllSettings": "تمام ترتیبات کو محفوظ کریں۔",
+    "SaveAccountDetails": "Save Account Details"
+  },
+  "AccountView": {
+    "SocialLogin": "سماجی لاگ ان",
+    "SocialLoginDescription": "p5.js ویب ایڈیٹر میں لاگ ان کرنے کے لیے اپنا GitHub یا Google اکاؤنٹ استعمال کریں۔",
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "Settings": "اکاؤنٹ کی ترتیبات",
+    "AccountTab": "کھاتہ",
+    "AccessTokensTab": "ٹوکنز تک رسائی حاصل کریں۔"
+  },
+  "APIKeyForm": {
+    "ConfirmDelete": "کیا آپ واقعی حذف کرنا چاہتے ہیں۔ {{key_label}}?",
+    "Summary": "ذاتی رسائی کے ٹوکنز خودکار اجازت دینے کے لیے آپ کے پاس ورڈ کی طرح کام کرتے ہیں۔\n          ",
+    "CreateToken": "نیا ٹوکن بنائیں",
+    "TokenLabel": "یہ نشان کس لیے ہے؟",
+    "TokenPlaceholder": "یہ نشان کس لیے ہے؟ ",
+    "CreateTokenSubmit": "بنانا",
+    "NoTokens": "آپ کے پاس کوئی موجودہ ٹوکن نہیں ہے۔",
+    "NewTokenTitle": "آپ کا نیا رسائی ٹوکن",
+    "NewTokenInfo": "اپنا نیا ذاتی رسائی ٹوکن ابھی کاپی کرنا یقینی بنائیں۔\n                  ",
+    "ExistingTokensTitle": "موجودہ ٹوکنز"
+  },
+  "APIKeyList": {
+    "Name": "نام",
+    "Created": "پر بنایا",
+    "LastUsed": "آخری بار استعمال کیا گیا۔",
+    "Actions": "اعمال",
+    "Never": "کبھی نہیں",
+    "DeleteARIA": "API کلید کو حذف کریں۔"
+  },
+  "NewPasswordForm": {
+    "Title": "پاس ورڈ",
+    "TitleARIA": "پاس ورڈ",
+    "ConfirmPassword": "پاس ورڈ کی تصدیق کریں۔",
+    "ConfirmPasswordARIA": "پاس ورڈ کی تصدیق کریں۔",
+    "SubmitSetNewPassword": "نیا پاس ورڈ سیٹ کریں۔"
+  },
+  "SignupForm": {
+    "Title": "صارف کا نام",
+    "TitleARIA": "صارف نام",
+    "Email": "ای میل",
+    "EmailARIA": "ای میل",
+    "Password": "پاس ورڈ",
+    "PasswordARIA": "پاس ورڈ",
+    "ConfirmPassword": "پاس ورڈ کی تصدیق کریں۔",
+    "ConfirmPasswordARIA": "پاس ورڈ کی تصدیق کریں۔",
+    "SubmitSignup": "سائن اپ",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
+  },
+  "SignupView": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "Description": "سائن اپ",
+    "Or": "یا",
+    "AlreadyHave": "پہلے سے ہی اکاؤنٹ ہے؟",
+    "Login": "لاگ ان کریں",
+    "Warning": "By signing up, you agree to the p5.js Editor's <0>Terms of Use</0> and <1>Privacy Policy.</1>"
+  },
+  "EmailVerificationView": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "Verify": "اپنے ای میل کی تصدیق کریں۔",
+    "InvalidTokenNull": "وہ لنک غلط ہے۔",
+    "Checking": "ٹوکن کی توثیق ہو رہی ہے، براہ کرم انتظار کریں...",
+    "Verified": "سب ہو گیا، آپ کے ای میل ایڈریس کی تصدیق ہو گئی ہے۔",
+    "InvalidState": "کچھ غلط ہو گیا."
+  },
+  "AssetList": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "ToggleOpenCloseARIA": "اثاثہ جات کے اختیارات کھولیں / بند کریں۔",
+    "Delete": "حذف کریں۔",
+    "OpenNewTab": "نئے ٹیب میں کھولیں۔",
+    "NoUploadedAssets": "کوئی اپ لوڈ کردہ اثاثے نہیں ہیں۔",
+    "HeaderName": "نام",
+    "HeaderSize": "سائز",
+    "HeaderSketch": "خاکہ",
+    "maximum": "Maximum"
+  },
+  "Feedback": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "ViaGithubHeader": "گیتھب ایشوز کے ذریعے",
+    "ViaGithubDescription": "اگر آپ Github سے واقف ہیں، تو یہ بگ رپورٹس اور تاثرات حاصل کرنے کا ہمارا ترجیحی طریقہ ہے۔",
+    "GoToGithub": "گیتھب پر جائیں۔",
+    "ViaGoogleHeader": "گوگل فارم کے ذریعے",
+    "ViaGoogleDescription": "آپ یہ فوری فارم بھی جمع کرا سکتے ہیں۔",
+    "GoToForm": "فارم پر جائیں۔"
+  },
+  "Searchbar": {
+    "SearchSketch": "خاکے تلاش کریں...",
+    "SearchCollection": "مجموعے تلاش کریں...",
+    "ClearTerm": "صاف"
+  },
+  "UploadFileModal": {
+    "Title": "اپ لوڈ فائل",
+    "CloseButtonARIA": "اپ لوڈ فائل موڈل بند کریں۔",
+    "SizeLimitError": "خرابی: آپ مزید فائلیں اپ لوڈ نہیں کر سکتے۔  {{sizeLimit}}.\n                 "
+  },
+  "FileUploader": {
+    "DictDefaultMessage": "فائلیں یہاں ڈراپ کریں یا فائل براؤزر استعمال کرنے کے لیے کلک کریں۔"
+  },
+  "ErrorModal": {
+    "MessageLogin": "خاکے محفوظ کرنے کے لیے، آپ کو لاگ اِن ہونا چاہیے۔ براہِ کرم ",
+    "Login": "لاگ ان کریں",
+    "LoginOr": " یا ",
+    "SignUp": "سائن اپ",
+    "MessageLoggedOut": "ایسا لگتا ہے کہ آپ لاگ آؤٹ ہو گئے ہیں۔  ",
+    "LogIn": "لاگ ان کریں",
+    "SavedDifferentWindow": "آپ نے جس پروجیکٹ کو محفوظ کرنے کی کوشش کی ہے اسے دوسری ونڈو سے محفوظ کر لیا گیا ہے۔\n        ",
+    "LinkTitle": "اکاؤنٹ لنک کرنے میں خرابی۔",
+    "LinkMessage": "آپ کے لنک کرنے میں ایک مسئلہ تھا۔ {{serviceauth}} اپنے p5.js ویب ایڈیٹر اکاؤنٹ میں اکاؤنٹ۔  {{serviceauth}} اکاؤنٹ پہلے ہی دوسرے p5.js ویب ایڈیٹر اکاؤنٹ سے منسلک ہے۔"
+  },
+  "ShareModal": {
+    "Embed": "ایمبیڈ",
+    "Present": "موجودہ",
+    "Fullscreen": "مکمل اسکرین یا بڑی اسکرین",
+    "Edit": "ترمیم"
+  },
+  "CollectionView": {
+    "TitleCreate": "مجموعہ بنائیں",
+    "TitleDefault": "مجموعہ"
+  },
+  "Collection": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "AnothersTitle": "p5.js ویب ایڈیٹر | {{anotheruser}}کے مجموعے",
+    "Share": "بانٹیں",
+    "URLLink": "مجموعہ سے لنک",
+    "AddSketch": "خاکہ شامل کریں۔",
+    "DeleteFromCollection": "کیا آپ واقعی ہٹانا چاہتے ہیں {{name_sketch}} اس مجموعہ سے؟",
+    "SketchDeleted": "خاکہ حذف کر دیا گیا۔",
+    "SketchRemoveARIA": "مجموعہ سے خاکہ کو ہٹا دیں۔",
+    "DescriptionPlaceholder": "تفصیل شامل کریں۔",
+    "Description": "تفصیل",
+    "NumSketches": "{{count}} خاکہ",
+    "NumSketches_plural": "{{count}} خاکے",
+    "By": "کی طرف سے مجموعہ ",
+    "NoSketches": "مجموعہ میں کوئی خاکہ نہیں۔",
+    "TableSummary": "تمام مجموعوں پر مشتمل میز",
+    "HeaderName": "نام",
+    "HeaderCreatedAt": "شامل کرنے کی تاریخ",
+    "HeaderUser": "مالک",
+    "DirectionAscendingARIA": "صعودی",
+    "DirectionDescendingARIA": "نزول",
+    "ButtonLabelAscendingARIA": "ترتیب دیں {{displayName}} چڑھتے ہوئے",
+    "ButtonLabelDescendingARIA": "ترتیب دیں {{displayName}} نزول",
+    "RemoveFromCollection": "Remove from Collection"
+  },
+  "AddToCollectionList": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "AnothersTitle": "p5.js ویب ایڈیٹر | {{anotheruser}}کے مجموعے",
+    "Empty": "کوئی مجموعہ نہیں۔"
+  },
+  "CollectionCreate": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "FormError": "مجموعہ نہیں بنایا جا سکا",
+    "FormLabel": "مجموعہ کا نام",
+    "FormLabelARIA": "نام",
+    "NameRequired": "مجموعہ کا نام درکار ہے۔",
+    "Description": "تفصیل (اختیاری)",
+    "DescriptionARIA": "تفصیل",
+    "DescriptionPlaceholder": "میرے پسندیدہ خاکے",
+    "SubmitCollectionCreate": "مجموعہ بنائیں"
+  },
+  "DashboardView": {
+    "CreateCollection": "مجموعہ بنائیں",
+    "NewSketch": "نیا خاکہ",
+    "CreateCollectionOverlay": "مجموعہ بنائیں"
+  },
+  "DashboardTabSwitcher": {
+    "Sketches": "خاکے",
+    "Collections": "مجموعے",
+    "Assets": "اثاثے"
+  },
+  "CollectionList": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "AnothersTitle": "p5.js ویب ایڈیٹر | {{anotheruser}}کے مجموعے",
+    "NoCollections": "کوئی مجموعہ نہیں۔",
+    "TableSummary": "تمام مجموعوں پر مشتمل میز",
+    "HeaderName": "نام",
+    "HeaderCreatedAt": "تاریخ تخلیق",
+    "HeaderCreatedAt_mobile": "بنایا",
+    "HeaderUpdatedAt": "تاریخ کی تازہ کاری",
+    "HeaderUpdatedAt_mobile": "تازہ کاری",
+    "HeaderNumItems": "",
+    "HeaderNumItems_mobile": "",
+    "DirectionAscendingARIA": "صعودی",
+    "DirectionDescendingARIA": "نزول",
+    "ButtonLabelAscendingARIA": "ترتیب دیں {{displayName}} چڑھتے ہوئے",
+    "ButtonLabelDescendingARIA": "ترتیب دیں {{displayName}} نزول",
+    "AddSketch": "خاکہ شامل کریں۔"
+  },
+  "CollectionListRow": {
+    "ToggleCollectionOptionsARIA": "اوپن/کلوز کلیکشن آپشنز کو ٹوگل کریں۔",
+    "AddSketch": "خاکہ شامل کریں۔",
+    "Delete": "حذف کریں۔",
+    "Rename": "نام تبدیل کریں۔"
+  },
+  "Overlay": {
+    "AriaLabel": "بند کریں {{title}} اوورلے"
+  },
+  "QuickAddList": {
+    "ButtonRemoveARIA": "مجموعہ سے ہٹا دیں۔",
+    "ButtonAddToCollectionARIA": "مجموعہ میں شامل کریں۔",
+    "View": "دیکھیں"
+  },
+  "Pagination": {
+    "Next": "Next",
+    "Previous": "Previous",
+    "Of": "of",
+    "PreviousPageARIA": "Previous Page",
+    "NextPageARIA": "Next Page"
+  },
+  "SketchList": {
+    "View": "دیکھیں",
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "AnothersTitle": "p5.js ویب ایڈیٹر | {{anotheruser}}کے خاکے",
+    "ToggleLabelARIA": "اوپن/کلوز اسکیچ آپشنز کو ٹوگل کریں۔",
+    "DropdownRename": "نام تبدیل کریں۔",
+    "DropdownDownload": "ڈاؤن لوڈ کریں",
+    "DropdownDuplicate": "نقل",
+    "DropdownAddToCollection": "مجموعہ میں شامل کریں۔",
+    "DropdownDelete": "حذف کریں۔",
+    "DirectionAscendingARIA": "صعودی",
+    "DirectionDescendingARIA": "نزول",
+    "ButtonLabelAscendingARIA": "ترتیب دیں {{displayName}} چڑھتے ہوئے",
+    "ButtonLabelDescendingARIA": "ترتیب دیں {{displayName}} نزول",
+    "AddToCollectionOverlayTitle": "مجموعہ میں شامل کریں۔",
+    "TableSummary": "تمام محفوظ شدہ منصوبوں پر مشتمل ٹیبل",
+    "HeaderName": "خاکہ",
+    "HeaderCreatedAt": "تاریخ تخلیق",
+    "HeaderCreatedAt_mobile": "بنایا",
+    "HeaderUpdatedAt": "تاریخ کی تازہ کاری",
+    "HeaderUpdatedAt_mobile": "تازہ کاری",
+    "NoSketches": "کوئی خاکے نہیں۔"
+  },
+  "AddToCollectionSketchList": {
+    "Title": "p5.js ویب ایڈیٹر | ",
+    "AnothersTitle": "p5.js ویب ایڈیٹر | {{anotheruser}}کے خاکے",
+    "NoCollections": "کوئی مجموعہ نہیں۔"
+  },
+  "Editor": {
+    "OpenSketchARIA": "اسکیچ فائلز نیویگیشن کھولیں۔",
+    "CloseSketchARIA": "اسکیچ فائلز نیویگیشن بند کریں۔",
+    "UnsavedChangesARIA": "اسکیچ میں غیر محفوظ شدہ تبدیلیاں ہیں۔",
+    "KeyUpLineNumber": "لائن {{lineNumber}}"
+  },
+  "EditorAccessibility": {
+    "NoLintMessages": "کوئی لنٹ پیغامات نہیں ہیں۔",
+    "CurrentLine": "موجودہ لائن"
+  },
+  "Timer": {
+    "SavedAgo": "محفوظ کیا گیا: {{timeAgo}}"
+  },
+  "formatDate": {
+    "JustNow": "ابھی ابھی",
+    "15Seconds": "15 سیکنڈ پہلے",
+    "25Seconds": "25 سیکنڈ پہلے",
+    "35Seconds": "35 سیکنڈ پہلے",
+    "Ago": "{{timeAgo}} پہلے"
+  },
+  "CopyableInput": {
+    "CopiedARIA": "کلپ بورڈ پر کاپی ہو گیا!",
+    "OpenViewTabARIA": "کھولیں۔ {{label}} نئے ٹیب میں دیکھیں"
+  },
+  "EditableInput": {
+    "EditValue": "ترمیم {{display}} قدر",
+    "EmptyPlaceholder": "کوئی قدر نہیں"
+  },
+  "PreviewNav": {
+    "EditSketchARIA": "خاکہ میں ترمیم کریں۔",
+    "ByUser": "کی طرف سے"
+  },
+  "MobilePreferences": {
+    "Settings": "ترتیبات",
+    "GeneralSettings": "عام ترتیبات",
+    "Accessibility": "رسائی",
+    "AccessibleOutput": "قابل رسائی آؤٹ پٹ",
+    "Theme": "خیالیہ",
+    "LightTheme": "روشنی",
+    "DarkTheme": "اندھیرا",
+    "HighContrastTheme": "ہائی کنٹراسٹ",
+    "Autosave": "خودبخود محفوظ کریں۔",
+    "AutocompleteHinter": "خودکار تکمیل اشارہ",
+    "WordWrap": "لفظ لفاف",
+    "LineNumbers": "لائن نمبرز",
+    "LintWarningSound": "لنٹ وارننگ کی آواز",
+    "UsedScreenReader": "اسکرین ریڈر کے ساتھ استعمال کیا جاتا ہے۔",
+    "PlainText": "سادہ متن",
+    "TableText": "ٹیبل ٹیکسٹ",
+    "Sound": "آواز",
+    "SelectLanguage": "زبان منتخب کریں",
+    "Preferences": "Preferences",
+    "Language": "Language"
+  },
+  "PreferenceCreators": {
+    "On": "پر",
+    "Off": "بند"
+  },
+  "MobileDashboardView": {
+    "Examples": "مثالیں",
+    "Sketches": "خاکے",
+    "Collections": "مجموعے",
+    "Assets": "اثاثے",
+    "MyStuff": "میرا سامان",
+    "CreateSketch": "خاکہ بنائیں",
+    "CreateCollection": "مجموعہ بنائیں"
+  },
+  "Explorer": {
+    "Files": "فائلوں"
+  },
+  "Cookies": {
+    "Header": "کوکیز",
+    "Body": "p5.js ایڈیٹر کوکیز استعمال کرتا ہے۔  <strong> ہم اس ڈیٹا کو کبھی فروخت نہیں کرتے اور نہ ہی اسے اشتہارات کے لیے استعمال کرتے ہیں۔ </strong> آپ فیصلہ کر سکتے ہیں کہ آپ کن کوکیز کی اجازت دینا چاہیں گے، اور ہماری میں مزید جانیں۔ <0>رازداری کی پالیسی<0>.",
+    "AllowAll": "سب کو اجازت دیں۔",
+    "AllowEssential": "ضروری کی اجازت دیں۔"
+  },
+  "Legal": {
+    "PrivacyPolicy": "رازداری کی پالیسی",
+    "TermsOfUse": "استعمال کرنے کی شرائط",
+    "CodeOfConduct": "ضابطہ اخلاق"
+  },
+  "TextArea": {
+    "CopyARIA": "Copy"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
-  
+}

--- a/translations/locales/zh-CN/translations.json
+++ b/translations/locales/zh-CN/translations.json
@@ -8,7 +8,13 @@
       "Open": "打开",
       "Download": "下载",
       "AddToCollection": "添加到集合",
-      "Examples": "范例"
+      "Examples": "范例",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "编辑",
@@ -27,7 +33,10 @@
       "Title": "帮助",
       "KeyboardShortcuts": "快捷键",
       "Reference": "参考文档",
-      "About": "关于"
+      "About": "关于",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
     "Lang": "语言",
     "BackEditor": "回到编辑器",
@@ -70,7 +79,12 @@
     "UsernameOrEmailARIA": "邮箱或用户名",
     "Password": "密码",
     "PasswordARIA": "密码",
-    "Submit": "登陆"
+    "Submit": "登陆",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
   },
   "LoginView": {
     "Title": "p5.js 在线编辑器 ｜ 登陆",
@@ -107,7 +121,34 @@
     "Examples": "范例",
     "PrivacyPolicy": "隐私政策",
     "TermsOfUse": "使用条款",
-    "CodeOfConduct": "行为准则"
+    "CodeOfConduct": "行为准则",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
+    },
+    "Contact": "Contact Us"
   },
   "Toast": {
     "OpenedNewSketch": "打开了新项目。",
@@ -116,7 +157,12 @@
     "AutosaveEnabled": "自动保存已打开。",
     "LangChange": "语言已更改",
     "SettingsSaved": "设置保存成功。",
-    "CloseAlertARIA": "Close Alert"
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
   },
   "Toolbar": {
     "Preview": "预览",
@@ -128,7 +174,10 @@
     "EditSketchARIA": "修改项目名称",
     "NewSketchNameARIA": "新项目名称",
     "By": "作者 ",
-    "SelectVersionARIA": "Select p5.js version"
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
   },
   "Console": {
     "Title": "控制台",
@@ -182,7 +231,24 @@
     "PlainText": "纯文本",
     "TextOutputARIA": "打开文字输出",
     "TableText": "表格文本",
-    "TableOutputARIA": "打开表格文本"
+    "TableOutputARIA": "打开表格文本",
+    "LibraryManagement": "Library Management",
+    "FontSize": "Font Size",
+    "SetFontSize": "set font size",
+    "LibraryVersion": "p5.js Version",
+    "LibraryVersionInfo": "There's a [new 2.0 release](https://github.com/processing/p5.js/releases/) of p5.js available! It will become default in August, 2026, so take this time to test it out and report bugs. Interested in transitioning sketches from 1.x to 2.0? Check out the [compatibility & transition resources.](https://github.com/processing/p5.js-compatibility)",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "SoundAddon": "p5.sound.js Add-on Library",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on Library — Preload",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on Library — Shapes",
+    "DataAddon": "p5.js 1.x Compatibility Add-on Library — Data & Events",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
   },
   "KeyboardShortcuts": {
     "Title": "快捷键",
@@ -199,14 +265,19 @@
       "CommentLine": "注释（或取消注释）行",
       "FindNextTextMatch": "查找下一个符合的文字",
       "FindPreviousTextMatch": "查找上一个符合的文字",
-      "CodeEditing": "代码编辑"
+      "CodeEditing": "代码编辑",
+      "ColorPicker": "Show Inline Color Picker",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
     },
     "GeneralSelection": {
       "StartSketch": "运行项目",
       "StopSketch": "停止运行",
       "TurnOnAccessibleOutput": "打开无障碍输出",
-      "TurnOffAccessibleOutput": "关闭无障碍输出"
-    }
+      "TurnOffAccessibleOutput": "关闭无障碍输出",
+      "Reference": "Go to Reference for Selected Item in Hinter"
+    },
+    "General": "General"
   },
   "Sidebar": {
     "Title": "项目文件",
@@ -216,7 +287,8 @@
     "AddFile": "新建文件",
     "AddFileARIA": "新建文件",
     "UploadFile": "上传文件",
-    "UploadFileARIA": "上传文件"
+    "UploadFileARIA": "上传文件",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "展开文件夹",
@@ -292,7 +364,8 @@
     "errorNewPasswordRepeat": "Your New Password must differ from the current one.",
     "errorEmptyUsername": "请输入一个用户名",
     "errorLongUsername": "用户名至多20位",
-    "errorValidUsername": "用户名只能含有数字，字母，和某些标点符号（. - _）。"
+    "errorValidUsername": "用户名只能含有数字，字母，和某些标点符号（. - _）。",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
   },
   "NewPasswordView": {
     "Title": "p5.js 在线编辑器 ｜ 新密码",
@@ -314,7 +387,8 @@
     "CurrentPasswordARIA": "当前密码",
     "NewPassword": "新密码",
     "NewPasswordARIA": "新密码",
-    "SubmitSaveAllSettings": "保存所有设置"
+    "SubmitSaveAllSettings": "保存所有设置",
+    "SaveAccountDetails": "Save Account Details"
   },
   "AccountView": {
     "SocialLogin": "第三方登陆",
@@ -360,14 +434,19 @@
     "PasswordARIA": "密码",
     "ConfirmPassword": "确认密码",
     "ConfirmPasswordARIA": "确认密码",
-    "SubmitSignup": "注册"
+    "SubmitSignup": "注册",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": "p5.js 在线编辑器 ｜ 注册",
     "Description": "注册",
     "Or": "或",
     "AlreadyHave": "已经有账户了？",
-    "Login": "登陆"
+    "Login": "登陆",
+    "Warning": "By signing up, you agree to the p5.js Editor's <0>Terms of Use</0> and <1>Privacy Policy.</1>"
   },
   "EmailVerificationView": {
     "Title": "p5.js 在线编辑器 ｜ 确认邮箱",
@@ -385,7 +464,8 @@
     "NoUploadedAssets": "没有上传的资产。",
     "HeaderName": "名称",
     "HeaderSize": "大小",
-    "HeaderSketch": "项目"
+    "HeaderSketch": "项目",
+    "maximum": "Maximum"
   },
   "Feedback": {
     "Title": "p5.js 在线编辑器 ｜ 反馈",
@@ -452,7 +532,8 @@
     "DirectionAscendingARIA": "升序",
     "DirectionDescendingARIA": "降序",
     "ButtonLabelAscendingARIA": "按 {{displayName}} 升序排列。",
-    "ButtonLabelDescendingARIA": "按 {{displayName}} 降序排列。"
+    "ButtonLabelDescendingARIA": "按 {{displayName}} 降序排列。",
+    "RemoveFromCollection": "Remove from Collection"
   },
   "AddToCollectionList": {
     "Title": "p5.js 在线编辑器 ｜ 我的集合",
@@ -596,7 +677,10 @@
     "UsedScreenReader": "结合屏幕阅读器使用",
     "PlainText": "纯文本",
     "TableText": "表格文本",
-    "Sound": "声音"
+    "Sound": "声音",
+    "SelectLanguage": "选择语言",
+    "Preferences": "Preferences",
+    "Language": "Language"
   },
   "PreferenceCreators": {
     "On": "打开",
@@ -616,5 +700,31 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "Cookies": {
+    "Header": "Cookies",
+    "Body": "The p5.js Editor uses cookies. Some are essential to the website functionality and allow you to manage an account and preferences. Others are not essential—they are used for analytics and allow us to learn more about our community. <strong> We never sell this data or use it for advertising. </strong> You can decide which cookies you would like to allow, and learn more in our <0>Privacy Policy<0>.",
+    "AllowAll": "Allow All",
+    "AllowEssential": "Allow Essential"
+  },
+  "Legal": {
+    "PrivacyPolicy": "Privacy Policy",
+    "TermsOfUse": "Terms of Use",
+    "CodeOfConduct": "Code of Conduct"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
 }

--- a/translations/locales/zh-TW/translations.json
+++ b/translations/locales/zh-TW/translations.json
@@ -8,7 +8,13 @@
       "Open": "開啟",
       "Download": "下載",
       "AddToCollection": "加入作品集",
-      "Examples": "範例"
+      "Examples": "範例",
+      "SaveTooltipUnauthenticated": "Log in to save your sketch",
+      "DuplicateTooltipUnauthenticated": "Log in to duplicate this sketch",
+      "OpenTooltipUnauthenticated": "Log in to open your sketches",
+      "AddToCollectionTooltipUnauthenticated": "Log in to add to collections",
+      "ShareTooltipUnsaved": "Save your sketch before sharing",
+      "DownloadTooltipUnsaved": "Save your sketch before downloading"
     },
     "Edit": {
       "Title": "編輯",
@@ -27,7 +33,10 @@
       "Title": "說明",
       "KeyboardShortcuts": "快捷鍵",
       "Reference": "參考文件",
-      "About": "關於"
+      "About": "關於",
+      "ReportBug": "Report a Bug",
+      "ChatOnDiscord": "Chat On Discord",
+      "PostOnTheForum": "Post on the Forum"
     },
     "Lang": "語言",
     "BackEditor": "回到編輯器",
@@ -70,7 +79,12 @@
     "UsernameOrEmailARIA": "電子郵件或使用者名稱",
     "Password": "密碼",
     "PasswordARIA": "密碼",
-    "Submit": "登入"
+    "Submit": "登入",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "Errors": {
+      "invalidCredentials": "Invalid email or password."
+    }
   },
   "LoginView": {
     "Title": "p5.js 網頁編輯器 | 登入",
@@ -107,7 +121,34 @@
     "Examples": "範例",
     "PrivacyPolicy": "隱私政策",
     "TermsOfUse": "使用條款",
-    "CodeOfConduct": "行為準則"
+    "CodeOfConduct": "行為準則",
+    "Headline": "Create, share, and remix p5.js sketches with the p5.js Editor.",
+    "IntroDescription1": "p5.js is a free, open-source JavaScript library for learning to code and make art. Using the p5.js Editor, you can create, share, and remix p5.js sketches without needing to download or configure anything.",
+    "IntroDescription2": "We believe software the tools to learn it, should be as open and inclusive as possible. You can support this work by making a donation to the Processing Foundation, the organization that supports p5.js. Your donation supports software development for p5.js, education resources like code examples and tutorials, fellowships, and community events.",
+    "Donate": "Donate",
+    "X": "X",
+    "DiscordCTA": "Join the Discord",
+    "Youtube": "Youtube",
+    "Github": "Github",
+    "GetInvolved": "Get Involved",
+    "Reference": "Reference",
+    "ForumCTA": "Join the Forum",
+    "Email": "Email",
+    "EmailAddress": "hello@p5js.org",
+    "Socials": "Socials",
+    "LinkDescriptions": {
+      "Home": "Learn more about p5.js and our community.",
+      "Examples": "Explore the possibilities of p5.js with short examples.",
+      "CodeOfConduct": "Read our Community Statement and Code of Conduct.",
+      "Libraries": "Expand the possibilities of p5.js with community-created libraries.",
+      "Reference": "Find easy explanations for every piece of p5.js code.",
+      "Donate": "Support this work with a donation to the Processing Foundation.",
+      "Contribute": "Contribute to the open-source p5.js Editor on Github.",
+      "Report": "Report broken or incorrect behavior with the p5.js Editor.",
+      "Forum": "Ask questions, share sketches, and get help from the p5.js community.",
+      "Discord": "Chat with the p5.js community and get quick help."
+    },
+    "Contact": "Contact Us"
   },
   "Toast": {
     "OpenedNewSketch": "已開啟新草稿",
@@ -116,7 +157,12 @@
     "AutosaveEnabled": "已啟用自動儲存",
     "LangChange": "已變更語系",
     "SettingsSaved": "已儲存設定",
-    "CloseAlertARIA": "Close Alert"
+    "CloseAlertARIA": "Close Alert",
+    "EmptyCurrentPass": "Current password field is empty",
+    "IncorrectCurrentPass": "Current password is incorrect",
+    "DefaultError": "Something went wrong",
+    "UserNotFound": "User not found",
+    "NetworkError": "Network error"
   },
   "Toolbar": {
     "Preview": "預覽",
@@ -128,7 +174,10 @@
     "EditSketchARIA": "編輯草稿名稱",
     "NewSketchNameARIA": "新草稿名稱",
     "By": " 作者： ",
-    "SelectVersionARIA": "Select p5.js version"
+    "SelectVersionARIA": "Select p5.js version",
+    "CustomLibraryVersion": "Custom p5.js version",
+    "VersionPickerARIA": "Version picker",
+    "NewVersionPickerARIA": "Version picker"
   },
   "Console": {
     "Title": "主控台",
@@ -182,7 +231,24 @@
     "PlainText": "純文字",
     "TextOutputARIA": "讀出文字輸出",
     "TableText": "表格文字",
-    "TableOutputARIA": "讀出表格文字"
+    "TableOutputARIA": "讀出表格文字",
+    "LibraryManagement": "Library Management",
+    "FontSize": "Font Size",
+    "SetFontSize": "set font size",
+    "LibraryVersion": "p5.js Version",
+    "LibraryVersionInfo": "There's a [new 2.0 release](https://github.com/processing/p5.js/releases/) of p5.js available! It will become default in August, 2026, so take this time to test it out and report bugs. Interested in transitioning sketches from 1.x to 2.0? Check out the [compatibility & transition resources.](https://github.com/processing/p5.js-compatibility)",
+    "CustomVersionTitle": "Managing your own libraries? Nice!",
+    "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
+    "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",
+    "SoundAddon": "p5.sound.js Add-on Library",
+    "PreloadAddon": "p5.js 1.x Compatibility Add-on Library — Preload",
+    "ShapesAddon": "p5.js 1.x Compatibility Add-on Library — Shapes",
+    "DataAddon": "p5.js 1.x Compatibility Add-on Library — Data & Events",
+    "AddonOnARIA": "on",
+    "AddonOffARIA": "off",
+    "SoundReference": "View the reference for p5.sound compatible with p5.js {{version}}",
+    "CopyToClipboardSuccess": "Copied to clipboard!",
+    "CopyToClipboardFailure": "We weren't able to copy the text, try selecting it and copying it manually."
   },
   "KeyboardShortcuts": {
     "Title": " 鍵盤快捷鍵",
@@ -199,14 +265,19 @@
       "CommentLine": "將此行變成註解",
       "FindNextTextMatch": "尋找下一個相符的文字",
       "FindPreviousTextMatch": "尋找上一個相符的文字",
-      "CodeEditing": "編輯程式碼"
+      "CodeEditing": "編輯程式碼",
+      "ColorPicker": "Show Inline Color Picker",
+      "CreateNewFile": "Create New File",
+      "RenameVariable": "Rename Variable"
     },
     "GeneralSelection": {
       "StartSketch": "執行草稿",
       "StopSketch": "停止草稿",
       "TurnOnAccessibleOutput": "啟用輔助輸出",
-      "TurnOffAccessibleOutput": "停用輔助輸出"
-    }
+      "TurnOffAccessibleOutput": "停用輔助輸出",
+      "Reference": "Go to Reference for Selected Item in Hinter"
+    },
+    "General": "General"
   },
   "Sidebar": {
     "Title": "草稿檔案",
@@ -216,7 +287,8 @@
     "AddFile": "建立檔案",
     "AddFileARIA": "新增檔案",
     "UploadFile": "上傳檔案",
-    "UploadFileARIA": "上傳檔案"
+    "UploadFileARIA": "上傳檔案",
+    "UploadFileTooltipUnauthenticated": "Log in to upload files"
   },
   "FileNode": {
     "OpenFolderARIA": "開啟資料夾",
@@ -292,7 +364,8 @@
     "errorNewPasswordRepeat": "Your New Password must differ from the current one.",
     "errorEmptyUsername": "請輸入使用者名稱",
     "errorLongUsername": "使用者名稱最多只能 20 個字元",
-    "errorValidUsername": "使用者名稱只能有數字、字母、英文句點、減號以及底線符號"
+    "errorValidUsername": "使用者名稱只能有數字、字母、英文句點、減號以及底線符號",
+    "errorEmptyEmailorUserName": "Please enter an email or username"
   },
   "NewPasswordView": {
     "Title": "p5.js 網頁編輯器 | 新密碼",
@@ -314,7 +387,8 @@
     "CurrentPasswordARIA": "目前密碼",
     "NewPassword": "新密碼",
     "NewPasswordARIA": "新密碼",
-    "SubmitSaveAllSettings": "儲存所有設定"
+    "SubmitSaveAllSettings": "儲存所有設定",
+    "SaveAccountDetails": "Save Account Details"
   },
   "AccountView": {
     "SocialLogin": "以社群帳號登入",
@@ -360,14 +434,19 @@
     "PasswordARIA": "密碼",
     "ConfirmPassword": "確認密碼",
     "ConfirmPasswordARIA": "確認密碼",
-    "SubmitSignup": "註冊"
+    "SubmitSignup": "註冊",
+    "ShowPasswordARIA": "Show password as plain text",
+    "HidePasswordARIA": "Hide password",
+    "ShowConfirmPasswordARIA": "Show confirm password as plain text",
+    "HideConfirmPasswordARIA": "Hide confirm password"
   },
   "SignupView": {
     "Title": "p5.js 網頁編輯器 | 註冊",
     "Description": "註冊",
     "Or": "或是",
     "AlreadyHave": "已經有帳號？",
-    "Login": "登入"
+    "Login": "登入",
+    "Warning": "By signing up, you agree to the p5.js Editor's <0>Terms of Use</0> and <1>Privacy Policy.</1>"
   },
   "EmailVerificationView": {
     "Title": "p5.js 網頁編輯器 | 驗證電子郵件",
@@ -385,7 +464,8 @@
     "NoUploadedAssets": "尚未上傳資產",
     "HeaderName": "名稱",
     "HeaderSize": "大小",
-    "HeaderSketch": "草稿"
+    "HeaderSketch": "草稿",
+    "maximum": "Maximum"
   },
   "Feedback": {
     "Title": "p5.js 網頁編輯器 | 回饋",
@@ -452,7 +532,8 @@
     "DirectionAscendingARIA": "升序",
     "DirectionDescendingARIA": "降序",
     "ButtonLabelAscendingARIA": "以 {{displayName}} 升序排列",
-    "ButtonLabelDescendingARIA": "以 {{displayName}} 降序排列"
+    "ButtonLabelDescendingARIA": "以 {{displayName}} 降序排列",
+    "RemoveFromCollection": "Remove from Collection"
   },
   "AddToCollectionList": {
     "Title": "p5.js 網頁編輯器 | 我的作品集",
@@ -596,7 +677,10 @@
     "UsedScreenReader": "搭配螢幕報讀軟體使用",
     "PlainText": "純文字",
     "TableText": "表格文字",
-    "Sound": "聲"
+    "Sound": "聲",
+    "SelectLanguage": "選擇語言",
+    "Preferences": "Preferences",
+    "Language": "Language"
   },
   "PreferenceCreators": {
     "On": "啟用",
@@ -616,5 +700,31 @@
   },
   "TextArea": {
     "CopyARIA": "Copy"
+  },
+  "Cookies": {
+    "Header": "Cookies",
+    "Body": "The p5.js Editor uses cookies. Some are essential to the website functionality and allow you to manage an account and preferences. Others are not essential—they are used for analytics and allow us to learn more about our community. <strong> We never sell this data or use it for advertising. </strong> You can decide which cookies you would like to allow, and learn more in our <0>Privacy Policy<0>.",
+    "AllowAll": "Allow All",
+    "AllowEssential": "Allow Essential"
+  },
+  "Legal": {
+    "PrivacyPolicy": "Privacy Policy",
+    "TermsOfUse": "Terms of Use",
+    "CodeOfConduct": "Code of Conduct"
+  },
+  "SkipLink": {
+    "PlaySketch": "Skip to Play Sketch"
+  },
+  "Visibility": {
+    "Label": "Visibility",
+    "Public": {
+      "Description": "Anyone can see this sketch.",
+      "Label": "Public"
+    },
+    "Private": {
+      "Description": "Only you can see this sketch.",
+      "Label": "Private"
+    },
+    "Changed": "'{{projectName}}' is now {{newVisibility}}..."
   }
 }


### PR DESCRIPTION
### Issue
Fixes #3928

Some MobileNav UI labels ("My Stuff", "Settings", "Log Out", "by…") were hardcoded and did not respond to language changes. Additionally, the corresponding translation keys — including "Select Language" — were missing from non-English locale files.

---

### Demo
<img width="400" height="450" alt="image" src="https://github.com/user-attachments/assets/fbbab8a8-a0d7-4fdf-948a-07ede42c3fba" />
<img width="400" height="435" alt="image" src="https://github.com/user-attachments/assets/8650b611-2f4d-4e09-822d-b44485c2e7f5" />


---

### Changes
- Replaced hardcoded strings in `MobileNav.jsx` with `t()` calls.
- Added missing translation keys to all locale JSON files using English values as placeholders.
- Added a script to sync missing keys from the base English translations file.
- Added verified Hindi translations for key labels for local testing.

---

### I have verified that this pull request:
* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number.
* [x] meets the accessibility guidelines.