### PR TITLE
Fix missing space between sketch name and author in embed view

### DIFF
--- a/client/styles/components/_toolbar.scss
+++ b/client/styles/components/_toolbar.scss
@@ -156,7 +156,7 @@
 }
 
 .toolbar__project-owner {
-	margin: 0; 
+	margin: 0 #{math.div(5, $base-font-size)}rem;
 	@include themify() {
 		color: getThemifyVariable('secondary-text-color');
 	}


### PR DESCRIPTION
### Issue:
Fixes #4040
<!-- The embedded sketch preview nav was missing spacing between the sketch name and the author name (e.g., "Sepia rumba by f" rendered as "Sepia rumbaby f"). -->

### Demo:
**Before:**
![before](https://github.com/user-attachments/assets/ff97dd51-4350-4137-9ce2-8b7b7a678ef4)

**After:**

<img width="595" height="550" alt="Screenshot 2026-04-12 at 11 55 08 PM" src="https://github.com/user-attachments/assets/2fe6cb76-c92e-45aa-8ee9-3c055a8fd5ed" />

### Changes:
- Added horizontal margin to `.toolbar__project-owner` in `_toolbar.scss` to create spacing between the sketch name, "by" text, and the author link.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)