### PR TITLE
docs: added a new section in installation.md to get the mongodb connection string from cloud.mongodb.com 

### DIFF
--- a/contributor_docs/installation.md
+++ b/contributor_docs/installation.md
@@ -37,6 +37,13 @@ _Note_: The installation steps assume you are using a Unix-like shell. If you ar
 7. Install MongoDB and make sure it is running
    * For Mac OSX with [homebrew](http://brew.sh/): `brew tap mongodb/brew` then `brew install mongodb-community` and finally start the server with `brew services start mongodb-community` or you can visit the installation guide here [Installation Guide For MacOS](https://docs.mongodb.com/manual/tutorial/install-mongodb-on-os-x/)
    * For Windows and Linux: [MongoDB Installation](https://docs.mongodb.com/manual/installation/)
+   * If you have trouble setting up MongoDB locally, an alternative is to use [MongoDB Atlas](https://cloud.mongodb.com/) to get a connection string that you can use as your `MONGO_URL` in the `.env` file. To get your connection string:
+      - Navigate to [mongodb.com](https://www.mongodb.com/) and sign up or log in.
+      - Create a new project. Give it any name, and either add a key-value pair or skip that step.
+      - Create a cluster by choosing the free tier. Give your cluster a name, choose a region, and keep the provider as AWS.
+      - Set a username and password for your database user—these will be part of your connection string.
+      - Choose **Node.js** as the driver for your connection method. You will see a connection string, with or without the password filled in.
+      - Copy the string and use it as your `MONGO_URL` in the `.env` file.
 8. `$ cp .env.example .env`
 9. (Optional) Update `.env` with necessary keys to enable certain app behaviors, i.e. add Github ID and Github Secret if you want to be able to log in with Github.
    * See the [GitHub API Configuration](#github-api-configuration) section for information on how to authenticate with Github.

--- a/contributor_docs/installation.md
+++ b/contributor_docs/installation.md
@@ -41,7 +41,7 @@ _Note_: The installation steps assume you are using a Unix-like shell. If you ar
       - Navigate to [mongodb.com](https://www.mongodb.com/) and sign up or log in.
       - Create a new project. Give it any name, and either add a key-value pair or skip that step.
       - Create a cluster by choosing the free tier. Give your cluster a name, choose a region, and keep the provider as AWS.
-      - Set a username and password for your database user—these will be part of your connection string.
+      - Set a username and password for your database-user, these will be part of your connection string.
       - Choose **Node.js** as the driver for your connection method. You will see a connection string, with or without the password filled in.
       - Copy the string and use it as your `MONGO_URL` in the `.env` file.
 8. `$ cp .env.example .env`


### PR DESCRIPTION
### Issue:
fixes #3984 

PR attempts to fix. --> just added a new section about getting the mongodb connection string from cloud.mongodb.com

### Demo:
<img width="1041" height="380" alt="Screenshot 2026-03-07 at 11 08 44 AM" src="https://github.com/user-attachments/assets/7295896d-5b58-4e10-bd28-f2ba12f5b3cc" />


### Changes:
just a new section added in installation.md file about getting the mongodb connection string from cloud.mongodb.com, in case new contributors have trouble setting up mongodb locally.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)

@raclim 

Thanks for your time.
