### PR TITLE
Add data-testid attributes to Play and Stop buttons for E2E testing

### DIFF
--- a/client/modules/IDE/components/Header/Toolbar.jsx
+++ b/client/modules/IDE/components/Header/Toolbar.jsx
@@ -73,6 +73,7 @@ const Toolbar = (props) => {
       <button
         className={playButtonClass}
         id="play-sketch"
+        data-testid="play-button"
         onClick={() => {
           props.syncFileContent();
           dispatch(startSketch());
@@ -85,6 +86,7 @@ const Toolbar = (props) => {
       </button>
       <button
         className={stopButtonClass}
+        data-testid="stop-button"
         onClick={() => dispatch(stopSketch())}
         aria-label={t('Toolbar.StopSketchARIA')}
         title={t('Toolbar.StopSketchARIA')}


### PR DESCRIPTION
## Summary

Adds `data-testid` attributes to the Play and Stop buttons in the toolbar to support stable E2E testing.

## Changes

* Added `data-testid="play-button"` to the main Play button (`id="play-sketch"`)
* Added `data-testid="stop-button"` to the Stop button

## Why

Currently, E2E tests rely on fragile selectors like CSS classes or IDs, which may change during refactoring or styling updates.

Using `data-testid` provides a stable and explicit contract between the UI and test code, improving test reliability.

## Impact

* No functional changes
* Improves testability of core sketch execution flow
