### PR TITLE
fix:Right arrow key navigation after auto-closing brackets

### DIFF
--- a/client/modules/IDE/components/Editor/stateUtils.js
+++ b/client/modules/IDE/components/Editor/stateUtils.js
@@ -272,6 +272,7 @@ const emmetKeymaps = [{ key: 'Tab', run: expandAbbreviation }];
 
 /** Returns completion options configured for autocomplete. */
 export const createAutocompleteOptions = (referenceBaseUrl) => ({
+  selectOnOpen: false,
   tooltipClass: () => 'CodeMirror-hints',
   closeOnBlur: false,
   icons: false,


### PR DESCRIPTION
### Issue:
Fixes #4087 

### Changes:
Disabled `selectOnOpen` on autocomplete options. Previously, the first suggestion is already selected as the popup appears.
<img width="300" height="130" alt="image" src="https://github.com/user-attachments/assets/b97c18d7-e628-439c-8b41-19808317358b" />
Now, the user can press right arrow key to move the cursor past the closing bracket ")". Press down arrow key to move into the autocomplete suggestion list .
<img width="300" height="130" alt="image" src="https://github.com/user-attachments/assets/2cd399ec-4b9d-4f66-bec3-007d01531dc2" />

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)