### PR TITLE
Nityam/fix private assets authorization

### DIFF
--- a/server/controllers/project.controller.js
+++ b/server/controllers/project.controller.js
@@ -131,6 +131,14 @@ export async function getProjectAsset(req, res) {
       .send({ message: 'Project with that id does not exist' });
   }
 
+  // Check visibility and ownership for private projects
+  if (
+    project.visibility === 'Private' &&
+    (!req.user || !project.user._id.equals(req.user._id))
+  ) {
+    return res.status(403).send({ message: 'Project is private' });
+  }
+
   const filePath = req.params[0];
   const resolvedFile = resolvePathToFile(filePath, project.files);
   if (!resolvedFile) {

--- a/server/controllers/project.controller/__test__/getProjectAsset.test.js
+++ b/server/controllers/project.controller/__test__/getProjectAsset.test.js
@@ -1,0 +1,213 @@
+/**
+ * @jest-environment node
+ */
+import { Request, Response } from 'jest-express';
+import axios from 'axios';
+import mime from 'mime';
+import Project from '../../../models/project';
+import { getProjectAsset } from '../../project.controller';
+import { resolvePathToFile } from '../../../utils/filePath';
+
+jest.mock('../../../models/project');
+jest.mock('../../../utils/filePath');
+jest.mock('mime');
+jest.mock('axios');
+
+describe('project.controller', () => {
+  describe('getProjectAsset()', () => {
+    let request;
+    let response;
+
+    beforeEach(() => {
+      request = new Request();
+      response = new Response();
+      response.send = jest.fn();
+      response.status = jest.fn().mockReturnThis();
+      response.set = jest.fn().mockReturnThis();
+      request.setParams({ project_id: 'project-123', 0: 'image.png' });
+      Project.findOne = jest.fn().mockReturnValue({
+        populate: jest.fn().mockReturnThis(),
+        exec: jest.fn()
+      });
+      jest.clearAllMocks();
+    });
+
+    afterEach(() => {
+      request.resetMocked();
+      response.resetMocked();
+    });
+
+    it('returns 404 if project does not exist', async () => {
+      Project.findOne().populate().exec.mockResolvedValue(null);
+
+      await getProjectAsset(request, response);
+
+      expect(response.status).toHaveBeenCalledWith(404);
+      expect(response.send).toHaveBeenCalledWith({
+        message: 'Project with that id does not exist'
+      });
+    });
+
+    it('returns 403 if private project is accessed by unauthenticated user', async () => {
+      const project = {
+        _id: 'project-123',
+        visibility: 'Private',
+        user: { _id: { equals: jest.fn() } },
+        files: []
+      };
+      request.user = undefined;
+
+      Project.findOne().populate().exec.mockResolvedValue(project);
+
+      await getProjectAsset(request, response);
+
+      expect(response.status).toHaveBeenCalledWith(403);
+      expect(response.send).toHaveBeenCalledWith({
+        message: 'Project is private'
+      });
+    });
+
+    it('returns 403 if private project is accessed by non-owner', async () => {
+      const ownerId = { equals: jest.fn().mockReturnValue(false) };
+      const project = {
+        _id: 'project-123',
+        visibility: 'Private',
+        user: { _id: ownerId },
+        files: []
+      };
+      request.user = { _id: 'other-user-id' };
+
+      Project.findOne().populate().exec.mockResolvedValue(project);
+
+      await getProjectAsset(request, response);
+
+      expect(response.status).toHaveBeenCalledWith(403);
+      expect(response.send).toHaveBeenCalledWith({
+        message: 'Project is private'
+      });
+      expect(ownerId.equals).toHaveBeenCalledWith('other-user-id');
+    });
+
+    it('allows owner to access private project assets', async () => {
+      const ownerId = 'owner-123';
+      const ownerIdObj = { equals: jest.fn().mockReturnValue(true) };
+      const project = {
+        _id: 'project-123',
+        visibility: 'Private',
+        user: { _id: ownerIdObj },
+        files: []
+      };
+      const resolvedFile = {
+        name: 'image.png',
+        content: Buffer.from('image content')
+      };
+
+      request.user = { _id: ownerId };
+      Project.findOne().populate().exec.mockResolvedValue(project);
+      resolvePathToFile.mockReturnValue(resolvedFile);
+      mime.getType.mockReturnValue('image/png');
+
+      await getProjectAsset(request, response);
+
+      expect(ownerIdObj.equals).toHaveBeenCalledWith(ownerId);
+      expect(response.status).not.toHaveBeenCalledWith(403);
+      expect(response.set).toHaveBeenCalledWith('Content-Type', 'image/png');
+      expect(response.send).toHaveBeenCalledWith(resolvedFile.content);
+    });
+
+    it('allows anyone to access public project assets', async () => {
+      const project = {
+        _id: 'project-123',
+        visibility: 'Public',
+        user: { _id: { equals: jest.fn() } },
+        files: []
+      };
+      const resolvedFile = {
+        name: 'image.png',
+        content: Buffer.from('image content')
+      };
+
+      request.user = undefined; // unauthenticated
+      Project.findOne().populate().exec.mockResolvedValue(project);
+      resolvePathToFile.mockReturnValue(resolvedFile);
+      mime.getType.mockReturnValue('image/png');
+
+      await getProjectAsset(request, response);
+
+      expect(response.status).not.toHaveBeenCalledWith(403);
+      expect(response.set).toHaveBeenCalledWith('Content-Type', 'image/png');
+      expect(response.send).toHaveBeenCalledWith(resolvedFile.content);
+    });
+
+    it('returns 404 if asset does not exist', async () => {
+      const project = {
+        _id: 'project-123',
+        visibility: 'Public',
+        user: { _id: { equals: jest.fn() } },
+        files: []
+      };
+
+      Project.findOne().populate().exec.mockResolvedValue(project);
+      resolvePathToFile.mockReturnValue(null);
+
+      await getProjectAsset(request, response);
+
+      expect(response.status).toHaveBeenCalledWith(404);
+      expect(response.send).toHaveBeenCalledWith({
+        message: 'Asset does not exist'
+      });
+    });
+
+    it('fetches and serves asset from URL when resolvedFile has url', async () => {
+      const project = {
+        _id: 'project-123',
+        visibility: 'Public',
+        user: { _id: { equals: jest.fn() } },
+        files: []
+      };
+      const resolvedFile = {
+        name: 'image.png',
+        url: 'https://example.com/image.png'
+      };
+      const imageData = Buffer.from('image data');
+
+      Project.findOne().populate().exec.mockResolvedValue(project);
+      resolvePathToFile.mockReturnValue(resolvedFile);
+      mime.getType.mockReturnValue('image/png');
+      axios.get.mockResolvedValue({ data: imageData });
+
+      await getProjectAsset(request, response);
+
+      expect(axios.get).toHaveBeenCalledWith(resolvedFile.url, {
+        responseType: 'arraybuffer'
+      });
+      expect(response.set).toHaveBeenCalledWith('Content-Type', 'image/png');
+      expect(response.send).toHaveBeenCalledWith(imageData);
+    });
+
+    it('returns 404 if fetching asset URL fails', async () => {
+      const project = {
+        _id: 'project-123',
+        visibility: 'Public',
+        user: { _id: { equals: jest.fn() } },
+        files: []
+      };
+      const resolvedFile = {
+        name: 'image.png',
+        url: 'https://example.com/image.png'
+      };
+
+      Project.findOne().populate().exec.mockResolvedValue(project);
+      resolvePathToFile.mockReturnValue(resolvedFile);
+      mime.getType.mockReturnValue('image/png');
+      axios.get.mockRejectedValue(new Error('Network error'));
+
+      await getProjectAsset(request, response);
+
+      expect(response.status).toHaveBeenCalledWith(404);
+      expect(response.send).toHaveBeenCalledWith({
+        message: 'Asset does not exist'
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Issue:
Fixes #3904

The `getProjectAsset()` endpoint was serving project assets (files, images) for any project ID without checking the project's `visibility` setting. This security vulnerability allowed anyone who knew or guessed a project ID to access **Private** project assets, even when logged out or as a different user. While project listings correctly filter by visibility, this endpoint did not enforce the same authorization checks.

### Changes:

**Added authorization check to `getProjectAsset()`:**
- Added visibility and ownership validation before serving assets
- Private projects are now only accessible to their owners
- Unauthenticated users are blocked from accessing private project assets (returns 403)
- Non-owners are blocked from accessing private project assets (returns 403)
- Public projects remain accessible to everyone (no breaking changes)

**Security improvements:**
- Prevents unauthorized access to private project assets
- Protects all vulnerable routes: `/full/:project_id/*`, `/embed/:project_id/*`, `/:username/sketches/:project_id/*`, `/present/:project_id/*`
- Uses proper ObjectId comparison for ownership verification
- Follows the same authorization pattern as other protected endpoints in the codebase

**Added comprehensive test coverage:**
- Created test suite with 8 test cases covering all scenarios
- Tests verify: unauthenticated access blocking, non-owner blocking, owner access, public project access, and error handling
- All tests pass successfully

**Files changed:**
- `server/controllers/project.controller.js`: Added visibility and ownership check to `getProjectAsset` function
- `server/controllers/project.controller/__test__/getProjectAsset.test.js`: Added comprehensive test suite

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #3904`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
