### PR TITLE
fix(auth): prevent crash when Google OAuth email is missing 

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -240,8 +240,21 @@ passport.use(
     },
     async (req, accessToken, refreshToken, profile, done) => {
       try {
+        const emailEntries = profile?.emails || profile?._json?.emails || [];
+        const primaryEmail = (
+          emailEntries.find(
+            (email) => typeof email?.value === 'string' && email.value.trim()
+          ) || {}
+        ).value;
+
+        if (!primaryEmail) {
+          return done(null, false, {
+            msg: 'Google account does not provide an email address.'
+          });
+        }
+
         const existingUser = await User.findOne({
-          google: profile._json.emails[0].value
+          google: primaryEmail
         }).exec();
 
         if (existingUser) {
@@ -258,18 +271,16 @@ passport.use(
           return done(null, existingUser);
         }
 
-        const primaryEmail = profile._json.emails[0].value;
-
         if (req.user) {
           if (!req.user.google) {
-            req.user.google = profile._json.emails[0].value;
+            req.user.google = primaryEmail;
             req.user.tokens.push({ kind: 'google', accessToken });
             req.user.verified = User.EmailConfirmation().Verified;
           }
           await req.user.save();
           return done(null, req.user);
         }
-        let username = profile._json.emails[0].value.split('@')[0];
+        let username = primaryEmail.split('@')[0];
         const existingEmailUser = await User.findByEmail(primaryEmail);
         const existingUsernameUser = await User.findByUsername(username, {
           caseInsensitive: true
@@ -285,14 +296,16 @@ passport.use(
             return done(null, false, { msg: accountSuspensionMessage });
           }
           existingEmailUser.email = existingEmailUser.email || primaryEmail;
-          existingEmailUser.google = profile._json.emails[0].value;
+          existingEmailUser.google = primaryEmail;
           existingEmailUser.username = existingEmailUser.username || username;
           existingEmailUser.tokens.push({
             kind: 'google',
             accessToken
           });
           existingEmailUser.name =
-            existingEmailUser.name || profile._json.displayName;
+            existingEmailUser.name ||
+            profile.displayName ||
+            profile._json?.displayName;
           existingEmailUser.verified = User.EmailConfirmation().Verified;
 
           await existingEmailUser.save();
@@ -301,10 +314,10 @@ passport.use(
 
         const user = new User();
         user.email = primaryEmail;
-        user.google = profile._json.emails[0].value;
+        user.google = primaryEmail;
         user.username = username;
         user.tokens.push({ kind: 'google', accessToken });
-        user.name = profile._json.displayName;
+        user.name = profile.displayName || profile._json?.displayName;
         user.verified = User.EmailConfirmation().Verified;
 
         await user.save();

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -241,15 +241,13 @@ passport.use(
     async (req, accessToken, refreshToken, profile, done) => {
       try {
         const emailEntries = profile?.emails || profile?._json?.emails || [];
-        const primaryEmail = (
-          emailEntries.find(
-            (email) => typeof email?.value === 'string' && email.value.trim()
-          ) || {}
-        ).value;
-
+        const primaryEmailEntry = emailEntries.find(
+          (email) => typeof email?.value === 'string'
+        );
+        const primaryEmail = primaryEmailEntry?.value?.trim();
         if (!primaryEmail) {
           return done(null, false, {
-            msg: 'Google account does not provide an email address.'
+            msg: 'Google account does not provide a valid email address.'
           });
         }
 


### PR DESCRIPTION
## Summary

Fixes an issue in the Google OAuth strategy where the code directly accessed
`profile._json.emails[0].value` without validating that `emails` exists and
contains at least one entry.

If Google does not return an email array, this results in:
TypeError: Cannot read property '0' of undefined

This PR adds proper validation and ensures the OAuth flow fails gracefully
instead of crashing.

## Changes

- Added safe check for `profile.emails` (or `_json.emails`) before accessing index 0
- Extracted email into a `primaryEmail` variable
- If no email is found, return:
  `done(null, false, { msg: 'Google account does not provide an email address.' })`
- Replaced all direct usages of `profile._json.emails[0].value`

## Why This Is Needed

Google does not guarantee that the `emails` array will be present
(depending on scopes, account type, or privacy settings).
Without validation, the OAuth flow crashes instead of failing gracefully.

## Testing

- Mocked a Google profile without `emails`
- Confirmed OAuth flow no longer throws a TypeError
- Verified user-friendly failure message is returned instead

Closes #3907