### PR TITLE
fix(signup): validate check_type in duplicate duplicate_check endpoint

### DIFF
--- a/server/controllers/user.controller/signup.ts
+++ b/server/controllers/user.controller/signup.ts
@@ -96,7 +96,14 @@ export const duplicateUserCheck: RequestHandler<
   DuplicateUserCheckQuery
 > = async (req, res) => {
   const checkType = req.query.check_type;
-  const value = req.query[checkType];
+
+  if (checkType !== 'email' && checkType !== 'username') {
+    return res
+      .status(400)
+      .json({ error: 'Invalid check_type. Must be email or username.' });
+  }
+
+  const value = checkType === 'email' ? req.query.email : req.query.username;
   const options = { caseInsensitive: true, valueType: checkType };
   const user = await User.findByEmailOrUsername(value!, options);
   if (user) {


### PR DESCRIPTION
## Summary

Fixes a security issue in the `duplicateUserCheck` controller where
`req.query.check_type` was used without validation.

Previously, the value of `check_type` was used both as:
- A dynamic key to access `req.query[checkType]`
- The `valueType` option passed to `User.findByEmailOrUsername`

This allowed sending values such as:
`check_type=__proto__` or `check_type=constructor`,
which could lead to prototype pollution or unexpected behavior.

## Changes

- Added strict validation to allow only:
  - 'email'
  - 'username'
- Return `400 Bad Request` for any invalid `check_type`
- Removed unsafe dynamic usage without whitelist validation

## Why This Is Needed

User input should never be used as dynamic object keys
without validation. This change ensures:

- Safer query handling
- Prevention of prototype manipulation
- Predictable endpoint behavior

## Testing

- Verified valid requests:
  - `/duplicate_check?check_type=email&email=test@example.com`
  - `/duplicate_check?check_type=username&username=testuser`
- Verified invalid requests:
  - `/duplicate_check?check_type=__proto__`
  - `/duplicate_check?check_type=constructor`
- Confirmed invalid inputs return 400.

This improves input validation and overall endpoint security.

closes #3906