### PR TITLE
fix: scope CM6 Tidy keymap per file state (#4093)

### DIFF
--- a/client/modules/IDE/components/Editor/stateUtils.js
+++ b/client/modules/IDE/components/Editor/stateUtils.js
@@ -389,14 +389,22 @@ export function createNewFileState(filename, document, settings) {
   const autocompleteCpt = new Compartment();
 
   // Depending on the file mode, we have a different tidier function.
+  // Keep this binding local to each file state so modes don't accumulate
+  // across files via a shared module-level array.
   const mode = getFileMode(filename);
-  extraKeymaps.push({
-    key: `Shift-Mod-F`,
-    run: (cmView) => tidyCodeWithPrettier(cmView, mode)
-  });
+  const fileTidyKeymap = [
+    {
+      key: 'Shift-Mod-F',
+      run: (cmView) => {
+        tidyCodeWithPrettier(cmView, mode);
+        return true;
+      }
+    }
+  ];
 
   const keymaps = [
     extraKeymaps,
+    fileTidyKeymap,
     closeBracketsKeymap,
     defaultKeymap,
     historyKeymap,

--- a/client/modules/IDE/components/Editor/stateUtils.test.js
+++ b/client/modules/IDE/components/Editor/stateUtils.test.js
@@ -1,0 +1,62 @@
+/**
+ * @jest-environment jsdom
+ */
+import { EditorView, runScopeHandlers } from '@codemirror/view';
+import { createNewFileState } from './stateUtils';
+
+const defaultSettings = {
+  linewrap: false,
+  lineNumbers: false,
+  autocomplete: false,
+  autocloseBracketsQuotes: false,
+  onUpdateLinting: () => {},
+  onViewUpdate: () => {},
+  referenceBaseUrl: 'https://p5js.org'
+};
+
+function mountFile(filename, doc) {
+  const { cmState } = createNewFileState(filename, doc, defaultSettings);
+  const parent = document.createElement('div');
+  document.body.appendChild(parent);
+  const view = new EditorView({ state: cmState, parent });
+  return view;
+}
+
+function pressTidyShortcut(view) {
+  const event = new KeyboardEvent('keydown', {
+    key: 'F',
+    code: 'KeyF',
+    shiftKey: true,
+    ctrlKey: true
+  });
+  runScopeHandlers(view, event, 'editor');
+}
+
+describe('createNewFileState — Tidy keyboard shortcut', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  // Regression test for https://github.com/processing/p5.js-web-editor/issues/4093
+  // Each file's Shift-Mod-F binding must only tidy with its own mode, regardless
+  // of the order in which the file states were created.
+  it('tidies each file with its own mode regardless of creation order', () => {
+    const jsView = mountFile('sketch.js', `function foo(){console.log("hi")}`);
+    const cssView = mountFile('style.css', `body{margin:0;padding:0;}`);
+    const htmlView = mountFile('index.html', `<html><body>hello</body></html>`);
+
+    pressTidyShortcut(jsView);
+    pressTidyShortcut(cssView);
+    pressTidyShortcut(htmlView);
+
+    expect(jsView.state.doc.toString()).toBe(
+      'function foo() {\n  console.log("hi");\n}\n'
+    );
+    expect(cssView.state.doc.toString()).toBe(
+      'body {\n  margin: 0;\n  padding: 0;\n}\n'
+    );
+    expect(htmlView.state.doc.toString()).toBe(
+      '<html>\n  <body>\n    hello\n  </body>\n</html>\n'
+    );
+  });
+});


### PR DESCRIPTION
### Issue:
Fixes #4093

In the CM6 editor (`develop-codemirror-v6`), the Tidy shortcut (`Cmd/Ctrl+Shift+F`) works on the first file but misbehaves on subsequent files — sometimes nothing happens, sometimes the file is reformatted as "one big block."

Root cause: `createNewFileState` in `client/modules/IDE/components/Editor/stateUtils.js` pushed a Shift-Mod-F binding into a **module-scoped** `extraKeymaps` array, closing over the current file's mode. Because later-created file states snapshot that shared array, files created after the first end up with multiple tidy handlers (one per previously-initialized file's mode). On a CSS file, the JS-mode tidy runs first → prettier's babel parser throws on CSS, or (for files it can parse) mangles the content before the correct-mode tidy ever runs.

The Edit → Tidy Code menu click path was unaffected because it computes the mode from `file.name` at call time.

### Changes:
- `stateUtils.js`: stop mutating the module-level `extraKeymaps`. Build the tidy binding as a per-state local array (`fileTidyKeymap`) and include it in the state's keymaps. Handler now returns `true` so CM6 consumes the shortcut.
- `stateUtils.test.js`: new regression test. Creates JS, CSS, and HTML file states in order, dispatches `Shift-Ctrl-F` via `runScopeHandlers`, and asserts each file is tidied with its own mode. Test fails on the previous code (prettier throws parsing CSS as JS) and passes on the fix.

###Fix video:


https://github.com/user-attachments/assets/24d27963-9f3d-4b6c-bfeb-026c80de9eaf


Uploading Screen Recording 2026-05-12 at 3.30.40 AM.mp4…



### Testing:
Manually verified that pressing `Cmd+Shift+F` now tidies correctly in `sketch.js`, `style.css`, and `index.html` regardless of which file is opened first.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test` — Editor suite; 9/9 pass)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the \`develop-codemirror-v6\` branch.
* [x] is descriptively named and links to an issue number, i.e. \`Fixes #4093\`
* [x] meets the standards outlined in the accessibility guidelines (no UI changes)