### PR TITLE
feat: add tooltip to collection item remove button 

### DIFF
--- a/client/modules/User/components/CollectionItemRow.jsx
+++ b/client/modules/User/components/CollectionItemRow.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
+import { Tooltip } from '../../../common/Tooltip';
 import { removeFromCollection } from '../../IDE/actions/collections';
 import { formatDateToString } from '../../../utils/formatDate';
 import RemoveIcon from '../../../images/close.svg';
@@ -48,13 +49,14 @@ const CollectionItemRow = ({ collection, item, isOwner }) => {
       <td>{sketchOwnerUsername}</td>
       <td className="collection-row__action-column">
         {isOwner && (
-          <button
-            className="collection-row__remove-button"
-            onClick={handleSketchRemove}
-            aria-label={t('Collection.SketchRemoveARIA')}
-          >
-            <RemoveIcon focusable="false" aria-hidden="true" />
-          </button>
+          <Tooltip content={t('RemoveFromCollection')}>
+            <button
+              className="collection-row__remove-button"
+              onClick={handleSketchRemove}
+            >
+              <RemoveIcon focusable="false" aria-hidden="true" />
+            </button>
+          </Tooltip>
         )}
       </td>
     </tr>

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -438,7 +438,8 @@
     "TitleDefault": "collezione"
   },
   "Collection": {
-    "Title": "p5.js redattore web | Mie collezioni",
+    "RemoveFromCollection":"Remove from Collection ",
+    "Title": "p5.js redattore web | My collezioni",
     "AnothersTitle": "p5.js redattore web | Le collezioni di {{anotheruser}}",
     "Share": "Condividi",
     "URLLink": "Collegamento alla collezione",


### PR DESCRIPTION
Hi @raclim 
### Issue:
Fixes #3882 

Added a hover tooltip to the "Remove from Collection" button in the CollectionItemRow component. Currently, the button only has an x icon, which might be unclear to users; this PR provides text feedback ("Remove from collection") to improve UX and accessibility.

### Demo:
<img width="1440" height="900" alt="Screenshot 2026-03-27 at 12 34 55 AM" src="https://github.com/user-attachments/assets/56b50289-cb90-4f65-bb5b-c7a454cd59bf" />

### Changes:
Component Update: Wrapped the button in CollectionItemRow.jsx with the shared Tooltip component.
Prop Mapping: Passed the translated string to the content prop of the Tooltip.
 I have Added the RemoveFromCollection key to client/i18n/locales/en-US/translation.json and client/i18n/locales/it-IT/translation.json.
### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)


* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
