### PR TITLE
Add autocomplete keymap

### DIFF
--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -197,6 +197,7 @@ class Editor extends React.Component {
       [`Shift-${metaKey}-Enter`]: () => null,
       [`${metaKey}-F`]: 'findPersistent',
       [`Shift-${metaKey}-F`]: this.tidyCode,
+      [`${metaKey}-Space`]: () => this.showHint(this._cm),
       [`${metaKey}-G`]: 'findPersistentNext',
       [`Shift-${metaKey}-G`]: 'findPersistentPrev',
       [replaceCommand]: 'replace',

--- a/client/utils/contextAwareHinter.js
+++ b/client/utils/contextAwareHinter.js
@@ -1,6 +1,7 @@
 import getContext from './getContext';
 import p5CodeAstAnalyzer from './p5CodeAstAnalyzer';
 import classMap from './p5-instance-methods-and-creators.json';
+import * as hints from './p5-hinter';
 
 const scopeMap = require('./p5-scope-function-access-map.json');
 
@@ -86,7 +87,17 @@ export default function contextAwareHinter(cm, options = {}) {
   const currentWord = string.trim();
 
   const currentContext = getContext(cm);
-  const allHints = hinter.search(currentWord);
+
+  let allHints;
+
+  if (!currentWord) {
+    allHints = hints.p5Hinter;
+    allHints = allHints.map((h) => ({
+      item: h
+    }));
+  } else {
+    allHints = hinter.search(currentWord);
+  }
 
   // const whitelist = scopeMap[currentContext]?.whitelist || [];
   const blacklist = scopeMap[currentContext]?.blacklist || [];


### PR DESCRIPTION
### Demo:

https://github.com/user-attachments/assets/c43f8669-8e63-45c1-904e-0d318f75ed41


### Changes:
This adds a new keymap in `index.jsx`  and modifies `contextAwareHinter.jsx` to return all hints in a context aware manner. This simulates other editors like VSCode.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
