### PR TITLE
Hardcoded url

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -234,7 +234,7 @@ passport.use(
     {
       clientID: process.env.GOOGLE_ID,
       clientSecret: process.env.GOOGLE_SECRET,
-      callbackURL: 'https://editor.p5js.org/auth/google/callback',
+      callbackURL: `${process.env.EDITOR_URL}/auth/google/callback`,
       passReqToCallback: true,
       scope: ['openid email']
     },


### PR DESCRIPTION
### Issue:
Fixes #3910 

### Changes:
Use the EDITOR_URL environment variable to construct the callback URL. instead of hardcoded `https://editor.p5js.org/auth/google/callback`
### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
