### PR TITLE
fix loop protection breaking shader strings and p5.strands functions

### DIFF
--- a/client/modules/Preview/EmbedFrame.jsx
+++ b/client/modules/Preview/EmbedFrame.jsx
@@ -2,8 +2,7 @@ import blobUtil from 'blob-util';
 import PropTypes from 'prop-types';
 import React, { useRef, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
-import loopProtect from 'loop-protect';
-import decomment from 'decomment';
+import { jsPreprocess } from './jsPreprocess';
 import { resolvePathToFile } from '../../../server/utils/filePath';
 import { getConfig } from '../../utils/getConfig';
 import {
@@ -52,47 +51,6 @@ function resolveCSSLinksInString(content, files) {
       }
     }
   });
-  return newContent;
-}
-
-function jsPreprocess(jsText) {
-  let newContent = jsText;
-
-  // Skip loop protection if the user explicitly opts out with // noprotect
-  if (/\/\/\s*noprotect/.test(newContent)) {
-    return newContent;
-  }
-
-  // Detect and fix multiple consecutive loops on the same line (e.g. "for(){}for(){}")
-  // which can bypass loop protection. Add semicolons between them so each loop
-  // is properly wrapped by loopProtect. See #3891.
-  // Match: for/while/do-while loops followed immediately by another loop
-  newContent = newContent.replace(
-    /((?:for|while)\s*\([^)]*\)\s*\{[^}]*\})((?:for|while)\s*\([^)]*\)\s*\{[^}]*\})/g,
-    '$1; $2'
-  );
-
-  // Always apply loop protection to prevent infinite loops from crashing
-  // the browser tab. Previously, loop protection was skipped when JSHINT
-  // found errors, but this left users vulnerable to infinite loops in
-  // syntactically imperfect code (common while typing). See #3891.
-  try {
-    newContent = decomment(newContent, {
-      ignore: /\/\/\s*noprotect/g,
-      space: true
-    });
-    newContent = loopProtect(newContent);
-  } catch (e) {
-    // If decomment or loopProtect fails (e.g. due to syntax issues),
-    // still try to apply loop protection on the original code.
-    try {
-      newContent = loopProtect(jsText);
-    } catch (err) {
-      // If loop protection can't be applied at all, return original code.
-      // The sketch will still run, but without loop protection.
-      return jsText;
-    }
-  }
   return newContent;
 }
 

--- a/client/modules/Preview/jsPreprocess.js
+++ b/client/modules/Preview/jsPreprocess.js
@@ -1,5 +1,6 @@
 import * as acorn from 'acorn';
 import * as walk from 'acorn-walk';
+import escodegen from 'escodegen';
 
 const LOOP_TIMEOUT_MS = 100;
 
@@ -7,13 +8,9 @@ function isShaderCall(node) {
   const { callee } = node;
   const isBuildShader =
     callee.type === 'Identifier' && /^build\w*Shader$/.test(callee.name);
-  const isBaseShaderModify =
-    callee.type === 'MemberExpression' &&
-    callee.property.name === 'modify' &&
-    callee.object.type === 'CallExpression' &&
-    callee.object.callee.type === 'Identifier' &&
-    /^base\w*Shader$/.test(callee.object.callee.name);
-  return isBuildShader || isBaseShaderModify;
+  const isModifyCall =
+    callee.type === 'MemberExpression' && callee.property.name === 'modify';
+  return isBuildShader || isModifyCall;
 }
 
 function collectShaderFunctionNames(ast) {
@@ -77,56 +74,165 @@ function collectLoopsToProtect(ast, shaderNames) {
   return loops;
 }
 
+function makeVarDecl(varName) {
+  return {
+    type: 'VariableDeclaration',
+    kind: 'var',
+    declarations: [
+      {
+        type: 'VariableDeclarator',
+        id: { type: 'Identifier', name: varName },
+        init: {
+          type: 'CallExpression',
+          callee: {
+            type: 'MemberExpression',
+            object: { type: 'Identifier', name: 'Date' },
+            property: { type: 'Identifier', name: 'now' },
+            computed: false
+          },
+          arguments: []
+        }
+      }
+    ]
+  };
+}
+
+function makeCheckStatement(varName, line) {
+  return {
+    type: 'IfStatement',
+    test: {
+      type: 'BinaryExpression',
+      operator: '>',
+      left: {
+        type: 'BinaryExpression',
+        operator: '-',
+        left: {
+          type: 'CallExpression',
+          callee: {
+            type: 'MemberExpression',
+            object: { type: 'Identifier', name: 'Date' },
+            property: { type: 'Identifier', name: 'now' },
+            computed: false
+          },
+          arguments: []
+        },
+        right: { type: 'Identifier', name: varName }
+      },
+      right: {
+        type: 'Literal',
+        value: LOOP_TIMEOUT_MS,
+        raw: String(LOOP_TIMEOUT_MS)
+      }
+    },
+    consequent: {
+      type: 'BlockStatement',
+      body: [
+        {
+          type: 'ExpressionStatement',
+          expression: {
+            type: 'CallExpression',
+            callee: {
+              type: 'MemberExpression',
+              object: {
+                type: 'MemberExpression',
+                object: { type: 'Identifier', name: 'window' },
+                property: { type: 'Identifier', name: 'loopProtect' },
+                computed: false
+              },
+              property: { type: 'Identifier', name: 'hit' },
+              computed: false
+            },
+            arguments: [{ type: 'Literal', value: line, raw: String(line) }]
+          }
+        },
+        { type: 'BreakStatement', label: null }
+      ]
+    },
+    alternate: null
+  };
+}
+
+function injectProtection(loop, idx) {
+  const varName = `_LP${idx}`;
+  const { line } = loop.loc.start;
+  const check = makeCheckStatement(varName, line);
+
+  if (loop.body.type === 'BlockStatement') {
+    loop.body.body.unshift(check);
+  } else {
+    loop.body = {
+      type: 'BlockStatement',
+      body: [check, loop.body]
+    };
+  }
+
+  return makeVarDecl(varName);
+}
+
+function insertVarDeclsIntoBlock(blockBody, loopsWithVarDecls) {
+  loopsWithVarDecls.forEach(({ loop, varDecl }) => {
+    const idx = blockBody.indexOf(loop);
+    if (idx !== -1) {
+      blockBody.splice(idx, 0, varDecl);
+    }
+  });
+}
+
+function injectVarDeclsIntoAst(ast, loops) {
+  const loopToVarDecl = new Map();
+  loops.forEach((loop, idx) => {
+    loopToVarDecl.set(loop, injectProtection(loop, idx));
+  });
+
+  walk.simple(ast, {
+    BlockStatement(node) {
+      const loopsWithVarDecls = node.body
+        .filter((child) => loopToVarDecl.has(child))
+        .map((loop) => ({ loop, varDecl: loopToVarDecl.get(loop) }));
+      if (loopsWithVarDecls.length > 0) {
+        insertVarDeclsIntoBlock(node.body, loopsWithVarDecls);
+        loopsWithVarDecls.forEach(({ loop }) => loopToVarDecl.delete(loop));
+      }
+    },
+    Program(node) {
+      const loopsWithVarDecls = node.body
+        .filter((child) => loopToVarDecl.has(child))
+        .map((loop) => ({ loop, varDecl: loopToVarDecl.get(loop) }));
+      if (loopsWithVarDecls.length > 0) {
+        insertVarDeclsIntoBlock(node.body, loopsWithVarDecls);
+        loopsWithVarDecls.forEach(({ loop }) => loopToVarDecl.delete(loop));
+      }
+    }
+  });
+}
+
+function parseJs(jsText) {
+  const options = { ecmaVersion: 'latest', locations: true };
+  try {
+    return acorn.parse(jsText, { ...options, sourceType: 'script' });
+  } catch (e) {
+    try {
+      return acorn.parse(jsText, { ...options, sourceType: 'module' });
+    } catch (e2) {
+      return null;
+    }
+  }
+}
+
 export function jsPreprocess(jsText) {
   if (/\/\/\s*noprotect/.test(jsText)) {
     return jsText;
   }
 
-  let ast;
-  try {
-    ast = acorn.parse(jsText, {
-      ecmaVersion: 'latest',
-      sourceType: 'script',
-      locations: true
-    });
-  } catch (e) {
-    return jsText;
-  }
+  const ast = parseJs(jsText);
+  if (!ast) return jsText;
 
   const shaderNames = collectShaderFunctionNames(ast);
   const loops = collectLoopsToProtect(ast, shaderNames);
 
   if (loops.length === 0) return jsText;
 
-  const insertions = [];
+  injectVarDeclsIntoAst(ast, loops);
 
-  loops.forEach((loop) => {
-    const { line } = loop.loc.start;
-    const varName = `_LP${loop.start}`;
-
-    const beforeCode = `var ${varName} = Date.now(); `;
-
-    const checkCode =
-      `if (Date.now() - ${varName} > ${LOOP_TIMEOUT_MS}) ` +
-      `{ window.loopProtect.hit(${line}); break; } `;
-
-    const { body } = loop;
-    if (body.type === 'BlockStatement') {
-      insertions.push({ pos: loop.start, code: beforeCode });
-      insertions.push({ pos: body.start + 1, code: checkCode });
-    } else {
-      insertions.push({ pos: loop.start, code: beforeCode });
-      insertions.push({ pos: body.start, code: `{ ${checkCode}` });
-      insertions.push({ pos: body.end, code: ` }` });
-    }
-  });
-
-  insertions.sort((a, b) => b.pos - a.pos);
-
-  let result = jsText;
-  insertions.forEach(({ pos, code }) => {
-    result = result.slice(0, pos) + code + result.slice(pos);
-  });
-
-  return result;
+  return escodegen.generate(ast);
 }

--- a/client/modules/Preview/jsPreprocess.js
+++ b/client/modules/Preview/jsPreprocess.js
@@ -107,8 +107,8 @@ function makeCheckStatement(varName, line) {
   };
 }
 
-function protectLoops(ast, shaderNames) {
-  let loopCount = 0;
+function collectLoopsToProtect(ast, shaderNames) {
+  const loops = [];
 
   function visitNode(node, ancestors) {
     const isInsideShader = ancestors.some((ancestor, idx) => {
@@ -142,30 +142,19 @@ function protectLoops(ast, shaderNames) {
 
     if (isInsideShader) return;
 
-    const varName = `_LP${loopCount++}`;
-    const { line } = node.loc.start;
-    const check = makeCheckStatement(varName, line);
-
-    if (node.body.type === 'BlockStatement') {
-      node.body.body.unshift(check);
-    } else {
-      node.body = { type: 'BlockStatement', body: [check, node.body] };
-    }
-
-    const varDecl = makeVarDecl(varName);
+    let parentBlock = null;
     for (let i = ancestors.length - 1; i >= 0; i--) {
       const ancestor = ancestors[i];
       if (
         ancestor !== node &&
         (ancestor.type === 'BlockStatement' || ancestor.type === 'Program')
       ) {
-        const nodeIdx = ancestor.body.indexOf(node);
-        if (nodeIdx !== -1) {
-          ancestor.body.splice(nodeIdx, 0, varDecl);
-          break;
-        }
+        parentBlock = ancestor;
+        break;
       }
     }
+
+    loops.push({ loop: node, parentBlock });
   }
 
   walk.ancestor(ast, {
@@ -174,7 +163,29 @@ function protectLoops(ast, shaderNames) {
     DoWhileStatement: visitNode
   });
 
-  return loopCount;
+  return loops;
+}
+
+function injectProtection(loops) {
+  loops.forEach(({ loop, parentBlock }, idx) => {
+    const varName = `_LP${idx}`;
+    const { line } = loop.loc.start;
+    const check = makeCheckStatement(varName, line);
+
+    if (loop.body.type === 'BlockStatement') {
+      loop.body.body.unshift(check);
+    } else {
+      loop.body = { type: 'BlockStatement', body: [check, loop.body] };
+    }
+
+    if (parentBlock) {
+      const varDecl = makeVarDecl(varName);
+      const nodeIdx = parentBlock.body.indexOf(loop);
+      if (nodeIdx !== -1) {
+        parentBlock.body.splice(nodeIdx, 0, varDecl);
+      }
+    }
+  });
 }
 
 function parseJs(jsText) {
@@ -199,9 +210,11 @@ export function jsPreprocess(jsText) {
   if (!ast) return jsText;
 
   const shaderNames = collectShaderFunctionNames(ast);
-  const loopCount = protectLoops(ast, shaderNames);
+  const loops = collectLoopsToProtect(ast, shaderNames);
 
-  if (loopCount === 0) return jsText;
+  if (loops.length === 0) return jsText;
+
+  injectProtection(loops);
 
   return escodegen.generate(ast);
 }

--- a/client/modules/Preview/jsPreprocess.js
+++ b/client/modules/Preview/jsPreprocess.js
@@ -1,0 +1,132 @@
+import * as acorn from 'acorn';
+import * as walk from 'acorn-walk';
+
+const LOOP_TIMEOUT_MS = 100;
+
+function isShaderCall(node) {
+  const { callee } = node;
+  const isBuildShader =
+    callee.type === 'Identifier' && /^build\w*Shader$/.test(callee.name);
+  const isBaseShaderModify =
+    callee.type === 'MemberExpression' &&
+    callee.property.name === 'modify' &&
+    callee.object.type === 'CallExpression' &&
+    callee.object.callee.type === 'Identifier' &&
+    /^base\w*Shader$/.test(callee.object.callee.name);
+  return isBuildShader || isBaseShaderModify;
+}
+
+function collectShaderFunctionNames(ast) {
+  const names = new Set();
+  walk.simple(ast, {
+    CallExpression(node) {
+      if (isShaderCall(node)) {
+        node.arguments.forEach((arg) => {
+          if (arg.type === 'Identifier') {
+            names.add(arg.name);
+          }
+        });
+      }
+    }
+  });
+  return names;
+}
+
+function collectLoopsToProtect(ast, shaderNames) {
+  const loops = [];
+
+  function visitNode(node, ancestors) {
+    const isInsideShader = ancestors.some((ancestor, idx) => {
+      if (
+        ancestor.type === 'FunctionDeclaration' &&
+        shaderNames.has(ancestor.id?.name)
+      ) {
+        return true;
+      }
+      if (
+        ancestor.type === 'FunctionExpression' ||
+        ancestor.type === 'ArrowFunctionExpression'
+      ) {
+        const parent = ancestors[idx - 1];
+        if (
+          parent?.type === 'CallExpression' &&
+          isShaderCall(parent) &&
+          parent.arguments.includes(ancestor)
+        ) {
+          return true;
+        }
+        if (
+          parent?.type === 'VariableDeclarator' &&
+          shaderNames.has(parent.id?.name)
+        ) {
+          return true;
+        }
+      }
+      return false;
+    });
+
+    if (!isInsideShader) loops.push(node);
+  }
+
+  walk.ancestor(ast, {
+    ForStatement: visitNode,
+    WhileStatement: visitNode,
+    DoWhileStatement: visitNode
+  });
+
+  return loops;
+}
+
+export function jsPreprocess(jsText) {
+  if (/\/\/\s*noprotect/.test(jsText)) {
+    return jsText;
+  }
+
+  let ast;
+  try {
+    ast = acorn.parse(jsText, {
+      ecmaVersion: 'latest',
+      sourceType: 'script',
+      locations: true
+    });
+  } catch (e) {
+    return jsText;
+  }
+
+  const shaderNames = collectShaderFunctionNames(ast);
+  const loops = collectLoopsToProtect(ast, shaderNames);
+
+  if (loops.length === 0) return jsText;
+
+  const insertions = [];
+
+  loops.forEach((loop) => {
+    const { line } = loop.loc.start;
+    const varName = `_LP${loop.start}`;
+
+    const beforeCode = `var ${varName} = Date.now(); `;
+
+    const checkCode =
+      `if (Date.now() - ${varName} > ${LOOP_TIMEOUT_MS}) ` +
+      `{ window.loopProtect.hit(${line}); break; } `;
+
+    const { body } = loop;
+    if (body.type === 'BlockStatement') {
+      insertions.push({ pos: loop.start, code: beforeCode });
+      insertions.push({ pos: body.start + 1, code: checkCode });
+    } else {
+      insertions.push({ pos: loop.start, code: beforeCode });
+      insertions.push({ pos: body.start, code: `{ ${checkCode}` });
+      insertions.push({ pos: body.end, code: ` }` });
+    }
+  });
+
+  insertions.sort((a, b) => b.pos - a.pos);
+
+  let result = jsText;
+  insertions.forEach(({ pos, code }) => {
+    result = result.slice(0, pos) + code + result.slice(pos);
+  });
+
+  return result;
+}

--- a/client/modules/Preview/jsPreprocess.js
+++ b/client/modules/Preview/jsPreprocess.js
@@ -29,51 +29,6 @@ function collectShaderFunctionNames(ast) {
   return names;
 }
 
-function collectLoopsToProtect(ast, shaderNames) {
-  const loops = [];
-
-  function visitNode(node, ancestors) {
-    const isInsideShader = ancestors.some((ancestor, idx) => {
-      if (
-        ancestor.type === 'FunctionDeclaration' &&
-        shaderNames.has(ancestor.id?.name)
-      ) {
-        return true;
-      }
-      if (
-        ancestor.type === 'FunctionExpression' ||
-        ancestor.type === 'ArrowFunctionExpression'
-      ) {
-        const parent = ancestors[idx - 1];
-        if (
-          parent?.type === 'CallExpression' &&
-          isShaderCall(parent) &&
-          parent.arguments.includes(ancestor)
-        ) {
-          return true;
-        }
-        if (
-          parent?.type === 'VariableDeclarator' &&
-          shaderNames.has(parent.id?.name)
-        ) {
-          return true;
-        }
-      }
-      return false;
-    });
-
-    if (!isInsideShader) loops.push(node);
-  }
-
-  walk.ancestor(ast, {
-    ForStatement: visitNode,
-    WhileStatement: visitNode,
-    DoWhileStatement: visitNode
-  });
-
-  return loops;
-}
-
 function makeVarDecl(varName) {
   return {
     type: 'VariableDeclaration',
@@ -152,58 +107,74 @@ function makeCheckStatement(varName, line) {
   };
 }
 
-function injectProtection(loop, idx) {
-  const varName = `_LP${idx}`;
-  const { line } = loop.loc.start;
-  const check = makeCheckStatement(varName, line);
+function protectLoops(ast, shaderNames) {
+  let loopCount = 0;
 
-  if (loop.body.type === 'BlockStatement') {
-    loop.body.body.unshift(check);
-  } else {
-    loop.body = {
-      type: 'BlockStatement',
-      body: [check, loop.body]
-    };
+  function visitNode(node, ancestors) {
+    const isInsideShader = ancestors.some((ancestor, idx) => {
+      if (
+        ancestor.type === 'FunctionDeclaration' &&
+        shaderNames.has(ancestor.id?.name)
+      ) {
+        return true;
+      }
+      if (
+        ancestor.type === 'FunctionExpression' ||
+        ancestor.type === 'ArrowFunctionExpression'
+      ) {
+        const parent = ancestors[idx - 1];
+        if (
+          parent?.type === 'CallExpression' &&
+          isShaderCall(parent) &&
+          parent.arguments.includes(ancestor)
+        ) {
+          return true;
+        }
+        if (
+          parent?.type === 'VariableDeclarator' &&
+          shaderNames.has(parent.id?.name)
+        ) {
+          return true;
+        }
+      }
+      return false;
+    });
+
+    if (isInsideShader) return;
+
+    const varName = `_LP${loopCount++}`;
+    const { line } = node.loc.start;
+    const check = makeCheckStatement(varName, line);
+
+    if (node.body.type === 'BlockStatement') {
+      node.body.body.unshift(check);
+    } else {
+      node.body = { type: 'BlockStatement', body: [check, node.body] };
+    }
+
+    const varDecl = makeVarDecl(varName);
+    for (let i = ancestors.length - 1; i >= 0; i--) {
+      const ancestor = ancestors[i];
+      if (
+        ancestor !== node &&
+        (ancestor.type === 'BlockStatement' || ancestor.type === 'Program')
+      ) {
+        const nodeIdx = ancestor.body.indexOf(node);
+        if (nodeIdx !== -1) {
+          ancestor.body.splice(nodeIdx, 0, varDecl);
+          break;
+        }
+      }
+    }
   }
 
-  return makeVarDecl(varName);
-}
-
-function insertVarDeclsIntoBlock(blockBody, loopsWithVarDecls) {
-  loopsWithVarDecls.forEach(({ loop, varDecl }) => {
-    const idx = blockBody.indexOf(loop);
-    if (idx !== -1) {
-      blockBody.splice(idx, 0, varDecl);
-    }
-  });
-}
-
-function injectVarDeclsIntoAst(ast, loops) {
-  const loopToVarDecl = new Map();
-  loops.forEach((loop, idx) => {
-    loopToVarDecl.set(loop, injectProtection(loop, idx));
+  walk.ancestor(ast, {
+    ForStatement: visitNode,
+    WhileStatement: visitNode,
+    DoWhileStatement: visitNode
   });
 
-  walk.simple(ast, {
-    BlockStatement(node) {
-      const loopsWithVarDecls = node.body
-        .filter((child) => loopToVarDecl.has(child))
-        .map((loop) => ({ loop, varDecl: loopToVarDecl.get(loop) }));
-      if (loopsWithVarDecls.length > 0) {
-        insertVarDeclsIntoBlock(node.body, loopsWithVarDecls);
-        loopsWithVarDecls.forEach(({ loop }) => loopToVarDecl.delete(loop));
-      }
-    },
-    Program(node) {
-      const loopsWithVarDecls = node.body
-        .filter((child) => loopToVarDecl.has(child))
-        .map((loop) => ({ loop, varDecl: loopToVarDecl.get(loop) }));
-      if (loopsWithVarDecls.length > 0) {
-        insertVarDeclsIntoBlock(node.body, loopsWithVarDecls);
-        loopsWithVarDecls.forEach(({ loop }) => loopToVarDecl.delete(loop));
-      }
-    }
-  });
+  return loopCount;
 }
 
 function parseJs(jsText) {
@@ -228,11 +199,9 @@ export function jsPreprocess(jsText) {
   if (!ast) return jsText;
 
   const shaderNames = collectShaderFunctionNames(ast);
-  const loops = collectLoopsToProtect(ast, shaderNames);
+  const loopCount = protectLoops(ast, shaderNames);
 
-  if (loops.length === 0) return jsText;
-
-  injectVarDeclsIntoAst(ast, loops);
+  if (loopCount === 0) return jsText;
 
   return escodegen.generate(ast);
 }

--- a/client/modules/Preview/jsPreprocess.unit.test.js
+++ b/client/modules/Preview/jsPreprocess.unit.test.js
@@ -1,0 +1,129 @@
+import { jsPreprocess } from './jsPreprocess';
+
+describe('jsPreprocess', () => {
+  describe('// noprotect', () => {
+    it('returns code unchanged when // noprotect is present', () => {
+      const code = '// noprotect\nfor (let i = 0; i < 10; i++) {}';
+      expect(jsPreprocess(code)).toBe(code);
+    });
+  });
+
+  describe('regular loop protection', () => {
+    it('adds loop protection to a for loop', () => {
+      const code = 'for (let i = 0; i < 10; i++) {}';
+      const result = jsPreprocess(code);
+      expect(result).toContain('window.loopProtect.hit');
+      expect(result).toContain('Date.now()');
+    });
+
+    it('adds loop protection to a while loop', () => {
+      const code = 'while (true) {}';
+      const result = jsPreprocess(code);
+      expect(result).toContain('window.loopProtect.hit');
+    });
+
+    it('adds loop protection to a do-while loop', () => {
+      const code = 'do {} while (true)';
+      const result = jsPreprocess(code);
+      expect(result).toContain('window.loopProtect.hit');
+    });
+
+    it('returns original code if transform fails', () => {
+      const code = 'this is not valid javascript @@@@';
+      expect(jsPreprocess(code)).toBe(code);
+    });
+  });
+
+  describe('shader strings', () => {
+    it('does not modify for loops inside template literal shader strings', () => {
+      const code = `
+        const shader = \`
+          for (int i = 0; i < 20; i++) {
+            total += texture(tex, uv);
+          }
+        \`;
+      `;
+      const result = jsPreprocess(code);
+      expect(result).not.toContain('window.loopProtect.hit');
+    });
+
+    it('does not modify for loops inside single-quoted strings', () => {
+      const code = "const glsl = 'for (int i = 0; i < 10; i++) {}';";
+      const result = jsPreprocess(code);
+      expect(result).not.toContain('window.loopProtect.hit');
+    });
+
+    it('does not modify GLSL inside buildFilterShader object argument', () => {
+      const code = `
+        blur = buildFilterShader({
+          'vec4 getColor': \`(FilterInputs inputs) {
+            for (int i = 0; i < 20; i++) {
+              total += getTexture(canvasContent, inputs.texCoord);
+            }
+          }\`
+        });
+      `;
+      const result = jsPreprocess(code);
+      expect(result).not.toContain('window.loopProtect.hit');
+    });
+  });
+
+  describe('p5.strands shader functions', () => {
+    it('skips loop protection for named function passed to buildFilterShader', () => {
+      const code = `
+        blur = buildFilterShader(doBlur);
+        function doBlur() {
+          for (let i = 0; i < 20; i++) {}
+        }
+      `;
+      const result = jsPreprocess(code);
+      expect(result).not.toContain('window.loopProtect.hit');
+    });
+
+    it('skips loop protection for arrow function variable passed to buildFilterShader', () => {
+      const code = `
+        const doBlur = () => {
+          for (let i = 0; i < 20; i++) {}
+        };
+        blur = buildFilterShader(doBlur);
+      `;
+      const result = jsPreprocess(code);
+      expect(result).not.toContain('window.loopProtect.hit');
+    });
+
+    it('skips loop protection for inline function passed to buildFilterShader', () => {
+      const code = `
+        blur = buildFilterShader(function() {
+          for (let i = 0; i < 20; i++) {}
+        });
+      `;
+      const result = jsPreprocess(code);
+      expect(result).not.toContain('window.loopProtect.hit');
+    });
+
+    it('skips loop protection for function passed to base*Shader().modify()', () => {
+      const code = `
+        blur = baseFilterShader().modify(doBlur);
+        function doBlur() {
+          for (let i = 0; i < 20; i++) {}
+        }
+      `;
+      const result = jsPreprocess(code);
+      expect(result).not.toContain('window.loopProtect.hit');
+    });
+
+    it('still protects regular loops outside shader functions', () => {
+      const code = `
+        blur = buildFilterShader(doBlur);
+        function doBlur() {
+          for (let i = 0; i < 20; i++) {}
+        }
+        function draw() {
+          for (let j = 0; j < 100; j++) {}
+        }
+      `;
+      const result = jsPreprocess(code);
+      expect(result).toContain('window.loopProtect.hit');
+    });
+  });
+});

--- a/client/modules/Preview/jsPreprocess.unit.test.js
+++ b/client/modules/Preview/jsPreprocess.unit.test.js
@@ -32,6 +32,15 @@ describe('jsPreprocess', () => {
       const code = 'this is not valid javascript @@@@';
       expect(jsPreprocess(code)).toBe(code);
     });
+
+    it('handles module scripts with import statements', () => {
+      const code = `
+        import something from 'somewhere';
+        for (let i = 0; i < 10; i++) {}
+      `;
+      const result = jsPreprocess(code);
+      expect(result).toContain('window.loopProtect.hit');
+    });
   });
 
   describe('shader strings', () => {
@@ -104,6 +113,17 @@ describe('jsPreprocess', () => {
     it('skips loop protection for function passed to base*Shader().modify()', () => {
       const code = `
         blur = baseFilterShader().modify(doBlur);
+        function doBlur() {
+          for (let i = 0; i < 20; i++) {}
+        }
+      `;
+      const result = jsPreprocess(code);
+      expect(result).not.toContain('window.loopProtect.hit');
+    });
+
+    it('skips loop protection for function passed to any .modify() call', () => {
+      const code = `
+        blur = someCustomShader().modify(doBlur);
         function doBlur() {
           for (let i = 0; i < 20; i++) {}
         }

--- a/client/utils/previewEntry.js
+++ b/client/utils/previewEntry.js
@@ -1,4 +1,3 @@
-import loopProtect from 'loop-protect';
 import { Hook, Decode, Encode } from 'console-feed';
 import StackTrace from 'stacktrace-js';
 import { evaluateExpression } from './evaluateExpression';
@@ -14,16 +13,13 @@ const htmlOffset = 12;
 window.objectUrls[window.location.href] = '/index.html';
 const blobPath = window.location.href.split('/').pop();
 window.objectPaths[blobPath] = 'index.html';
-// Monkey-patch loopProtect to send infinite loop warnings to the in-app console
-window.loopProtect = loopProtect;
-if (window.loopProtect && typeof window.loopProtect.hit === 'function') {
-  let hitCount = 0;
-  let lastHitTime = 0;
-  let firstLine = null;
-  let stopTimeout = null;
-  window.loopProtect.hit = function handleLoopHit(line) {
+let hitCount = 0;
+let lastHitTime = 0;
+let firstLine = null;
+let stopTimeout = null;
+window.loopProtect = {
+  hit: function handleLoopHit(line) {
     const now = Date.now();
-    // Reset counters if more than 1 second has passed
     if (now - lastHitTime > 1000) {
       hitCount = 0;
       firstLine = null;
@@ -35,37 +31,28 @@ if (window.loopProtect && typeof window.loopProtect.hit === 'function') {
     hitCount++;
     lastHitTime = now;
 
-    // Track first line for single loop case
     if (hitCount === 1) {
       firstLine = line;
-      // Wait briefly to see if more loops are detected (minimal delay)
       stopTimeout = setTimeout(() => {
         if (hitCount === 1) {
-          // Only one loop detected - show line number
           const msg = `Infinite loop detected at line ${firstLine}. Stopping execution.`;
           throw new Error(msg);
         }
-        // If hitCount > 1, another loop already threw the error
       }, 30);
     }
 
-    // If multiple loops detected, stop immediately without waiting
     if (hitCount > 1) {
-      // Clear single loop timeout since we have multiple
       if (stopTimeout) {
         clearTimeout(stopTimeout);
         stopTimeout = null;
       }
-      // Stop immediately - multiple loops exist
       const msg = 'Multiple infinite loops detected. Stopping execution.';
       throw new Error(msg);
     }
 
-    // Don't call origHit to prevent duplicate messages
-    // The loop protection still works, we just handle the messaging ourselves
-    return true; // Return true to indicate loop was detected
-  };
-}
+    return true;
+  }
+};
 
 const consoleBuffer = [];
 const LOGWAIT = 500;

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
         "dotenv": "^2.0.0",
         "dropzone": "^4.3.0",
         "escape-string-regexp": "^1.0.5",
+        "escodegen": "^2.1.0",
         "eslint-scope": "^8.4.0",
         "eslint-webpack-plugin": "^3.1.1",
         "express": "^4.22.1",
@@ -374,1278 +375,6 @@
         "@aws-sdk/types": "^3.222.0",
         "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.609.0.tgz",
-      "integrity": "sha512-3kDTpia1iN/accayoH3MbZRbDvX2tzrKrBTU7wNNoazVrh+gOMS8KCOWrOB72F0V299l4FsfQhnl9BDMVrc1iw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^2.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-      "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-      "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sts": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-      "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/core": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-      "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/core": "^2.2.4",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-      "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-      "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-      "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-ini": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-      "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-      "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.609.0",
-        "@aws-sdk/token-providers": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-      "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
-      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-      "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-      "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-      "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-      "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.609.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-      "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
-      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-      "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
-      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/config-resolver": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.4.tgz",
-      "integrity": "sha512-VwiOk7TwXoE7NlNguV/aPq1hFH72tqkHCw8eWXbr2xHspRyyv9DLpLXhq+Ieje+NwoqXrY0xyQjPXdOE6cGcHA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/core": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.5.tgz",
-      "integrity": "sha512-0kqyj93/Aa30TEXnnWRBetN8fDGjFF+u8cdIiMI8YS6CrUF2dLTavRfHKfWh5cL5d6s2ZNyEnLjBitdcKmkETQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.8",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.6",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/credential-provider-imds": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.3.tgz",
-      "integrity": "sha512-U1Yrv6hx/mRK6k8AncuI6jLUx9rn0VVSd9NPEX6pyYFBfkSkChOc/n4zUb8alHUVg83TbI4OdZVo1X0Zfj3ijA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.1.tgz",
-      "integrity": "sha512-0w0bgUvZmfa0vHN8a+moByhCJT07WN6AHKEhFSOLsDpnszm+5dLVv5utGaqbhOrZ/aF5x3xuPMs/oMCd+4O5xg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-base64": "^3.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/hash-node": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
-      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/hash-node/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
-      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.3.tgz",
-      "integrity": "sha512-Dbz2bzexReYIQDWMr+gZhpwBetNXzbhnEMhYKA6urqmojO14CsXjnsoPYO8UL/xxcawn8ZsuVU61ElkLSltIUQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.4.tgz",
-      "integrity": "sha512-whUJMEPwl3ANIbXjBXZVdJNgfV2ZU8ayln7xUM47rXL2txuenI7jQ/VFFwCzy5lCmXScjp6zYtptW5Evud8e9g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-retry": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.8.tgz",
-      "integrity": "sha512-wmIw3t6ZbeqstUFdXtStzSSltoYrcfc28ndnr0mDSMmtMSRNduNbmneA7xiE224fVFXzbf24+0oREks1u2X7Mw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.1.6",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-serde": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
-      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-stack": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
-      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.3.tgz",
-      "integrity": "sha512-rxdpAZczzholz6CYZxtqDu/aKTxATD5DAUDVj7HoEulq+pDSQVWzbg0btZDlxeFfa6bb2b5tUvgdX5+k8jUqcg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-http-handler": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.2.tgz",
-      "integrity": "sha512-Td3rUNI7qqtoSLTsJBtsyfoG4cF/XMFmJr6Z2dX8QNzIi6tIW6YmuyFml8mJ2cNpyWNqITKbROMOFrvQjmsOvw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/property-provider": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
-      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/protocol-http": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.3.tgz",
-      "integrity": "sha512-x5jmrCWwQlx+Zv4jAtc33ijJ+vqqYN+c/ZkrnpvEe/uDas7AT7A/4Rc2CdfxgWv4WFGmEqODIrrUToPN6DDkGw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-builder": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
-      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-uri-escape": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
-      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.3.tgz",
-      "integrity": "sha512-Z8Y3+08vgoDgl4HENqNnnzSISAaGrF2RoKupoC47u2wiMp+Z8P/8mDh1CL8+8ujfi2U5naNvopSBmP/BUj8b5w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/signature-v4": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
-      "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-uri-escape": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/smithy-client": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.6.tgz",
-      "integrity": "sha512-w9oboI661hfptr26houZ5mdKc//DMxkuOMXSaIiALqGn4bHYT9S4U69BBS6tHX4TZHgShmhcz0d6aXk7FY5soA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/url-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
-      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/querystring-parser": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-base64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
-      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-base64/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
-      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
-      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-config-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
-      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.8.tgz",
-      "integrity": "sha512-eLRHCvM1w3ZJkYcd60yKqM3d70dPB+071EDpf9ZGYqFed3xcm/+pWwNS/xM0JXRrjm0yAA19dWcdFN2IE/66pQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.6",
-        "@smithy/types": "^3.3.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.8.tgz",
-      "integrity": "sha512-Tajvdyg5+k77j6AOrwSCZgi7KdBizqPNs3HCnFGRoxDjzh+CjPLaLrXbIRB0lsAmqYmRHIU34IogByaqvDrkBQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/credential-provider-imds": "^3.1.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.6",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-endpoints": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.4.tgz",
-      "integrity": "sha512-ZAtNf+vXAsgzgRutDDiklU09ZzZiiV/nATyqde4Um4priTmasDH+eLpp3tspL0hS2dEootyFMhu1Y6Y+tzpWBQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-hex-encoding": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-middleware": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
-      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-stream": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.6.tgz",
-      "integrity": "sha512-w9i//7egejAIvplX821rPWWgaiY1dxsQUw0hXX7qwa/uZ9U3zplqTQ871jWadkcVB9gFDhkPWYVZf4yfFbZ0xA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.1",
-        "@smithy/node-http-handler": "^3.1.2",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-stream/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-uri-escape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@aws-sdk/client-cognito-identity/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@aws-sdk/client-s3": {
@@ -3194,71 +1923,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.609.0.tgz",
-      "integrity": "sha512-BqrpAXRr64dQ/uZsRB2wViGKTkVRlfp8Q+Zd7Bc8Ikk+YXjPtl+IyWXKtdKQ3LBO255KwAcPmra5oFC+2R1GOQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/property-provider": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
-      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.535.0.tgz",
@@ -3416,1267 +2080,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-    },
-    "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.609.0.tgz",
-      "integrity": "sha512-bJKMY4QwRVderh8R2s9kukoZhuNZew/xzwPa9DRRFVOIsznsS0faAdmAAFrKb8e06YyQq6DiZP0BfFyVHAXE2A==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.609.0",
-        "@aws-sdk/client-sso": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.609.0",
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-ini": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-browser": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-js": "^5.2.0",
-        "@aws-crypto/supports-web-crypto": "^5.2.0",
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "@aws-sdk/util-locate-window": "^3.0.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/sha256-js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/util": "^5.2.0",
-        "@aws-sdk/types": "^3.222.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/supports-web-crypto": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-crypto/util": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "^3.222.0",
-        "@smithy/util-utf8": "^2.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-      "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-      "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso-oidc/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-      "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sts/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-      "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/core": "^2.2.4",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/signature-v4": "^3.1.2",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "fast-xml-parser": "4.2.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-      "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-      "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.5",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-      "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-      "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-ini": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-      "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-      "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/client-sso": "3.609.0",
-        "@aws-sdk/token-providers": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-      "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sts": "^3.609.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-      "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
-      "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-      "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-      "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-      "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-      "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/client-sso-oidc": "^3.609.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-      "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-      "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-endpoints": "^2.0.4",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
-      "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/types": "^3.3.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-      "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "aws-crt": ">=1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "aws-crt": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/abort-controller": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
-      "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/config-resolver": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.4.tgz",
-      "integrity": "sha512-VwiOk7TwXoE7NlNguV/aPq1hFH72tqkHCw8eWXbr2xHspRyyv9DLpLXhq+Ieje+NwoqXrY0xyQjPXdOE6cGcHA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-config-provider": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/core": {
-      "version": "2.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.5.tgz",
-      "integrity": "sha512-0kqyj93/Aa30TEXnnWRBetN8fDGjFF+u8cdIiMI8YS6CrUF2dLTavRfHKfWh5cL5d6s2ZNyEnLjBitdcKmkETQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.8",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.6",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/credential-provider-imds": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.3.tgz",
-      "integrity": "sha512-U1Yrv6hx/mRK6k8AncuI6jLUx9rn0VVSd9NPEX6pyYFBfkSkChOc/n4zUb8alHUVg83TbI4OdZVo1X0Zfj3ijA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/fetch-http-handler": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.1.tgz",
-      "integrity": "sha512-0w0bgUvZmfa0vHN8a+moByhCJT07WN6AHKEhFSOLsDpnszm+5dLVv5utGaqbhOrZ/aF5x3xuPMs/oMCd+4O5xg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-base64": "^3.0.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/hash-node": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
-      "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/hash-node/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/invalid-dependency": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
-      "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/is-array-buffer": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-      "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-content-length": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.3.tgz",
-      "integrity": "sha512-Dbz2bzexReYIQDWMr+gZhpwBetNXzbhnEMhYKA6urqmojO14CsXjnsoPYO8UL/xxcawn8ZsuVU61ElkLSltIUQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-endpoint": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.4.tgz",
-      "integrity": "sha512-whUJMEPwl3ANIbXjBXZVdJNgfV2ZU8ayln7xUM47rXL2txuenI7jQ/VFFwCzy5lCmXScjp6zYtptW5Evud8e9g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-middleware": "^3.0.3",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-retry": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.8.tgz",
-      "integrity": "sha512-wmIw3t6ZbeqstUFdXtStzSSltoYrcfc28ndnr0mDSMmtMSRNduNbmneA7xiE224fVFXzbf24+0oREks1u2X7Mw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/smithy-client": "^3.1.6",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-serde": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
-      "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-stack": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
-      "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-config-provider": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.3.tgz",
-      "integrity": "sha512-rxdpAZczzholz6CYZxtqDu/aKTxATD5DAUDVj7HoEulq+pDSQVWzbg0btZDlxeFfa6bb2b5tUvgdX5+k8jUqcg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/shared-ini-file-loader": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-http-handler": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.2.tgz",
-      "integrity": "sha512-Td3rUNI7qqtoSLTsJBtsyfoG4cF/XMFmJr6Z2dX8QNzIi6tIW6YmuyFml8mJ2cNpyWNqITKbROMOFrvQjmsOvw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/abort-controller": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/querystring-builder": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/property-provider": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
-      "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/protocol-http": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.3.tgz",
-      "integrity": "sha512-x5jmrCWwQlx+Zv4jAtc33ijJ+vqqYN+c/ZkrnpvEe/uDas7AT7A/4Rc2CdfxgWv4WFGmEqODIrrUToPN6DDkGw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-builder": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
-      "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-uri-escape": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
-      "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/service-error-classification": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-      "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/shared-ini-file-loader": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.3.tgz",
-      "integrity": "sha512-Z8Y3+08vgoDgl4HENqNnnzSISAaGrF2RoKupoC47u2wiMp+Z8P/8mDh1CL8+8ujfi2U5naNvopSBmP/BUj8b5w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
-      "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-uri-escape": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/smithy-client": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.6.tgz",
-      "integrity": "sha512-w9oboI661hfptr26houZ5mdKc//DMxkuOMXSaIiALqGn4bHYT9S4U69BBS6tHX4TZHgShmhcz0d6aXk7FY5soA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-stream": "^3.0.6",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-      "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/url-parser": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
-      "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/querystring-parser": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-base64": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
-      "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-base64/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-browser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
-      "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-node": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
-      "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-      "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/is-array-buffer": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-config-provider": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
-      "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.8.tgz",
-      "integrity": "sha512-eLRHCvM1w3ZJkYcd60yKqM3d70dPB+071EDpf9ZGYqFed3xcm/+pWwNS/xM0JXRrjm0yAA19dWcdFN2IE/66pQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.6",
-        "@smithy/types": "^3.3.0",
-        "bowser": "^2.11.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-node": {
-      "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.8.tgz",
-      "integrity": "sha512-Tajvdyg5+k77j6AOrwSCZgi7KdBizqPNs3HCnFGRoxDjzh+CjPLaLrXbIRB0lsAmqYmRHIU34IogByaqvDrkBQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/credential-provider-imds": "^3.1.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/smithy-client": "^3.1.6",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-endpoints": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.4.tgz",
-      "integrity": "sha512-ZAtNf+vXAsgzgRutDDiklU09ZzZiiV/nATyqde4Um4priTmasDH+eLpp3tspL0hS2dEootyFMhu1Y6Y+tzpWBQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-hex-encoding": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-      "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-middleware": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
-      "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-retry": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-      "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/service-error-classification": "^3.0.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-stream": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.6.tgz",
-      "integrity": "sha512-w9i//7egejAIvplX821rPWWgaiY1dxsQUw0hXX7qwa/uZ9U3zplqTQ871jWadkcVB9gFDhkPWYVZf4yfFbZ0xA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/fetch-http-handler": "^3.2.1",
-        "@smithy/node-http-handler": "^3.1.2",
-        "@smithy/types": "^3.3.0",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-buffer-from": "^3.0.0",
-        "@smithy/util-hex-encoding": "^3.0.0",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-stream/node_modules/@smithy/util-utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-      "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@smithy/util-buffer-from": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-uri-escape": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-      "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/tslib": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/@aws-sdk/credential-providers/node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.535.0",
@@ -8856,6 +6259,57 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/@esbuild/darwin-arm64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
@@ -8867,6 +6321,312 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=12"
@@ -15079,6 +12839,159 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.13.tgz",
+      "integrity": "sha512-AW8akFSC+tmPE6YQQvK9S2A1B8pjnXEINg+gGgw0KRUUXunvu1/OEOeC5L2Co1wAwhD7bhnaefi06Qi9AiwOag==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.13.tgz",
+      "integrity": "sha512-f4gxxvDXVUm2HLYXRd311mSrmbpQF2MZ4Ja6XCQz1hWAxXdhRl1gpnZ+LH/xIfGSwQChrtLLVrkxdYUCVuIjFg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.13.tgz",
+      "integrity": "sha512-Nf/eoW2CbG8s+9JoLtjl9FByBXyQ5cjdBsA4efO7Zw4p+YSuXDgc8HRPC+E2+ns0praDpKNZtLvDtmF2lL+2Gg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.13.tgz",
+      "integrity": "sha512-2OysYSYtdw79prJYuKIiux/Gj0iaGEbpS2QZWCIY4X9sGoETJ5iMg+lY+YCrIxdkkNYd7OhIbXdYFyGs/w5LDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.13.tgz",
+      "integrity": "sha512-PkR4CZYJNk5hcd2+tMWBpnisnmYsUzazI1O5X7VkIGFcGePTqJ/bWlfUIVVExWxvAI33PQFzLbzmN5scyIUyGQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.13.tgz",
+      "integrity": "sha512-OdsY7wryTxCKwGQcwW9jwWg3cxaHBkTTHi91+5nm7hFPpmZMz1HivJrWAMwVE7iXFw+M4l6ugB/wCvpYrUAAjA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.13.tgz",
+      "integrity": "sha512-ap6uNmYjwk9M/+bFEuWRNl3hq4VqgQ/Lk+ID/F5WGqczNr0L7vEf+pOsRAn0F6EV+o/nyb3ePt8rLhE/wjHpPg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.13.tgz",
+      "integrity": "sha512-IJ8KH4yIUHTnS/U1jwQmtbfQals7zWPG0a9hbEfIr4zI0yKzjd83lmtS09lm2Q24QBWOCFGEEbuZxR4tIlvfzA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.13.tgz",
+      "integrity": "sha512-f6/sx6LMuEnbuxtiSL/EkR0Y6qUHFw1XVrh6rwzKXptTipUdOY+nXpKoh+1UsBm/r7H0/5DtOdrn3q5ZHbFZjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
       ],
       "engines": {
         "node": ">=10"
@@ -21785,6 +19698,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -24911,34 +22825,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "node_modules/ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
-      "engines": {
-        "node": ">= 12"
-      }
-    },
-    "node_modules/ip-address/node_modules/jsbn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/ip-address/node_modules/sprintf-js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -25886,23 +23772,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-circus/node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.12.5",
-        "cosmiconfig": "^7.0.0",
-        "resolve": "^1.19.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "npm": ">=6"
       }
     },
     "node_modules/jest-circus/node_modules/chalk": {
@@ -35927,32 +33796,6 @@
         "node": ">=8.0.0"
       }
     },
-    "node_modules/smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 6.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
-    "node_modules/socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ip-address": "^9.0.5",
-        "smart-buffer": "^4.2.0"
-      },
-      "engines": {
-        "node": ">= 10.0.0",
-        "npm": ">= 3.0.0"
-      }
-    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -36983,20 +34826,6 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -38730,1079 +36559,6 @@
         "tslib": "^1.11.1"
       }
     },
-    "@aws-sdk/client-cognito-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.609.0.tgz",
-      "integrity": "sha512-3kDTpia1iN/accayoH3MbZRbDvX2tzrKrBTU7wNNoazVrh+gOMS8KCOWrOB72F0V299l4FsfQhnl9BDMVrc1iw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/client-sso-oidc": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/core": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/middleware-host-header": "3.609.0",
-        "@aws-sdk/middleware-logger": "3.609.0",
-        "@aws-sdk/middleware-recursion-detection": "3.609.0",
-        "@aws-sdk/middleware-user-agent": "3.609.0",
-        "@aws-sdk/region-config-resolver": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@aws-sdk/util-endpoints": "3.609.0",
-        "@aws-sdk/util-user-agent-browser": "3.609.0",
-        "@aws-sdk/util-user-agent-node": "3.609.0",
-        "@smithy/config-resolver": "^3.0.4",
-        "@smithy/core": "^2.2.4",
-        "@smithy/fetch-http-handler": "^3.2.0",
-        "@smithy/hash-node": "^3.0.3",
-        "@smithy/invalid-dependency": "^3.0.3",
-        "@smithy/middleware-content-length": "^3.0.3",
-        "@smithy/middleware-endpoint": "^3.0.4",
-        "@smithy/middleware-retry": "^3.0.7",
-        "@smithy/middleware-serde": "^3.0.3",
-        "@smithy/middleware-stack": "^3.0.3",
-        "@smithy/node-config-provider": "^3.1.3",
-        "@smithy/node-http-handler": "^3.1.1",
-        "@smithy/protocol-http": "^4.0.3",
-        "@smithy/smithy-client": "^3.1.5",
-        "@smithy/types": "^3.3.0",
-        "@smithy/url-parser": "^3.0.3",
-        "@smithy/util-base64": "^3.0.0",
-        "@smithy/util-body-length-browser": "^3.0.0",
-        "@smithy/util-body-length-node": "^3.0.0",
-        "@smithy/util-defaults-mode-browser": "^3.0.7",
-        "@smithy/util-defaults-mode-node": "^3.0.7",
-        "@smithy/util-endpoints": "^2.0.4",
-        "@smithy/util-middleware": "^3.0.3",
-        "@smithy/util-retry": "^3.0.3",
-        "@smithy/util-utf8": "^3.0.0",
-        "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-crypto/sha256-browser": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-crypto/sha256-js": "^5.2.0",
-            "@aws-crypto/supports-web-crypto": "^5.2.0",
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
-              "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/util-buffer-from": "^2.2.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@aws-sdk/client-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-          "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
-            "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/hash-node": "^3.0.3",
-            "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
-            "@smithy/middleware-serde": "^3.0.3",
-            "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
-            "@smithy/types": "^3.3.0",
-            "@smithy/url-parser": "^3.0.3",
-            "@smithy/util-base64": "^3.0.0",
-            "@smithy/util-body-length-browser": "^3.0.0",
-            "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
-            "@smithy/util-middleware": "^3.0.3",
-            "@smithy/util-retry": "^3.0.3",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-          "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
-            "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/hash-node": "^3.0.3",
-            "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
-            "@smithy/middleware-serde": "^3.0.3",
-            "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
-            "@smithy/types": "^3.3.0",
-            "@smithy/url-parser": "^3.0.3",
-            "@smithy/util-base64": "^3.0.0",
-            "@smithy/util-body-length-browser": "^3.0.0",
-            "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
-            "@smithy/util-middleware": "^3.0.3",
-            "@smithy/util-retry": "^3.0.3",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-          "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/client-sso-oidc": "3.609.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
-            "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/hash-node": "^3.0.3",
-            "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
-            "@smithy/middleware-serde": "^3.0.3",
-            "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
-            "@smithy/types": "^3.3.0",
-            "@smithy/url-parser": "^3.0.3",
-            "@smithy/util-base64": "^3.0.0",
-            "@smithy/util-body-length-browser": "^3.0.0",
-            "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
-            "@smithy/util-middleware": "^3.0.3",
-            "@smithy/util-retry": "^3.0.3",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/core": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-          "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/core": "^2.2.4",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/signature-v4": "^3.1.2",
-            "@smithy/smithy-client": "^3.1.5",
-            "@smithy/types": "^3.3.0",
-            "fast-xml-parser": "4.2.5",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-          "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-http": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-          "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-stream": "^3.0.5",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-          "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-          "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-ini": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-          "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-          "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/client-sso": "3.609.0",
-            "@aws-sdk/token-providers": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-          "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-          "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
-          "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-          "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-          "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/region-config-resolver": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-          "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-config-provider": "^3.0.0",
-            "@smithy/util-middleware": "^3.0.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-          "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-          "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-          "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-endpoints": "^2.0.4",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
-          "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/types": "^3.3.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-          "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/abort-controller": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
-          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/config-resolver": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.4.tgz",
-          "integrity": "sha512-VwiOk7TwXoE7NlNguV/aPq1hFH72tqkHCw8eWXbr2xHspRyyv9DLpLXhq+Ieje+NwoqXrY0xyQjPXdOE6cGcHA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-config-provider": "^3.0.0",
-            "@smithy/util-middleware": "^3.0.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/core": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.5.tgz",
-          "integrity": "sha512-0kqyj93/Aa30TEXnnWRBetN8fDGjFF+u8cdIiMI8YS6CrUF2dLTavRfHKfWh5cL5d6s2ZNyEnLjBitdcKmkETQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.8",
-            "@smithy/middleware-serde": "^3.0.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.6",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-middleware": "^3.0.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/credential-provider-imds": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.3.tgz",
-          "integrity": "sha512-U1Yrv6hx/mRK6k8AncuI6jLUx9rn0VVSd9NPEX6pyYFBfkSkChOc/n4zUb8alHUVg83TbI4OdZVo1X0Zfj3ijA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/url-parser": "^3.0.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/fetch-http-handler": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.1.tgz",
-          "integrity": "sha512-0w0bgUvZmfa0vHN8a+moByhCJT07WN6AHKEhFSOLsDpnszm+5dLVv5utGaqbhOrZ/aF5x3xuPMs/oMCd+4O5xg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/querystring-builder": "^3.0.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-base64": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/hash-node": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
-          "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-buffer-from": "^3.0.0",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-buffer-from": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-              "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@smithy/invalid-dependency": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
-          "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/middleware-content-length": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.3.tgz",
-          "integrity": "sha512-Dbz2bzexReYIQDWMr+gZhpwBetNXzbhnEMhYKA6urqmojO14CsXjnsoPYO8UL/xxcawn8ZsuVU61ElkLSltIUQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/middleware-endpoint": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.4.tgz",
-          "integrity": "sha512-whUJMEPwl3ANIbXjBXZVdJNgfV2ZU8ayln7xUM47rXL2txuenI7jQ/VFFwCzy5lCmXScjp6zYtptW5Evud8e9g==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/middleware-serde": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/url-parser": "^3.0.3",
-            "@smithy/util-middleware": "^3.0.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/middleware-retry": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.8.tgz",
-          "integrity": "sha512-wmIw3t6ZbeqstUFdXtStzSSltoYrcfc28ndnr0mDSMmtMSRNduNbmneA7xiE224fVFXzbf24+0oREks1u2X7Mw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/smithy-client": "^3.1.6",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-middleware": "^3.0.3",
-            "@smithy/util-retry": "^3.0.3",
-            "tslib": "^2.6.2",
-            "uuid": "^9.0.1"
-          }
-        },
-        "@smithy/middleware-serde": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
-          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/middleware-stack": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
-          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/node-config-provider": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.3.tgz",
-          "integrity": "sha512-rxdpAZczzholz6CYZxtqDu/aKTxATD5DAUDVj7HoEulq+pDSQVWzbg0btZDlxeFfa6bb2b5tUvgdX5+k8jUqcg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/node-http-handler": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.2.tgz",
-          "integrity": "sha512-Td3rUNI7qqtoSLTsJBtsyfoG4cF/XMFmJr6Z2dX8QNzIi6tIW6YmuyFml8mJ2cNpyWNqITKbROMOFrvQjmsOvw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/abort-controller": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/querystring-builder": "^3.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/property-provider": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
-          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.3.tgz",
-          "integrity": "sha512-x5jmrCWwQlx+Zv4jAtc33ijJ+vqqYN+c/ZkrnpvEe/uDas7AT7A/4Rc2CdfxgWv4WFGmEqODIrrUToPN6DDkGw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/querystring-builder": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
-          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-uri-escape": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/querystring-parser": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
-          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/shared-ini-file-loader": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.3.tgz",
-          "integrity": "sha512-Z8Y3+08vgoDgl4HENqNnnzSISAaGrF2RoKupoC47u2wiMp+Z8P/8mDh1CL8+8ujfi2U5naNvopSBmP/BUj8b5w==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/signature-v4": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
-          "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^3.0.0",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-hex-encoding": "^3.0.0",
-            "@smithy/util-middleware": "^3.0.3",
-            "@smithy/util-uri-escape": "^3.0.0",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/smithy-client": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.6.tgz",
-          "integrity": "sha512-w9oboI661hfptr26houZ5mdKc//DMxkuOMXSaIiALqGn4bHYT9S4U69BBS6tHX4TZHgShmhcz0d6aXk7FY5soA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-stream": "^3.0.6",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/url-parser": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
-          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/querystring-parser": "^3.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-base64": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
-          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^3.0.0",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-buffer-from": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-              "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@smithy/util-body-length-browser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
-          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-body-length-node": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
-          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-config-provider": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
-          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-defaults-mode-browser": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.8.tgz",
-          "integrity": "sha512-eLRHCvM1w3ZJkYcd60yKqM3d70dPB+071EDpf9ZGYqFed3xcm/+pWwNS/xM0JXRrjm0yAA19dWcdFN2IE/66pQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/smithy-client": "^3.1.6",
-            "@smithy/types": "^3.3.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-defaults-mode-node": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.8.tgz",
-          "integrity": "sha512-Tajvdyg5+k77j6AOrwSCZgi7KdBizqPNs3HCnFGRoxDjzh+CjPLaLrXbIRB0lsAmqYmRHIU34IogByaqvDrkBQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/credential-provider-imds": "^3.1.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/smithy-client": "^3.1.6",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-endpoints": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.4.tgz",
-          "integrity": "sha512-ZAtNf+vXAsgzgRutDDiklU09ZzZiiV/nATyqde4Um4priTmasDH+eLpp3tspL0hS2dEootyFMhu1Y6Y+tzpWBQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-hex-encoding": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
-          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-stream": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.6.tgz",
-          "integrity": "sha512-w9i//7egejAIvplX821rPWWgaiY1dxsQUw0hXX7qwa/uZ9U3zplqTQ871jWadkcVB9gFDhkPWYVZf4yfFbZ0xA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/fetch-http-handler": "^3.2.1",
-            "@smithy/node-http-handler": "^3.1.2",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-base64": "^3.0.0",
-            "@smithy/util-buffer-from": "^3.0.0",
-            "@smithy/util-hex-encoding": "^3.0.0",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-buffer-from": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-              "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@smithy/util-uri-escape": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-utf8": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-          "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-buffer-from": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-              "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/is-array-buffer": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "tslib": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-          "optional": true,
-          "peer": true
-        },
-        "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "@aws-sdk/client-s3": {
       "version": "3.540.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.540.0.tgz",
@@ -41050,61 +37806,6 @@
         }
       }
     },
-    "@aws-sdk/credential-provider-cognito-identity": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.609.0.tgz",
-      "integrity": "sha512-BqrpAXRr64dQ/uZsRB2wViGKTkVRlfp8Q+Zd7Bc8Ikk+YXjPtl+IyWXKtdKQ3LBO255KwAcPmra5oFC+2R1GOQ==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@aws-sdk/client-cognito-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-sdk/types": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-          "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/property-provider": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
-          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "tslib": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "@aws-sdk/credential-provider-env": {
       "version": "3.535.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.535.0.tgz",
@@ -41253,1067 +37954,6 @@
           "version": "2.6.2",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
-        }
-      }
-    },
-    "@aws-sdk/credential-providers": {
-      "version": "3.609.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.609.0.tgz",
-      "integrity": "sha512-bJKMY4QwRVderh8R2s9kukoZhuNZew/xzwPa9DRRFVOIsznsS0faAdmAAFrKb8e06YyQq6DiZP0BfFyVHAXE2A==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@aws-sdk/client-cognito-identity": "3.609.0",
-        "@aws-sdk/client-sso": "3.609.0",
-        "@aws-sdk/client-sts": "3.609.0",
-        "@aws-sdk/credential-provider-cognito-identity": "3.609.0",
-        "@aws-sdk/credential-provider-env": "3.609.0",
-        "@aws-sdk/credential-provider-http": "3.609.0",
-        "@aws-sdk/credential-provider-ini": "3.609.0",
-        "@aws-sdk/credential-provider-node": "3.609.0",
-        "@aws-sdk/credential-provider-process": "3.609.0",
-        "@aws-sdk/credential-provider-sso": "3.609.0",
-        "@aws-sdk/credential-provider-web-identity": "3.609.0",
-        "@aws-sdk/types": "3.609.0",
-        "@smithy/credential-provider-imds": "^3.1.3",
-        "@smithy/property-provider": "^3.1.3",
-        "@smithy/types": "^3.3.0",
-        "tslib": "^2.6.2"
-      },
-      "dependencies": {
-        "@aws-crypto/sha256-browser": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
-          "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-crypto/sha256-js": "^5.2.0",
-            "@aws-crypto/supports-web-crypto": "^5.2.0",
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "@aws-sdk/util-locate-window": "^3.0.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/sha256-js": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
-          "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-crypto/util": "^5.2.0",
-            "@aws-sdk/types": "^3.222.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/supports-web-crypto": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
-          "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-crypto/util": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
-          "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "^3.222.0",
-            "@smithy/util-utf8": "^2.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/client-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.609.0.tgz",
-          "integrity": "sha512-gqXGFDkIpKHCKAbeJK4aIDt3tiwJ26Rf5Tqw9JS6BYXsdMeOB8FTzqD9R+Yc1epHd8s5L94sdqXT5PapgxFZrg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
-            "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/hash-node": "^3.0.3",
-            "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
-            "@smithy/middleware-serde": "^3.0.3",
-            "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
-            "@smithy/types": "^3.3.0",
-            "@smithy/url-parser": "^3.0.3",
-            "@smithy/util-base64": "^3.0.0",
-            "@smithy/util-body-length-browser": "^3.0.0",
-            "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
-            "@smithy/util-middleware": "^3.0.3",
-            "@smithy/util-retry": "^3.0.3",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-              "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@aws-sdk/client-sso-oidc": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.609.0.tgz",
-          "integrity": "sha512-0bNPAyPdkWkS9EGB2A9BZDkBNrnVCBzk5lYRezoT4K3/gi9w1DTYH5tuRdwaTZdxW19U1mq7CV0YJJARKO1L9Q==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
-            "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/hash-node": "^3.0.3",
-            "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
-            "@smithy/middleware-serde": "^3.0.3",
-            "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
-            "@smithy/types": "^3.3.0",
-            "@smithy/url-parser": "^3.0.3",
-            "@smithy/util-base64": "^3.0.0",
-            "@smithy/util-body-length-browser": "^3.0.0",
-            "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
-            "@smithy/util-middleware": "^3.0.3",
-            "@smithy/util-retry": "^3.0.3",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-              "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@aws-sdk/client-sts": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.609.0.tgz",
-          "integrity": "sha512-A0B3sDKFoFlGo8RYRjDBWHXpbgirer2bZBkCIzhSPHc1vOFHt/m2NcUoE2xnBKXJFrptL1xDkvo1P+XYp/BfcQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-crypto/sha256-browser": "5.2.0",
-            "@aws-crypto/sha256-js": "5.2.0",
-            "@aws-sdk/client-sso-oidc": "3.609.0",
-            "@aws-sdk/core": "3.609.0",
-            "@aws-sdk/credential-provider-node": "3.609.0",
-            "@aws-sdk/middleware-host-header": "3.609.0",
-            "@aws-sdk/middleware-logger": "3.609.0",
-            "@aws-sdk/middleware-recursion-detection": "3.609.0",
-            "@aws-sdk/middleware-user-agent": "3.609.0",
-            "@aws-sdk/region-config-resolver": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@aws-sdk/util-user-agent-browser": "3.609.0",
-            "@aws-sdk/util-user-agent-node": "3.609.0",
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/core": "^2.2.4",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/hash-node": "^3.0.3",
-            "@smithy/invalid-dependency": "^3.0.3",
-            "@smithy/middleware-content-length": "^3.0.3",
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.7",
-            "@smithy/middleware-serde": "^3.0.3",
-            "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
-            "@smithy/types": "^3.3.0",
-            "@smithy/url-parser": "^3.0.3",
-            "@smithy/util-base64": "^3.0.0",
-            "@smithy/util-body-length-browser": "^3.0.0",
-            "@smithy/util-body-length-node": "^3.0.0",
-            "@smithy/util-defaults-mode-browser": "^3.0.7",
-            "@smithy/util-defaults-mode-node": "^3.0.7",
-            "@smithy/util-endpoints": "^2.0.4",
-            "@smithy/util-middleware": "^3.0.3",
-            "@smithy/util-retry": "^3.0.3",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-              "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@aws-sdk/core": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.609.0.tgz",
-          "integrity": "sha512-ptqw+DTxLr01+pKjDUuo53SEDzI+7nFM3WfQaEo0yhDg8vWw8PER4sWj1Ysx67ksctnZesPUjqxd5SHbtdBxiA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/core": "^2.2.4",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/signature-v4": "^3.1.2",
-            "@smithy/smithy-client": "^3.1.5",
-            "@smithy/types": "^3.3.0",
-            "fast-xml-parser": "4.2.5",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-env": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.609.0.tgz",
-          "integrity": "sha512-v69ZCWcec2iuV9vLVJMa6fAb5xwkzN4jYIT8yjo2c4Ia/j976Q+TPf35Pnz5My48Xr94EFcaBazrWedF+kwfuQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-http": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.609.0.tgz",
-          "integrity": "sha512-GQQfB9Mk4XUZwaPsk4V3w8MqleS6ApkZKVQn3vTLAKa8Y7B2Imcpe5zWbKYjDd8MPpMWjHcBGFTVlDRFP4zwSQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/fetch-http-handler": "^3.2.0",
-            "@smithy/node-http-handler": "^3.1.1",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.5",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-stream": "^3.0.5",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-ini": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.609.0.tgz",
-          "integrity": "sha512-hwaBfXuBTv6/eAdEsDfGcteYUW6Km7lvvubbxEdxIuJNF3vswR7RMGIXaEC37hhPkTTgd3H0TONammhwZIfkog==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.609.0.tgz",
-          "integrity": "sha512-4J8/JRuqfxJDGD9jTHVCBxCvYt7/Vgj2Stlhj930mrjFPO/yRw8ilAAZxBWe0JHPX3QwepCmh4ErZe53F5ysxQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/credential-provider-env": "3.609.0",
-            "@aws-sdk/credential-provider-http": "3.609.0",
-            "@aws-sdk/credential-provider-ini": "3.609.0",
-            "@aws-sdk/credential-provider-process": "3.609.0",
-            "@aws-sdk/credential-provider-sso": "3.609.0",
-            "@aws-sdk/credential-provider-web-identity": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/credential-provider-imds": "^3.1.3",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-process": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.609.0.tgz",
-          "integrity": "sha512-Ux35nGOSJKZWUIM3Ny0ROZ8cqPRUEkh+tR3X2o9ydEbFiLq3eMMyEnHJqx4EeUjLRchidlm4CCid9GxMe5/gdw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-sso": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.609.0.tgz",
-          "integrity": "sha512-oQPGDKMMIxjvTcm86g07RPYeC7mCNk+29dPpY15ZAPRpAF7F0tircsC3wT9fHzNaKShEyK5LuI5Kg/uxsdy+Iw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/client-sso": "3.609.0",
-            "@aws-sdk/token-providers": "3.609.0",
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/credential-provider-web-identity": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.609.0.tgz",
-          "integrity": "sha512-U+PG8NhlYYF45zbr1km3ROtBMYqyyj/oK8NRp++UHHeuavgrP+4wJ4wQnlEaKvJBjevfo3+dlIBcaeQ7NYejWg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-host-header": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.609.0.tgz",
-          "integrity": "sha512-iTKfo158lc4jLDfYeZmYMIBHsn8m6zX+XB6birCSNZ/rrlzAkPbGE43CNdKfvjyWdqgLMRXF+B+OcZRvqhMXPQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-logger": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.609.0.tgz",
-          "integrity": "sha512-S62U2dy4jMDhDFDK5gZ4VxFdWzCtLzwbYyFZx2uvPYTECkepLUfzLic2BHg2Qvtu4QjX+oGE3P/7fwaGIsGNuQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-recursion-detection": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.609.0.tgz",
-          "integrity": "sha512-6sewsYB7/o/nbUfA99Aa/LokM+a/u4Wpm/X2o0RxOsDtSB795ObebLJe2BxY5UssbGaWkn7LswyfvrdZNXNj1w==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/middleware-user-agent": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.609.0.tgz",
-          "integrity": "sha512-nbq7MXRmeXm4IDqh+sJRAxGPAq0OfGmGIwKvJcw66hLoG8CmhhVMZmIAEBDFr57S+YajGwnLLRt+eMI05MMeVA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@aws-sdk/util-endpoints": "3.609.0",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/region-config-resolver": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.609.0.tgz",
-          "integrity": "sha512-lMHBG8zg9GWYBc9/XVPKyuAUd7iKqfPP7z04zGta2kGNOKbUTeqmAdc1gJGku75p4kglIPlGBorOxti8DhRmKw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-config-provider": "^3.0.0",
-            "@smithy/util-middleware": "^3.0.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/token-providers": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.609.0.tgz",
-          "integrity": "sha512-WvhW/7XSf+H7YmtiIigQxfDVZVZI7mbKikQ09YpzN7FeN3TmYib1+0tB+EE9TbICkwssjiFc71FEBEh4K9grKQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/types": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.609.0.tgz",
-          "integrity": "sha512-+Tqnh9w0h2LcrUsdXyT1F8mNhXz+tVYBtP19LpeEGntmvHwa2XzvLUCWpoIAIVsHp5+HdB2X9Sn0KAtmbFXc2Q==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-endpoints": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.609.0.tgz",
-          "integrity": "sha512-Rh+3V8dOvEeE1aQmUy904DYWtLUEJ7Vf5XBPlQ6At3pBhp+zpXbsnpZzVL33c8lW1xfj6YPwtO6gOeEsl1juCQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-endpoints": "^2.0.4",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-browser": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.609.0.tgz",
-          "integrity": "sha512-fojPU+mNahzQ0YHYBsx0ZIhmMA96H+ZIZ665ObU9tl+SGdbLneVZVikGve+NmHTQwHzwkFsZYYnVKAkreJLAtA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/types": "^3.3.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@aws-sdk/util-user-agent-node": {
-          "version": "3.609.0",
-          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.609.0.tgz",
-          "integrity": "sha512-DlZBwQ/HkZyf3pOWc7+wjJRk5R7x9YxHhs2szHwtv1IW30KMabjjjX0GMlGJ9LLkBHkbaaEY/w9Tkj12XRLhRg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@aws-sdk/types": "3.609.0",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/abort-controller": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-3.1.1.tgz",
-          "integrity": "sha512-MBJBiidoe+0cTFhyxT8g+9g7CeVccLM0IOKKUMCNQ1CNMJ/eIfoo0RTfVrXOONEI1UCN1W+zkiHSbzUNE9dZtQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/config-resolver": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-3.0.4.tgz",
-          "integrity": "sha512-VwiOk7TwXoE7NlNguV/aPq1hFH72tqkHCw8eWXbr2xHspRyyv9DLpLXhq+Ieje+NwoqXrY0xyQjPXdOE6cGcHA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-config-provider": "^3.0.0",
-            "@smithy/util-middleware": "^3.0.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/core": {
-          "version": "2.2.5",
-          "resolved": "https://registry.npmjs.org/@smithy/core/-/core-2.2.5.tgz",
-          "integrity": "sha512-0kqyj93/Aa30TEXnnWRBetN8fDGjFF+u8cdIiMI8YS6CrUF2dLTavRfHKfWh5cL5d6s2ZNyEnLjBitdcKmkETQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-retry": "^3.0.8",
-            "@smithy/middleware-serde": "^3.0.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/smithy-client": "^3.1.6",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-middleware": "^3.0.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/credential-provider-imds": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-3.1.3.tgz",
-          "integrity": "sha512-U1Yrv6hx/mRK6k8AncuI6jLUx9rn0VVSd9NPEX6pyYFBfkSkChOc/n4zUb8alHUVg83TbI4OdZVo1X0Zfj3ijA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/url-parser": "^3.0.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/fetch-http-handler": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-3.2.1.tgz",
-          "integrity": "sha512-0w0bgUvZmfa0vHN8a+moByhCJT07WN6AHKEhFSOLsDpnszm+5dLVv5utGaqbhOrZ/aF5x3xuPMs/oMCd+4O5xg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/querystring-builder": "^3.0.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-base64": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/hash-node": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-3.0.3.tgz",
-          "integrity": "sha512-2ctBXpPMG+B3BtWSGNnKELJ7SH9e4TNefJS0cd2eSkOOROeBnnVBnAy9LtJ8tY4vUEoe55N4CNPxzbWvR39iBw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-buffer-from": "^3.0.0",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-              "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@smithy/invalid-dependency": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-3.0.3.tgz",
-          "integrity": "sha512-ID1eL/zpDULmHJbflb864k72/SNOZCADRc9i7Exq3RUNJw6raWUSlFEQ+3PX3EYs++bTxZB2dE9mEHTQLv61tw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/is-array-buffer": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-3.0.0.tgz",
-          "integrity": "sha512-+Fsu6Q6C4RSJiy81Y8eApjEB5gVtM+oFKTffg+jSuwtvomJJrhUJBu2zS8wjXSgH/g1MKEWrzyChTBe6clb5FQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/middleware-content-length": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-3.0.3.tgz",
-          "integrity": "sha512-Dbz2bzexReYIQDWMr+gZhpwBetNXzbhnEMhYKA6urqmojO14CsXjnsoPYO8UL/xxcawn8ZsuVU61ElkLSltIUQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/middleware-endpoint": {
-          "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-3.0.4.tgz",
-          "integrity": "sha512-whUJMEPwl3ANIbXjBXZVdJNgfV2ZU8ayln7xUM47rXL2txuenI7jQ/VFFwCzy5lCmXScjp6zYtptW5Evud8e9g==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/middleware-serde": "^3.0.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/url-parser": "^3.0.3",
-            "@smithy/util-middleware": "^3.0.3",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/middleware-retry": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-3.0.8.tgz",
-          "integrity": "sha512-wmIw3t6ZbeqstUFdXtStzSSltoYrcfc28ndnr0mDSMmtMSRNduNbmneA7xiE224fVFXzbf24+0oREks1u2X7Mw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/smithy-client": "^3.1.6",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-middleware": "^3.0.3",
-            "@smithy/util-retry": "^3.0.3",
-            "tslib": "^2.6.2",
-            "uuid": "^9.0.1"
-          }
-        },
-        "@smithy/middleware-serde": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-3.0.3.tgz",
-          "integrity": "sha512-puUbyJQBcg9eSErFXjKNiGILJGtiqmuuNKEYNYfUD57fUl4i9+mfmThtQhvFXU0hCVG0iEJhvQUipUf+/SsFdA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/middleware-stack": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-3.0.3.tgz",
-          "integrity": "sha512-r4klY9nFudB0r9UdSMaGSyjyQK5adUyPnQN/ZM6M75phTxOdnc/AhpvGD1fQUvgmqjQEBGCwpnPbDm8pH5PapA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/node-config-provider": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-3.1.3.tgz",
-          "integrity": "sha512-rxdpAZczzholz6CYZxtqDu/aKTxATD5DAUDVj7HoEulq+pDSQVWzbg0btZDlxeFfa6bb2b5tUvgdX5+k8jUqcg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/shared-ini-file-loader": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/node-http-handler": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-3.1.2.tgz",
-          "integrity": "sha512-Td3rUNI7qqtoSLTsJBtsyfoG4cF/XMFmJr6Z2dX8QNzIi6tIW6YmuyFml8mJ2cNpyWNqITKbROMOFrvQjmsOvw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/abort-controller": "^3.1.1",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/querystring-builder": "^3.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/property-provider": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-3.1.3.tgz",
-          "integrity": "sha512-zahyOVR9Q4PEoguJ/NrFP4O7SMAfYO1HLhB18M+q+Z4KFd4V2obiMnlVoUFzFLSPeVt1POyNWneHHrZaTMoc/g==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/protocol-http": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-4.0.3.tgz",
-          "integrity": "sha512-x5jmrCWwQlx+Zv4jAtc33ijJ+vqqYN+c/ZkrnpvEe/uDas7AT7A/4Rc2CdfxgWv4WFGmEqODIrrUToPN6DDkGw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/querystring-builder": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-3.0.3.tgz",
-          "integrity": "sha512-vyWckeUeesFKzCDaRwWLUA1Xym9McaA6XpFfAK5qI9DKJ4M33ooQGqvM4J+LalH4u/Dq9nFiC8U6Qn1qi0+9zw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-uri-escape": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/querystring-parser": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-3.0.3.tgz",
-          "integrity": "sha512-zahM1lQv2YjmznnfQsWbYojFe55l0SLG/988brlLv1i8z3dubloLF+75ATRsqPBboUXsW6I9CPGE5rQgLfY0vQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/service-error-classification": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-3.0.3.tgz",
-          "integrity": "sha512-Jn39sSl8cim/VlkLsUhRFq/dKDnRUFlfRkvhOJaUbLBXUsLRLNf9WaxDv/z9BjuQ3A6k/qE8af1lsqcwm7+DaQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0"
-          }
-        },
-        "@smithy/shared-ini-file-loader": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-3.1.3.tgz",
-          "integrity": "sha512-Z8Y3+08vgoDgl4HENqNnnzSISAaGrF2RoKupoC47u2wiMp+Z8P/8mDh1CL8+8ujfi2U5naNvopSBmP/BUj8b5w==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/signature-v4": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-3.1.2.tgz",
-          "integrity": "sha512-3BcPylEsYtD0esM4Hoyml/+s7WP2LFhcM3J2AGdcL2vx9O60TtfpDOL72gjb4lU8NeRPeKAwR77YNyyGvMbuEA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^3.0.0",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-hex-encoding": "^3.0.0",
-            "@smithy/util-middleware": "^3.0.3",
-            "@smithy/util-uri-escape": "^3.0.0",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-              "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@smithy/smithy-client": {
-          "version": "3.1.6",
-          "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-3.1.6.tgz",
-          "integrity": "sha512-w9oboI661hfptr26houZ5mdKc//DMxkuOMXSaIiALqGn4bHYT9S4U69BBS6tHX4TZHgShmhcz0d6aXk7FY5soA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/middleware-endpoint": "^3.0.4",
-            "@smithy/middleware-stack": "^3.0.3",
-            "@smithy/protocol-http": "^4.0.3",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-stream": "^3.0.6",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/types": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/@smithy/types/-/types-3.3.0.tgz",
-          "integrity": "sha512-IxvBBCTFDHbVoK7zIxqA1ZOdc4QfM5HM7rGleCuHi7L1wnKv5Pn69xXJQ9hgxH60ZVygH9/JG0jRgtUncE3QUA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/url-parser": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-3.0.3.tgz",
-          "integrity": "sha512-pw3VtZtX2rg+s6HMs6/+u9+hu6oY6U7IohGhVNnjbgKy86wcIsSZwgHrFR+t67Uyxvp4Xz3p3kGXXIpTNisq8A==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/querystring-parser": "^3.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-base64": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-3.0.0.tgz",
-          "integrity": "sha512-Kxvoh5Qtt0CDsfajiZOCpJxgtPHXOKwmM+Zy4waD43UoEMA+qPxxa98aE/7ZhdnBFZFXMOiBR5xbcaMhLtznQQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/util-buffer-from": "^3.0.0",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-              "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@smithy/util-body-length-browser": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-3.0.0.tgz",
-          "integrity": "sha512-cbjJs2A1mLYmqmyVl80uoLTJhAcfzMOyPgjwAYusWKMdLeNtzmMz9YxNl3/jRLoxSS3wkqkf0jwNdtXWtyEBaQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-body-length-node": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-3.0.0.tgz",
-          "integrity": "sha512-Tj7pZ4bUloNUP6PzwhN7K386tmSmEET9QtQg0TgdNOnxhZvCssHji+oZTUIuzxECRfG8rdm2PMw2WCFs6eIYkA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-buffer-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-3.0.0.tgz",
-          "integrity": "sha512-aEOHCgq5RWFbP+UDPvPot26EJHjOC+bRgse5A8V3FSShqd5E5UN4qc7zkwsvJPPAVsf73QwYcHN1/gt/rtLwQA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/is-array-buffer": "^3.0.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-config-provider": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-3.0.0.tgz",
-          "integrity": "sha512-pbjk4s0fwq3Di/ANL+rCvJMKM5bzAQdE5S/6RL5NXgMExFAi6UgQMPOm5yPaIWPpr+EOXKXRonJ3FoxKf4mCJQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-defaults-mode-browser": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-3.0.8.tgz",
-          "integrity": "sha512-eLRHCvM1w3ZJkYcd60yKqM3d70dPB+071EDpf9ZGYqFed3xcm/+pWwNS/xM0JXRrjm0yAA19dWcdFN2IE/66pQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/smithy-client": "^3.1.6",
-            "@smithy/types": "^3.3.0",
-            "bowser": "^2.11.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-defaults-mode-node": {
-          "version": "3.0.8",
-          "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-3.0.8.tgz",
-          "integrity": "sha512-Tajvdyg5+k77j6AOrwSCZgi7KdBizqPNs3HCnFGRoxDjzh+CjPLaLrXbIRB0lsAmqYmRHIU34IogByaqvDrkBQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/config-resolver": "^3.0.4",
-            "@smithy/credential-provider-imds": "^3.1.3",
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/property-provider": "^3.1.3",
-            "@smithy/smithy-client": "^3.1.6",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-endpoints": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-2.0.4.tgz",
-          "integrity": "sha512-ZAtNf+vXAsgzgRutDDiklU09ZzZiiV/nATyqde4Um4priTmasDH+eLpp3tspL0hS2dEootyFMhu1Y6Y+tzpWBQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/node-config-provider": "^3.1.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-hex-encoding": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-3.0.0.tgz",
-          "integrity": "sha512-eFndh1WEK5YMUYvy3lPlVmYY/fZcQE1D8oSf41Id2vCeIkKJXPcYDCZD+4+xViI6b1XSd7tE+s5AmXzz5ilabQ==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-middleware": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-3.0.3.tgz",
-          "integrity": "sha512-l+StyYYK/eO3DlVPbU+4Bi06Jjal+PFLSMmlWM1BEwyLxZ3aKkf1ROnoIakfaA7mC6uw3ny7JBkau4Yc+5zfWw==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-retry": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-3.0.3.tgz",
-          "integrity": "sha512-AFw+hjpbtVApzpNDhbjNG5NA3kyoMs7vx0gsgmlJF4s+yz1Zlepde7J58zpIRIsdjc+emhpAITxA88qLkPF26w==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/service-error-classification": "^3.0.3",
-            "@smithy/types": "^3.3.0",
-            "tslib": "^2.6.2"
-          }
-        },
-        "@smithy/util-stream": {
-          "version": "3.0.6",
-          "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-3.0.6.tgz",
-          "integrity": "sha512-w9i//7egejAIvplX821rPWWgaiY1dxsQUw0hXX7qwa/uZ9U3zplqTQ871jWadkcVB9gFDhkPWYVZf4yfFbZ0xA==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@smithy/fetch-http-handler": "^3.2.1",
-            "@smithy/node-http-handler": "^3.1.2",
-            "@smithy/types": "^3.3.0",
-            "@smithy/util-base64": "^3.0.0",
-            "@smithy/util-buffer-from": "^3.0.0",
-            "@smithy/util-hex-encoding": "^3.0.0",
-            "@smithy/util-utf8": "^3.0.0",
-            "tslib": "^2.6.2"
-          },
-          "dependencies": {
-            "@smithy/util-utf8": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-3.0.0.tgz",
-              "integrity": "sha512-rUeT12bxFnplYDe815GXbq/oixEGHfRFFtcTF3YdDi/JaENIM6aSYYLJydG83UNzLXeRI5K8abYd/8Sp/QM0kA==",
-              "optional": true,
-              "peer": true,
-              "requires": {
-                "@smithy/util-buffer-from": "^3.0.0",
-                "tslib": "^2.6.2"
-              }
-            }
-          }
-        },
-        "@smithy/util-uri-escape": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-3.0.0.tgz",
-          "integrity": "sha512-LqR7qYLgZTD7nWLBecUi4aqolw8Mhza9ArpNEQ881MJJIU2sE5iHCK6TdyqqzcDLy0OPe10IY4T8ctVdtynubg==",
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "tslib": "^2.6.2"
-          }
-        },
-        "tslib": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-          "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-          "optional": true,
-          "peer": true
-        },
-        "uuid": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-          "optional": true,
-          "peer": true
         }
       }
     },
@@ -45434,10 +41074,157 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "@esbuild/android-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.18.20.tgz",
+      "integrity": "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.18.20.tgz",
+      "integrity": "sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/android-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.18.20.tgz",
+      "integrity": "sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==",
+      "dev": true,
+      "optional": true
+    },
     "@esbuild/darwin-arm64": {
       "version": "0.18.20",
       "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.18.20.tgz",
       "integrity": "sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/darwin-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.18.20.tgz",
+      "integrity": "sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.18.20.tgz",
+      "integrity": "sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/freebsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.18.20.tgz",
+      "integrity": "sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.18.20.tgz",
+      "integrity": "sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.18.20.tgz",
+      "integrity": "sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.18.20.tgz",
+      "integrity": "sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-loong64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.18.20.tgz",
+      "integrity": "sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-mips64el": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.18.20.tgz",
+      "integrity": "sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-ppc64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.18.20.tgz",
+      "integrity": "sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-riscv64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.18.20.tgz",
+      "integrity": "sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-s390x": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.18.20.tgz",
+      "integrity": "sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/linux-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.18.20.tgz",
+      "integrity": "sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/netbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/openbsd-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.18.20.tgz",
+      "integrity": "sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/sunos-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.18.20.tgz",
+      "integrity": "sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-arm64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.18.20.tgz",
+      "integrity": "sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-ia32": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.18.20.tgz",
+      "integrity": "sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==",
+      "dev": true,
+      "optional": true
+    },
+    "@esbuild/win32-x64": {
+      "version": "0.18.20",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.18.20.tgz",
+      "integrity": "sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==",
       "dev": true,
       "optional": true
     },
@@ -49877,6 +45664,69 @@
       "version": "1.6.13",
       "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.6.13.tgz",
       "integrity": "sha512-SOF4buAis72K22BGJ3N8y88mLNfxLNprTuJUpzikyMGrvkuBFNcxYtMhmomO0XHsgLDzOJ+hWzcgjRNzjMsUcQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-darwin-x64": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.6.13.tgz",
+      "integrity": "sha512-AW8akFSC+tmPE6YQQvK9S2A1B8pjnXEINg+gGgw0KRUUXunvu1/OEOeC5L2Co1wAwhD7bhnaefi06Qi9AiwOag==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm-gnueabihf": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.6.13.tgz",
+      "integrity": "sha512-f4gxxvDXVUm2HLYXRd311mSrmbpQF2MZ4Ja6XCQz1hWAxXdhRl1gpnZ+LH/xIfGSwQChrtLLVrkxdYUCVuIjFg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-gnu": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.6.13.tgz",
+      "integrity": "sha512-Nf/eoW2CbG8s+9JoLtjl9FByBXyQ5cjdBsA4efO7Zw4p+YSuXDgc8HRPC+E2+ns0praDpKNZtLvDtmF2lL+2Gg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-arm64-musl": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.6.13.tgz",
+      "integrity": "sha512-2OysYSYtdw79prJYuKIiux/Gj0iaGEbpS2QZWCIY4X9sGoETJ5iMg+lY+YCrIxdkkNYd7OhIbXdYFyGs/w5LDg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-gnu": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.6.13.tgz",
+      "integrity": "sha512-PkR4CZYJNk5hcd2+tMWBpnisnmYsUzazI1O5X7VkIGFcGePTqJ/bWlfUIVVExWxvAI33PQFzLbzmN5scyIUyGQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-linux-x64-musl": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.6.13.tgz",
+      "integrity": "sha512-OdsY7wryTxCKwGQcwW9jwWg3cxaHBkTTHi91+5nm7hFPpmZMz1HivJrWAMwVE7iXFw+M4l6ugB/wCvpYrUAAjA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-arm64-msvc": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.6.13.tgz",
+      "integrity": "sha512-ap6uNmYjwk9M/+bFEuWRNl3hq4VqgQ/Lk+ID/F5WGqczNr0L7vEf+pOsRAn0F6EV+o/nyb3ePt8rLhE/wjHpPg==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-ia32-msvc": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.6.13.tgz",
+      "integrity": "sha512-IJ8KH4yIUHTnS/U1jwQmtbfQals7zWPG0a9hbEfIr4zI0yKzjd83lmtS09lm2Q24QBWOCFGEEbuZxR4tIlvfzA==",
+      "dev": true,
+      "optional": true
+    },
+    "@swc/core-win32-x64-msvc": {
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.6.13.tgz",
+      "integrity": "sha512-f6/sx6LMuEnbuxtiSL/EkR0Y6qUHFw1XVrh6rwzKXptTipUdOY+nXpKoh+1UsBm/r7H0/5DtOdrn3q5ZHbFZjQ==",
       "dev": true,
       "optional": true
     },
@@ -57175,33 +53025,6 @@
         "loose-envify": "^1.0.0"
       }
     },
-    "ip-address": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
-      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "jsbn": "1.1.0",
-        "sprintf-js": "^1.1.3"
-      },
-      "dependencies": {
-        "jsbn": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
-          "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
-          "optional": true,
-          "peer": true
-        },
-        "sprintf-js": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
-          "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
-          "optional": true,
-          "peer": true
-        }
-      }
-    },
     "ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -57813,19 +53636,6 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
-          }
-        },
-        "babel-plugin-macros": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
-          "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@babel/runtime": "^7.12.5",
-            "cosmiconfig": "^7.0.0",
-            "resolve": "^1.19.0"
           }
         },
         "chalk": {
@@ -65220,24 +61030,6 @@
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.0.tgz",
       "integrity": "sha512-FkMq+MQc5hzYgM86nLuHI98Acwi3p4wX+a5BO9Hhw4JdK4L7WueIiZ4tXEobImPqBz2sVcV0+Mu3GRB30IGang=="
     },
-    "smart-buffer": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
-      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
-      "optional": true,
-      "peer": true
-    },
-    "socks": {
-      "version": "2.8.3",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.3.tgz",
-      "integrity": "sha512-l5x7VUUWbjVFbafGLxPWkYsHIhEvmF85tbIeFZWc8ZPtoMyybuEhL7Jye/ooC4/d48FgOjSJXgsF/AJPYCW8Zw==",
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "ip-address": "^9.0.5",
-        "smart-buffer": "^4.2.0"
-      }
-    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -65998,13 +61790,6 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
-    },
-    "type-fest": {
-      "version": "4.41.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
-      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
-      "optional": true,
-      "peer": true
     },
     "type-is": {
       "version": "1.6.18",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:client": "cross-env NODE_ENV=production webpack --config webpack/config.prod.js",
     "build:server": "cross-env NODE_ENV=production webpack --config webpack/config.server.js",
     "build:examples": "cross-env NODE_ENV=production webpack --config webpack/config.examples.js",
-    "test": "NODE_ENV=test jest",
+    "test": "NODE_ENV=test jest --forceExit",
     "test:watch": "NODE_ENV=test jest --watch",
     "test:ci": "npm run lint && npm run test",
     "fetch-examples": "cross-env NODE_ENV=development node ./server/scripts/fetch-examples.js",

--- a/package.json
+++ b/package.json
@@ -243,6 +243,7 @@
     "dotenv": "^2.0.0",
     "dropzone": "^4.3.0",
     "escape-string-regexp": "^1.0.5",
+    "escodegen": "^2.1.0",
     "eslint-scope": "^8.4.0",
     "eslint-webpack-plugin": "^3.1.1",
     "express": "^4.22.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:client": "cross-env NODE_ENV=production webpack --config webpack/config.prod.js",
     "build:server": "cross-env NODE_ENV=production webpack --config webpack/config.server.js",
     "build:examples": "cross-env NODE_ENV=production webpack --config webpack/config.examples.js",
-    "test": "NODE_ENV=test jest --forceExit",
+    "test": "NODE_ENV=test jest",
     "test:watch": "NODE_ENV=test jest --watch",
     "test:ci": "npm run lint && npm run test",
     "fetch-examples": "cross-env NODE_ENV=development node ./server/scripts/fetch-examples.js",


### PR DESCRIPTION
### issue:
fixes #4080

### demo:
<img width="1440" height="622" alt="Screenshot 2026-04-15 at 4 46 25 PM" src="https://github.com/user-attachments/assets/069461bc-9d92-4936-9f72-bd72e88d4d82" />

### changes:
- replaced regex-based loop protection with acorn ast-based approach in a new `jspreprocess.js` module
- strings are never visited by the ast parser, so glsl for loops inside template literals and quoted strings are no longer modified
- added two-pass detection for p5.strands shader functions: first pass collects function names passed to `build*shader()` and `base*shader().modify()`, second pass skips loop protection inside those functions
- removed `loop-protect` and `decomment` dependencies from `embedframe.jsx`
- added 13 unit tests covering all cases

### i have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `fixes #4080`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)