### PR TITLE
ci: add coverage reporting, bump deprecated action versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,12 @@ jobs:
     name: Test and lint code base
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '18.20.x'
       - run: npm install
-      - run: npm run test
+      - run: npm run test -- --coverage
       - run: npm run typecheck
       - run: npm run lint

--- a/package.json
+++ b/package.json
@@ -42,6 +42,14 @@
     ]
   },
   "jest": {
+    "coverageReporters": [
+      "text-summary"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "lines": 5
+      }
+    },
     "projects": [
       {
         "displayName": "server",


### PR DESCRIPTION

Fixes #3895

Both `actions/checkout` and `actions/setup-node` were still on v2/v1 (Node 12, deprecated for ages, GitHub's been warning about it in every run). Also added `--coverage` to the test step with a `text-summary` reporter and a 5% line threshold so we at least have a number to look at in CI.

 Changes: Bumped deprecated GitHub Actions to v4 and enabled Jest coverage in CI with a text summary plus a minimal 5% global line threshold so coverage regressions don’t slip by silently.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #3895`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)