### PR TITLE
fix back to editor button clickable area

### DIFF
--- a/client/styles/components/_nav.scss
+++ b/client/styles/components/_nav.scss
@@ -289,4 +289,7 @@
 
 .nav__back-link {
   display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
### Issue:
Fixes #4051 

### Changes:
this pr fixes an issue where the “back to editor” button was only clickable on the text and icon, instead of the full button area.

the anchor element was rendering inline, limiting its clickable region. this change updates .nav__back-link to use flex layout and occupy full width/height, ensuring the entire row is interactive.

no visual changes, only improves usability and click target consistency.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
