### PR TITLE
fix: remove duplicate Mongoose index on username and email fields

### DIFF
--- a/server/models/user.ts
+++ b/server/models/user.ts
@@ -12,7 +12,7 @@ import { apiKeySchema } from './apiKey';
 const userSchema = new Schema<UserDocument, UserModel>(
   {
     name: { type: String, default: '' },
-    username: { type: String, required: true, unique: true },
+    username: { type: String, required: true },
     password: { type: String },
     resetPasswordToken: String,
     resetPasswordExpires: Date,
@@ -21,7 +21,7 @@ const userSchema = new Schema<UserDocument, UserModel>(
     verifiedTokenExpires: Date,
     github: { type: String },
     google: { type: String },
-    email: { type: String, unique: true },
+    email: { type: String },
     tokens: Array,
     apiKeys: { type: [apiKeySchema] },
     preferences: {


### PR DESCRIPTION
### Issue:
Fixes #3752

When running the backend locally, Mongoose throws duplicate index 
warnings for both the `username` and `email` fields on startup. 
This was caused by having both `unique: true` in the schema field 
definition AND a separate `userSchema.index()` call for the same 
fields, resulting in two index definitions for each field.

### Demo:
No UI changes — this is a backend fix. The Mongoose warnings no 
longer appear on server startup after this fix.

### Changes:
- Removed `unique: true` from the `username` field definition
- Removed `unique: true` from the `email` field definition
- Uniqueness and case-insensitive collation is now handled solely 
  by the existing `userSchema.index()` calls at the bottom of the 
  file, which already include the correct collation settings

### I have verified that this pull request:
* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`) — note: `npm run test` 
      fails on Windows due to NODE_ENV syntax, unrelated to this fix
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date 
      with the `develop` branch.
* [x] is descriptively named and links to an issue number — Fixes #3752
* [x] meets the standards outlined in the accessibility guidelines