### PR TITLE
Remove raw error responses from server

### DIFF
--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -149,7 +149,8 @@ export async function copyObjectInS3RequestHandler(req, res) {
     const newUrl = await copyObjectInS3(url, req.user.id);
     res.json({ url: newUrl });
   } catch (error) {
-    res.status(500).json({ error: error.message });
+    console.error('Error copying object in S3:', error.message);
+    res.status(500).json({ error: 'Internal server error' });
   }
 }
 

--- a/server/controllers/user.controller/__tests__/authManagement/updateSettings.test.ts
+++ b/server/controllers/user.controller/__tests__/authManagement/updateSettings.test.ts
@@ -523,7 +523,7 @@ describe('user.controller > auth management > updateSettings (email, username, p
 
   describe('and when there is any other error', () => {
     beforeEach(async () => {
-      User.findById = jest.fn().mockRejectedValue('db error');
+      User.findById = jest.fn().mockRejectedValue('Internal server error');
       requestBody = minimumValidRequest;
       request.setBody(requestBody);
       await updateSettings(
@@ -534,7 +534,9 @@ describe('user.controller > auth management > updateSettings (email, username, p
     });
     it('returns a 500 error', () => {
       expect(response.status).toHaveBeenCalledWith(500);
-      expect(response.json).toHaveBeenCalledWith({ error: 'db error' });
+      expect(response.json).toHaveBeenCalledWith({
+        error: 'Internal server error'
+      });
     });
   });
 });

--- a/server/controllers/user.controller/__tests__/helpers.test.ts
+++ b/server/controllers/user.controller/__tests__/helpers.test.ts
@@ -87,7 +87,7 @@ describe('user.controller > helpers', () => {
       );
       expect(response.status).toHaveBeenCalledWith(500);
       expect(response.json).toHaveBeenCalledWith({
-        error: 'async error'
+        error: 'Internal server error'
       });
     });
   });

--- a/server/controllers/user.controller/__tests__/userPreferences.test.ts
+++ b/server/controllers/user.controller/__tests__/userPreferences.test.ts
@@ -84,7 +84,7 @@ describe('user.controller > user preferences', () => {
     it('returns 500 if saving preferences fails', async () => {
       mockUser = createMockUser({
         preferences: { ...mockUserPreferences, theme: AppThemeOptions.LIGHT },
-        save: jest.fn().mockRejectedValue(new Error('DB error'))
+        save: jest.fn().mockRejectedValue(new Error('Internal server error'))
       });
 
       User.findById = jest
@@ -101,7 +101,9 @@ describe('user.controller > user preferences', () => {
       );
 
       expect(response.status).toHaveBeenCalledWith(500);
-      expect(response.json).toHaveBeenCalledWith({ error: expect.any(Error) });
+      expect(response.json).toHaveBeenCalledWith({
+        error: 'Internal server error'
+      });
     });
   });
 
@@ -155,7 +157,7 @@ describe('user.controller > user preferences', () => {
     it('returns 500 if saving cookieConsent fails', async () => {
       mockUser = createMockUser({
         cookieConsent: CookieConsentOptions.ALL,
-        save: jest.fn().mockRejectedValue(new Error('DB error'))
+        save: jest.fn().mockRejectedValue(new Error('Internal server error'))
       });
 
       User.findById = jest
@@ -172,7 +174,9 @@ describe('user.controller > user preferences', () => {
       );
 
       expect(response.status).toHaveBeenCalledWith(500);
-      expect(response.json).toHaveBeenCalledWith({ error: expect.any(Error) });
+      expect(response.json).toHaveBeenCalledWith({
+        error: 'Internal server error'
+      });
     });
   });
 });

--- a/server/controllers/user.controller/apiKey.ts
+++ b/server/controllers/user.controller/apiKey.ts
@@ -77,10 +77,9 @@ export const createApiKey: RequestHandler<
     res.json({ apiKeys });
   } catch (err) {
     if (err instanceof Error) {
-      res.status(500).json({ error: err.message });
-    } else {
-      res.status(500).json({ error: 'Internal server error' });
+      console.error('Could not create API key:', err.message);
     }
+    res.status(500).json({ error: 'Internal server error' });
   }
 };
 
@@ -122,9 +121,8 @@ export const removeApiKey: RequestHandler<
     res.status(200).json({ apiKeys: user.apiKeys });
   } catch (err: unknown) {
     if (err instanceof Error) {
-      res.status(500).json({ error: err.message });
-    } else {
-      res.status(500).json({ error: 'Internal server error' });
+      console.error('Could not remove API key:', err.message);
     }
+    res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/server/controllers/user.controller/authManagement.ts
+++ b/server/controllers/user.controller/authManagement.ts
@@ -201,7 +201,8 @@ export const updateSettings: RequestHandler<
       await saveUser(res, user);
     }
   } catch (err) {
-    res.status(500).json({ error: err });
+    console.error('Could not save settings:', err);
+    res.status(500).json({ error: 'Internal server error' });
   }
 };
 

--- a/server/controllers/user.controller/helpers.ts
+++ b/server/controllers/user.controller/helpers.ts
@@ -67,7 +67,8 @@ export async function saveUser(res: Response, user: UserDocument) {
     await user.save();
     res.json(userResponse(user));
   } catch (error) {
-    res.status(500).json({ error });
+    console.error('Could not save user:', error);
+    res.status(500).json({ error: 'Internal server error' });
   }
 }
 

--- a/server/controllers/user.controller/signup.ts
+++ b/server/controllers/user.controller/signup.ts
@@ -75,8 +75,8 @@ export const createUser: RequestHandler<
       }
     });
   } catch (err) {
-    console.error(err);
-    res.status(500).json({ error: err });
+    console.error('Could not create user:', err);
+    res.status(500).json({ error: 'Internal server error' });
   }
 };
 
@@ -158,7 +158,8 @@ export const emailVerificationInitiate: RequestHandler<
 
     res.json(userResponse(req.user!));
   } catch (err) {
-    res.status(500).json({ error: err });
+    console.error('Could not initiate email verification:', err);
+    res.status(500).json({ error: 'Internal server error' });
   }
 };
 

--- a/server/controllers/user.controller/userPreferences.ts
+++ b/server/controllers/user.controller/userPreferences.ts
@@ -33,7 +33,8 @@ export const updatePreferences: RequestHandler<
     await user.save();
     res.json(user.preferences);
   } catch (err) {
-    res.status(500).json({ error: err });
+    console.error('Could not save preferences:', err);
+    res.status(500).json({ error: 'Internal server error' });
   }
 };
 
@@ -61,6 +62,7 @@ export const updateCookieConsent: RequestHandler<
     user.cookieConsent = cookieConsent;
     await saveUser(res, user);
   } catch (err) {
-    res.status(500).json({ error: err });
+    console.error('Could not save cookie consent:', err);
+    res.status(500).json({ error: 'Internal server error' });
   }
 };

--- a/server/server.js
+++ b/server/server.js
@@ -168,7 +168,8 @@ app.get('/', (req, res) => {
 // Handle API errors
 app.use('/api', (error, req, res, next) => {
   if (error && error.code && !res.headersSent) {
-    res.status(error.code).json({ error: error.message });
+    console.error('API error:', error.message);
+    res.status(error.code).json({ error: 'Internal server error' });
     return;
   }
 


### PR DESCRIPTION
### Issue:
Fixes #3954 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->

### Changes:
Updates all sources which gives a raw error message prints it to the server logs and returns a `Internal server error` response instead

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
