### PR TITLE
Generated unique username not applied during account creation

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -211,7 +211,7 @@ passport.use(
         const user = new User();
         user.email = primaryEmail;
         user.github = profile.id;
-        user.username = profile.username;
+        user.username = username;
         user.tokens.push({ kind: 'github', accessToken });
         user.name = profile.displayName;
         user.verified = User.EmailConfirmation().Verified;


### PR DESCRIPTION
### Changes:
Fixed an issue where username conflict occurs from a manual signup and then a github account signup using same username. Destructuring profile to get username does not create a reference to the profile object property so we must manually assign the value.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
