### PR TITLE
fix:Emmet expands abbrevations when text is pasted

### DIFF
--- a/client/modules/IDE/components/Editor/stateUtils.js
+++ b/client/modules/IDE/components/Editor/stateUtils.js
@@ -359,6 +359,15 @@ export function createNewFileState(filename, document, settings) {
   if (fileEmmetConfig) {
     extensions.push(fileEmmetConfig);
     extensions.push(abbreviationTracker());
+    extensions.push(
+      EditorView.domEventHandlers({
+        paste(event, view) {
+          setTimeout(() => {
+            expandAbbreviation(view);
+          }, 0);
+        }
+      })
+    );
     keymaps.push(emmetKeymaps);
   }
 


### PR DESCRIPTION
### Issue:
Fixes #3872 

### Demo:
[Screencast from 2026-02-22 14-49-21.webm](https://github.com/user-attachments/assets/2179dbba-dffa-45bf-b653-f60a561ffa3d)

### Changes:
Added a paste event handler to trigger `expandAbbreviation` when content is pasted.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
