### PR TITLE
fix: add email validation for google oauth

### DIFF
--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -136,7 +136,8 @@ const getGooglePrimaryEmail = (googleEmails) => {
   ) {
     return null;
   }
-  return googleEmails[0]?.value || null;
+  const primaryEmail = googleEmails[0]?.value?.trim();
+  return primaryEmail || null;
 };
 
 /**

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -129,11 +129,7 @@ const getPrimaryEmail = (githubEmails) =>
  * Returns the first email if available, or null if emails array is missing/empty.
  */
 const getGooglePrimaryEmail = (googleEmails) => {
-  if (
-    !googleEmails ||
-    !Array.isArray(googleEmails) ||
-    googleEmails.length === 0
-  ) {
+  if (!Array.isArray(googleEmails) || googleEmails.length === 0) {
     return null;
   }
   const primaryEmail = googleEmails[0]?.value?.trim();

--- a/server/config/passport.js
+++ b/server/config/passport.js
@@ -125,6 +125,21 @@ const getPrimaryEmail = (githubEmails) =>
   (lodash.find(githubEmails, { primary: true }) || {}).value;
 
 /**
+ * Get primary email from Google OAuth profile.
+ * Returns the first email if available, or null if emails array is missing/empty.
+ */
+const getGooglePrimaryEmail = (googleEmails) => {
+  if (
+    !googleEmails ||
+    !Array.isArray(googleEmails) ||
+    googleEmails.length === 0
+  ) {
+    return null;
+  }
+  return googleEmails[0]?.value || null;
+};
+
+/**
  * Sign in with GitHub.
  */
 passport.use(
@@ -240,8 +255,18 @@ passport.use(
     },
     async (req, accessToken, refreshToken, profile, done) => {
       try {
+        // Validate that emails array exists and has at least one element
+        const primaryEmail = getGooglePrimaryEmail(profile._json?.emails);
+        if (!primaryEmail) {
+          return done(null, false, {
+            msg:
+              'Unable to retrieve email from Google account. ' +
+              'Please ensure your Google account has an email address and try again.'
+          });
+        }
+
         const existingUser = await User.findOne({
-          google: profile._json.emails[0].value
+          google: primaryEmail
         }).exec();
 
         if (existingUser) {
@@ -258,18 +283,16 @@ passport.use(
           return done(null, existingUser);
         }
 
-        const primaryEmail = profile._json.emails[0].value;
-
         if (req.user) {
           if (!req.user.google) {
-            req.user.google = profile._json.emails[0].value;
+            req.user.google = primaryEmail;
             req.user.tokens.push({ kind: 'google', accessToken });
             req.user.verified = User.EmailConfirmation().Verified;
           }
           await req.user.save();
           return done(null, req.user);
         }
-        let username = profile._json.emails[0].value.split('@')[0];
+        let username = primaryEmail.split('@')[0];
         const existingEmailUser = await User.findByEmail(primaryEmail);
         const existingUsernameUser = await User.findByUsername(username, {
           caseInsensitive: true
@@ -285,7 +308,7 @@ passport.use(
             return done(null, false, { msg: accountSuspensionMessage });
           }
           existingEmailUser.email = existingEmailUser.email || primaryEmail;
-          existingEmailUser.google = profile._json.emails[0].value;
+          existingEmailUser.google = primaryEmail;
           existingEmailUser.username = existingEmailUser.username || username;
           existingEmailUser.tokens.push({
             kind: 'google',
@@ -301,7 +324,7 @@ passport.use(
 
         const user = new User();
         user.email = primaryEmail;
-        user.google = profile._json.emails[0].value;
+        user.google = primaryEmail;
         user.username = username;
         user.tokens.push({ kind: 'google', accessToken });
         user.name = profile._json.displayName;


### PR DESCRIPTION
### Issue:
Fixes #3907

The Google OAuth strategy was accessing `profile._json.emails[0].value` without validating that the `emails` array exists or has any elements. This caused a `TypeError: Cannot read property '0' of undefined` crash when Google OAuth profiles didn't include email addresses, breaking the authentication flow.

### Changes:

**Added email validation helper function:**
- Created `getGooglePrimaryEmail()` helper function that safely extracts the primary email from Google OAuth profile
- Validates that `emails` array exists, is an array, and has at least one element
- Uses optional chaining for safe property access
- Trims whitespace from email addresses
- Returns `null` for missing or invalid emails

**Updated Google OAuth strategy callback:**
- Added validation at the start of the callback to check for email availability
- Returns user-friendly error message when emails are missing: "Unable to retrieve email from Google account. Please ensure your Google account has an email address and try again."
- Replaced all 6 unsafe `profile._json.emails[0].value` accesses with the validated `primaryEmail` variable
- Prevents crashes and provides graceful error handling

**Files changed:**
- `server/config/passport.js`: Added email validation helper and updated Google strategy

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #3907`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
