### PR TITLE
fix: add input validation for check_type in duplicate check

### DIFF
--- a/server/controllers/user.controller/signup.ts
+++ b/server/controllers/user.controller/signup.ts
@@ -98,7 +98,6 @@ export const duplicateUserCheck: RequestHandler<
   const checkType = req.query.check_type;
   const allowedCheckTypes = ['email', 'username'] as const;
 
-  // Validate check_type to prevent prototype pollution
   if (
     !checkType ||
     !allowedCheckTypes.includes(checkType as 'email' | 'username')
@@ -110,7 +109,6 @@ export const duplicateUserCheck: RequestHandler<
 
   const value = req.query[checkType];
 
-  // Validate that the corresponding value exists
   if (!value || typeof value !== 'string' || value.trim().length === 0) {
     return res.status(400).json({
       error: `Missing or invalid ${checkType} value.`

--- a/server/controllers/user.controller/signup.ts
+++ b/server/controllers/user.controller/signup.ts
@@ -96,9 +96,29 @@ export const duplicateUserCheck: RequestHandler<
   DuplicateUserCheckQuery
 > = async (req, res) => {
   const checkType = req.query.check_type;
+  const allowedCheckTypes = ['email', 'username'] as const;
+
+  // Validate check_type to prevent prototype pollution
+  if (
+    !checkType ||
+    !allowedCheckTypes.includes(checkType as 'email' | 'username')
+  ) {
+    return res.status(400).json({
+      error: 'Invalid check_type. Must be either "email" or "username".'
+    });
+  }
+
   const value = req.query[checkType];
+
+  // Validate that the corresponding value exists
+  if (!value || typeof value !== 'string' || value.trim().length === 0) {
+    return res.status(400).json({
+      error: `Missing or invalid ${checkType} value.`
+    });
+  }
+
   const options = { caseInsensitive: true, valueType: checkType };
-  const user = await User.findByEmailOrUsername(value!, options);
+  const user = await User.findByEmailOrUsername(value, options);
   if (user) {
     return res.json({
       exists: true,


### PR DESCRIPTION
### Issue:
Fixes #3906

The `duplicateUserCheck` endpoint was using `req.query.check_type` directly without validation, allowing it to be used as both a property key (`req.query[checkType]`) and as `valueType` for `findByEmailOrUsername`. This vulnerability could lead to prototype pollution attacks if malicious values like `check_type=__proto__` or `check_type=constructor` were sent, potentially causing unexpected behavior or security issues.

### Changes:

**Added input validation for `check_type`:**
- Created a whitelist of allowed values: `['email', 'username']`
- Validates that `check_type` is exactly one of the allowed values before processing
- Returns 400 error with clear message: "Invalid check_type. Must be either \"email\" or \"username\"." for invalid values
- Prevents prototype pollution by validating before using `checkType` as a property key

**Added value validation:**
- Validates that the corresponding value (`email` or `username`) exists in the query
- Ensures the value is a non-empty string after trimming
- Returns 400 error: "Missing or invalid {checkType} value." if validation fails

**Security improvements:**
- Prevents unsafe property access that could lead to prototype pollution
- Uses TypeScript `as const` for type safety
- Early validation prevents malicious inputs from reaching the database query

**Files changed:**
- `server/controllers/user.controller/signup.ts`: Added validation logic to `duplicateUserCheck` function

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #3906`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
