### PR TITLE
Fix/tooltip overflow issue

### DIFF
--- a/client/modules/User/components/CollectionItemRow.jsx
+++ b/client/modules/User/components/CollectionItemRow.jsx
@@ -3,10 +3,11 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
-import { Tooltip } from '../../../common/Tooltip';
-import { removeFromCollection } from '../../IDE/actions/collections';
+import { TableDropdown } from '../../../components/Dropdown/TableDropdown';
+import { MenuItem } from '../../../components/Dropdown/MenuItem';
 import { formatDateToString } from '../../../utils/formatDate';
 import RemoveIcon from '../../../images/close.svg';
+import { removeFromCollection } from '../../IDE/actions/collections';
 
 const CollectionItemRow = ({ collection, item, isOwner }) => {
   const { t } = useTranslation();
@@ -45,18 +46,18 @@ const CollectionItemRow = ({ collection, item, isOwner }) => {
       }`}
     >
       <th scope="row">{name}</th>
+
       <td>{formatDateToString(item.createdAt)}</td>
+
       <td>{sketchOwnerUsername}</td>
+
       <td className="collection-row__action-column">
         {isOwner && (
-          <Tooltip content={t('RemoveFromCollection')}>
-            <button
-              className="collection-row__remove-button"
-              onClick={handleSketchRemove}
-            >
-              <RemoveIcon focusable="false" aria-hidden="true" />
-            </button>
-          </Tooltip>
+          <TableDropdown aria-label={t('SketchList.ToggleLabelARIA')}>
+            <MenuItem onClick={handleSketchRemove}>
+              {t('RemoveFromCollection')}
+            </MenuItem>
+          </TableDropdown>
         )}
       </td>
     </tr>

--- a/client/modules/User/components/CollectionItemRow.jsx
+++ b/client/modules/User/components/CollectionItemRow.jsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useDispatch } from 'react-redux';
+import { Tooltip } from '../../../common/Tooltip';
 import { removeFromCollection } from '../../IDE/actions/collections';
 import { formatDateToString } from '../../../utils/formatDate';
 import RemoveIcon from '../../../images/close.svg';
@@ -48,13 +49,14 @@ const CollectionItemRow = ({ collection, item, isOwner }) => {
       <td>{sketchOwnerUsername}</td>
       <td className="collection-row__action-column">
         {isOwner && (
-          <button
-            className="collection-row__remove-button"
-            onClick={handleSketchRemove}
-            aria-label={t('Collection.SketchRemoveARIA')}
-          >
-            <RemoveIcon focusable="false" aria-hidden="true" />
-          </button>
+          <Tooltip content={t('RemoveFromCollection')}>
+            <button
+              className="collection-row__remove-button"
+              onClick={handleSketchRemove}
+            >
+              <RemoveIcon focusable="false" aria-hidden="true" />
+            </button>
+          </Tooltip>
         )}
       </td>
     </tr>

--- a/client/styles/components/_tooltip.scss
+++ b/client/styles/components/_tooltip.scss
@@ -12,12 +12,14 @@
   font-family: Montserrat, sans-serif;
   font-size: 1rem;
   padding: 0.5rem 0.75rem;
-  max-width: none;
-  white-space: nowrap;
-  left: 1rem;
-  right: auto;
+  max-width: 250px;
+  width: max-content;
+  white-space: normal;
+  left: auto;
+  right: -0.5rem;
   transform: translateX(0);
-  text-align: left;
+  text-align: right;
+  word-wrap: break-word;
 }
 
 .tooltip-wrapper .tooltipped-n::before,
@@ -26,7 +28,7 @@
     color: getThemifyVariable('button-background-hover-color');
     border-top-color: getThemifyVariable('button-background-hover-color');
   }
-  left: 1.75rem;
-  right: auto;
+  left: auto;
+  right: 0.25rem;
   transform: translateX(0);
 }

--- a/client/styles/components/_tooltip.scss
+++ b/client/styles/components/_tooltip.scss
@@ -14,7 +14,10 @@
   padding: 0.5rem 0.75rem;
   max-width: 250px;
   width: max-content;
-  white-space: normal;
+  white-space: nowrap;
+  position:absolute;
+  bottom: 100%;
+  margin-bottom: 8px;
   left: auto;
   right: -0.5rem;
   transform: translateX(0);
@@ -28,7 +31,17 @@
     color: getThemifyVariable('button-background-hover-color');
     border-top-color: getThemifyVariable('button-background-hover-color');
   }
+  content: "";
   left: auto;
+  position: absolute;
+  bottom: 100%;
+  margin-bottom: 2px;
   right: 0.25rem;
   transform: translateX(0);
+  border: 6px solid transparent;
+  @include themify() {
+    border-top-color: getThemifyVariable('button-background-hover-color');
+  }
 }
+
+

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -438,7 +438,8 @@
     "TitleDefault": "collezione"
   },
   "Collection": {
-    "Title": "p5.js redattore web | Mie collezioni",
+    "RemoveFromCollection":"Remove from Collection ",
+    "Title": "p5.js redattore web | My collezioni",
     "AnothersTitle": "p5.js redattore web | Le collezioni di {{anotheruser}}",
     "Share": "Condividi",
     "URLLink": "Collegamento alla collezione",


### PR DESCRIPTION
### Issue:
Fixes #3882 
The tooltip in the Collections table was overflowing its container, causing a horizontal scrollbar. I fixed this by:
-> Changing the tooltip anchor from left to right.
-> Setting a max-width and enabling white-space: normal so long text wraps correctly.

##demo
<img width="1440" height="813" alt="Screenshot 2026-03-28 at 8 26 30 PM" src="https://github.com/user-attachments/assets/0aba7f15-a659-4420-aa77-b149bab19342" />

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
