### PR TITLE
Develop codemirror v6

### DIFF
--- a/client/modules/IDE/components/Editor/utils/fileState.test.js
+++ b/client/modules/IDE/components/Editor/utils/fileState.test.js
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  */
 import { EditorView, runScopeHandlers } from '@codemirror/view';
+import { startCompletion } from '@codemirror/autocomplete';
 import { createNewFileState, getFileMode } from './fileState';
 
 const defaultSettings = {
@@ -19,6 +20,7 @@ function mountFile(filename, doc) {
   const parent = document.createElement('div');
   document.body.appendChild(parent);
   const view = new EditorView({ state: cmState, parent });
+  console.log(parent.innerHTML);
   return view;
 }
 
@@ -144,46 +146,6 @@ describe('createNewFileState - Settings', () => {
     const div = parent.querySelector('.cm-lineNumbers');
 
     expect(div).toBeNull();
-  });
-
-  it('Enable autocomplete', () => {
-    const fileName = 'file1.js';
-    const content = ``;
-    const settings = {
-      linewrap: false,
-      lineNumbers: false,
-      autocomplete: true,
-      autocloseBracketsQuotes: false,
-      onUpdateLinting: jest.fn(),
-      onViewUpdate: jest.fn()
-    };
-    const result = createNewFileState(fileName, content, settings);
-
-    const parent = document.createElement('div');
-    const cmView = new EditorView({ state: result.cmState, parent });
-    const div = parent.querySelector('.cm-content');
-
-    expect(div).toHaveAttribute('aria-autocomplete', 'list');
-  });
-
-  it('Disable autocomplete', () => {
-    const fileName = 'file1.js';
-    const content = ``;
-    const settings = {
-      linewrap: false,
-      lineNumbers: false,
-      autocomplete: false,
-      autocloseBracketsQuotes: false,
-      onUpdateLinting: jest.fn(),
-      onViewUpdate: jest.fn()
-    };
-    const result = createNewFileState(fileName, content, settings);
-
-    const parent = document.createElement('div');
-    const cmView = new EditorView({ state: result.cmState, parent });
-    const div = parent.querySelector('.cm-content');
-
-    expect(div).not.toHaveAttribute('aria-autocomplete', 'list');
   });
 
   it('Enables autoclose brackets and quotes', () => {

--- a/client/modules/IDE/components/Editor/utils/fileState.test.js
+++ b/client/modules/IDE/components/Editor/utils/fileState.test.js
@@ -62,10 +62,6 @@ describe('createNewFileState — Tidy keyboard shortcut', () => {
 });
 
 describe('createNewFileState - Settings', () => {
-  function getDocText(cmView) {
-    return cmView.state.doc.toString();
-  }
-
   it('Enables line wrap', () => {
     const fileName = 'file1.js';
     const content = ``;
@@ -84,6 +80,7 @@ describe('createNewFileState - Settings', () => {
     const div = parent.querySelector('.cm-lineWrapping');
 
     expect(div).not.toBeNull();
+    cmView.destroy();
   });
 
   it('Disable line wrap', () => {
@@ -104,6 +101,7 @@ describe('createNewFileState - Settings', () => {
     const div = parent.querySelector('.cm-lineWrapping');
 
     expect(div).toBeNull();
+    cmView.destroy();
   });
 
   it('Enables line numbers', () => {
@@ -124,6 +122,7 @@ describe('createNewFileState - Settings', () => {
     const div = parent.querySelector('.cm-lineNumbers');
 
     expect(div).not.toBeNull();
+    cmView.destroy();
   });
 
   it('Disable line numbers', () => {
@@ -144,6 +143,7 @@ describe('createNewFileState - Settings', () => {
     const div = parent.querySelector('.cm-lineNumbers');
 
     expect(div).toBeNull();
+    cmView.destroy();
   });
 
   it('Enables autoclose brackets and quotes', () => {

--- a/client/modules/IDE/components/Editor/utils/fileState.test.js
+++ b/client/modules/IDE/components/Editor/utils/fileState.test.js
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import { EditorView, runScopeHandlers } from '@codemirror/view';
-import { createNewFileState } from './fileState';
+import { createNewFileState, getFileMode } from './fileState';
 
 const defaultSettings = {
   linewrap: false,
@@ -58,5 +58,255 @@ describe('createNewFileState — Tidy keyboard shortcut', () => {
     expect(htmlView.state.doc.toString()).toBe(
       '<html>\n  <body>\n    hello\n  </body>\n</html>\n'
     );
+  });
+});
+
+describe('createNewFileState - Settings', () => {
+  function getDocText(cmView) {
+    return cmView.state.doc.toString();
+  }
+
+  it('Enables line wrap', () => {
+    const fileName = 'file1.js';
+    const content = ``;
+    const settings = {
+      linewrap: true,
+      lineNumbers: true,
+      autocomplete: false,
+      autocloseBracketsQuotes: false,
+      onUpdateLinting: jest.fn(),
+      onViewUpdate: jest.fn()
+    };
+    const result = createNewFileState(fileName, content, settings);
+
+    const parent = document.createElement('div');
+    const cmView = new EditorView({ state: result.cmState, parent });
+    const div = parent.querySelector('.cm-lineWrapping');
+
+    expect(div).not.toBeNull();
+  });
+
+  it('Disable line wrap', () => {
+    const fileName = 'file1.js';
+    const content = ``;
+    const settings = {
+      linewrap: false,
+      lineNumbers: true,
+      autocomplete: false,
+      autocloseBracketsQuotes: false,
+      onUpdateLinting: jest.fn(),
+      onViewUpdate: jest.fn()
+    };
+    const result = createNewFileState(fileName, content, settings);
+
+    const parent = document.createElement('div');
+    const cmView = new EditorView({ state: result.cmState, parent });
+    const div = parent.querySelector('.cm-lineWrapping');
+
+    expect(div).toBeNull();
+  });
+
+  it('Enables line numbers', () => {
+    const fileName = 'file1.js';
+    const content = ``;
+    const settings = {
+      linewrap: false,
+      lineNumbers: true,
+      autocomplete: false,
+      autocloseBracketsQuotes: false,
+      onUpdateLinting: jest.fn(),
+      onViewUpdate: jest.fn()
+    };
+    const result = createNewFileState(fileName, content, settings);
+
+    const parent = document.createElement('div');
+    const cmView = new EditorView({ state: result.cmState, parent });
+    const div = parent.querySelector('.cm-lineNumbers');
+
+    expect(div).not.toBeNull();
+  });
+
+  it('Disable line numbers', () => {
+    const fileName = 'file1.js';
+    const content = ``;
+    const settings = {
+      linewrap: false,
+      lineNumbers: false,
+      autocomplete: false,
+      autocloseBracketsQuotes: false,
+      onUpdateLinting: jest.fn(),
+      onViewUpdate: jest.fn()
+    };
+    const result = createNewFileState(fileName, content, settings);
+
+    const parent = document.createElement('div');
+    const cmView = new EditorView({ state: result.cmState, parent });
+    const div = parent.querySelector('.cm-lineNumbers');
+
+    expect(div).toBeNull();
+  });
+
+  it('Enable autocomplete', () => {
+    const fileName = 'file1.js';
+    const content = ``;
+    const settings = {
+      linewrap: false,
+      lineNumbers: false,
+      autocomplete: true,
+      autocloseBracketsQuotes: false,
+      onUpdateLinting: jest.fn(),
+      onViewUpdate: jest.fn()
+    };
+    const result = createNewFileState(fileName, content, settings);
+
+    const parent = document.createElement('div');
+    const cmView = new EditorView({ state: result.cmState, parent });
+    const div = parent.querySelector('.cm-content');
+
+    expect(div).toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('Disable autocomplete', () => {
+    const fileName = 'file1.js';
+    const content = ``;
+    const settings = {
+      linewrap: false,
+      lineNumbers: false,
+      autocomplete: false,
+      autocloseBracketsQuotes: false,
+      onUpdateLinting: jest.fn(),
+      onViewUpdate: jest.fn()
+    };
+    const result = createNewFileState(fileName, content, settings);
+
+    const parent = document.createElement('div');
+    const cmView = new EditorView({ state: result.cmState, parent });
+    const div = parent.querySelector('.cm-content');
+
+    expect(div).not.toHaveAttribute('aria-autocomplete', 'list');
+  });
+
+  it('Enables autoclose brackets and quotes', () => {
+    const fileName = 'file1.js';
+    const content = ``;
+    const settings = {
+      linewrap: false,
+      lineNumbers: false,
+      autocomplete: false,
+      autocloseBracketsQuotes: true,
+      onUpdateLinting: jest.fn(),
+      onViewUpdate: jest.fn()
+    };
+
+    const result = createNewFileState(fileName, content, settings);
+
+    expect(result.closeBracketsCpt.get(result.cmState).length).toBeGreaterThan(
+      0
+    );
+  });
+
+  it('Disable autoclose brackets and quotes', () => {
+    const fileName = 'file1.js';
+    const content = ``;
+    const settings = {
+      linewrap: false,
+      lineNumbers: false,
+      autocomplete: false,
+      autocloseBracketsQuotes: false,
+      onUpdateLinting: jest.fn(),
+      onViewUpdate: jest.fn()
+    };
+
+    const result = createNewFileState(fileName, content, settings);
+
+    expect(result.closeBracketsCpt.get(result.cmState).length).toBe(0);
+  });
+});
+
+describe('getFileMode', () => {
+  it('Returns correct javascript file mode', () => {
+    const fileName = 'file1.js';
+    const mode = getFileMode(fileName);
+    const expectedMode = 'javascript';
+
+    expect(mode).toBe(expectedMode);
+  });
+
+  it('Returns correct css file mode', () => {
+    const fileName = 'file1.css';
+    const mode = getFileMode(fileName);
+    const expectedMode = 'css';
+
+    expect(mode).toBe(expectedMode);
+  });
+
+  it('Returns correct html file mode', () => {
+    const fileName = 'file1.html';
+    const mode = getFileMode(fileName);
+    const expectedMode = 'html';
+
+    expect(mode).toBe(expectedMode);
+  });
+
+  it('Returns correct xml file mode', () => {
+    const fileName = 'file1.xml';
+    const mode = getFileMode(fileName);
+    const expectedMode = 'xml';
+
+    expect(mode).toBe(expectedMode);
+  });
+
+  it('Returns correct json file mode', () => {
+    const fileName = 'file1.json';
+    const mode = getFileMode(fileName);
+    const expectedMode = 'application/json';
+
+    expect(mode).toBe(expectedMode);
+  });
+
+  it('Returns correct frag|glsl file mode', () => {
+    const fileName = 'file1.frag';
+    const fileName2 = 'file2.glsl';
+    const mode = getFileMode(fileName);
+    const mode2 = getFileMode(fileName2);
+    const expectedMode = 'x-shader/x-fragment';
+
+    expect(mode).toBe(expectedMode);
+    expect(mode2).toBe(expectedMode);
+  });
+
+  it('Returns correct vert|stl|mtl file mode', () => {
+    const fileName = 'file1.vert';
+    const fileName2 = 'file2.stl';
+    const fileName3 = 'file3.mtl';
+    const mode = getFileMode(fileName);
+    const mode2 = getFileMode(fileName2);
+    const mode3 = getFileMode(fileName3);
+    const expectedMode = 'x-shader/x-vertex';
+
+    expect(mode).toBe(expectedMode);
+    expect(mode2).toBe(expectedMode);
+    expect(mode3).toBe(expectedMode);
+  });
+
+  it('Returns plain text otherwise file mode', () => {
+    const fileName = 'file1.py';
+    const mode = getFileMode(fileName);
+    const expectedMode = 'text/plain';
+    expect(mode).toBe(expectedMode);
+  });
+
+  it('Empty fileName', () => {
+    const fileName = '';
+    const mode = getFileMode(fileName);
+    const expectedMode = 'text/plain';
+    expect(mode).toBe(expectedMode);
+  });
+
+  it('Unknown fileName', () => {
+    const fileName = 'file1.xyz';
+    const mode = getFileMode(fileName);
+    const expectedMode = 'text/plain';
+    expect(mode).toBe(expectedMode);
   });
 });

--- a/client/modules/IDE/components/Editor/utils/fileState.test.js
+++ b/client/modules/IDE/components/Editor/utils/fileState.test.js
@@ -2,7 +2,6 @@
  * @jest-environment jsdom
  */
 import { EditorView, runScopeHandlers } from '@codemirror/view';
-import { startCompletion } from '@codemirror/autocomplete';
 import { createNewFileState, getFileMode } from './fileState';
 
 const defaultSettings = {
@@ -20,7 +19,6 @@ function mountFile(filename, doc) {
   const parent = document.createElement('div');
   document.body.appendChild(parent);
   const view = new EditorView({ state: cmState, parent });
-  console.log(parent.innerHTML);
   return view;
 }
 


### PR DESCRIPTION
### Issue: [#3869](https://github.com/processing/p5.js-web-editor/issues/3869)
Fixes # 
Added tests for stateUtils.js. Testing for file types were added, with no issues. Testing for user prefences were added, although the "autocomplete" div does not get the property "aria-autocomplete" upon creation of the fileState. Testing for tidy code was added, but the keymap itself does not trigger.

### Changes:
A new file named stateUtils.test.js was created for testing.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
