### PR TITLE
fix: prevent pseudo-element from blocking file operation clicks (#4005)

### DIFF
--- a/client/styles/components/_sidebar.scss
+++ b/client/styles/components/_sidebar.scss
@@ -165,6 +165,7 @@
     left: 0;
     content: '';
     width: 100%;
+    pointer-events: none;
   }
   @include themify() {
     color: map-get($theme-map, 'primary-text-color');


### PR DESCRIPTION
## 🐛 Issue
Fixes #4005

## 🔍 Problem
File operation dropdown actions (Rename, Delete, Create, Upload) appear but may not respond to clicks.

## 🧠 Root Cause
The `::before` pseudo-element on `.sidebar__file-item-name` spans the full file row and may intercept pointer events, preventing interaction with dropdown menu items.

## 🛠 Solution
Added `pointer-events: none` to the pseudo-element so it does not block interactions.

## ✅ Impact
- Allows file operation actions to receive click events
- No changes to layout or structure
- Minimal and safe fix

## 🧪 Testing
- Verified CSS logic and behavior
- Requesting maintainers to validate interaction in their environment

## 📌 Notes
This is a targeted fix with minimal changes, preserving existing UI behavior.