### PR TITLE
[Draft] Orphaned Assets Fix

### DIFF
--- a/client/modules/IDE/actions/project.js
+++ b/client/modules/IDE/actions/project.js
@@ -306,6 +306,7 @@ export function cloneProject(project) {
     generateNewIdsForChildren(rootFile, newFiles);
 
     // duplicate all files hosted on S3
+    const copiedAssetKeys = [];
     each(
       newFiles,
       (file, callback) => {
@@ -319,10 +320,16 @@ export function cloneProject(project) {
           const formParams = {
             url: file.url
           };
-          apiClient.post('/S3/copy', formParams).then((response) => {
-            file.url = response.data.url;
-            callback(null);
-          });
+          apiClient
+            .post('/S3/copy', formParams)
+            .then((response) => {
+              file.url = response.data.url;
+
+              const objectKeyFromUrl = file.url.split('/').pop();
+              copiedAssetKeys.push(objectKeyFromUrl);
+              callback(null);
+            })
+            .catch(callback);
         } else {
           callback(null);
         }
@@ -343,6 +350,12 @@ export function cloneProject(project) {
             dispatch(setNewProject(response.data));
           })
           .catch((error) => {
+            copiedAssetKeys.forEach((assetKey) => {
+              apiClient.delete(
+                `/S3/delete?objectKey=${encodeURIComponent(assetKey)}`
+              );
+            });
+
             dispatch({
               type: ActionTypes.PROJECT_SAVE_FAIL,
               error: error?.response?.data

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -156,7 +156,7 @@ export async function signS3(req, res) {
     const acl = 'public-read';
     const policy = S3Policy.generate({
       acl,
-      key: `${req.body.userId}/${filename}`,
+      key: `pending/${req.user.id}/${filename}`,
       bucket: process.env.S3_BUCKET,
       contentType: req.body.type,
       region: process.env.AWS_REGION,

--- a/server/controllers/project.controller.js
+++ b/server/controllers/project.controller.js
@@ -11,6 +11,7 @@ import Project from '../models/project';
 import { User } from '../models/user';
 import { resolvePathToFile } from '../utils/filePath';
 import { generateFileSystemSafeName } from '../utils/generateFileSystemSafeName';
+import { commitPendingFiles } from '../utils/pendingAssets';
 
 const s3Client = new S3Client({
   credentials: {
@@ -60,6 +61,11 @@ export async function updateProject(req, res) {
     // only allow whitelisted fields so ownership/slug etc can't be overwritten
     const allowedFields = ['name', 'files', 'updatedAt', 'visibility'];
     const updateData = {};
+
+    if (req.body.files !== undefined) {
+      updateData.files = await commitPendingFiles(req.body.files, req.user.id);
+    }
+
     allowedFields.forEach((field) => {
       if (req.body[field] !== undefined) {
         updateData[field] = req.body[field];
@@ -77,21 +83,7 @@ export async function updateProject(req, res) {
     )
       .populate('user', 'username')
       .exec();
-    if (
-      req.body.files &&
-      updatedProject.files.length !== req.body.files.length
-    ) {
-      const oldFileIds = updatedProject.files.map((file) => file.id);
-      const newFileIds = req.body.files.map((file) => file.id);
-      const staleIds = oldFileIds.filter((id) => newFileIds.indexOf(id) === -1);
-      staleIds.forEach((staleId) => {
-        updatedProject.files.id(staleId).deleteOne();
-      });
-      const savedProject = await updatedProject.save();
-      res.json(savedProject);
-    } else {
-      res.json(updatedProject);
-    }
+    res.json(updatedProject);
   } catch (error) {
     console.error(error);
     res.status(500).json({ success: false });

--- a/server/utils/pendingAssets.js
+++ b/server/utils/pendingAssets.js
@@ -1,0 +1,57 @@
+import {
+  s3Client,
+  CopyObjectCommand,
+  DeleteObjectsCommand
+} from '@aws-sdk/client-s3';
+
+export async function commitPendingFiles(files, userId) {
+  if (!files) {
+    return [];
+  }
+
+  const s3Base = process.env.S3_BUCKET_URL_BASE;
+  const s3Bucket = process.env.S3_BUCKET;
+
+  return Promise.all(
+    files.map(async (file) => {
+      if (!file.url || !file.url.startsWith(s3Base)) {
+        return [];
+      }
+
+      const assetKey = decodeURIComponent(file.url.slice(s3Base.length));
+      console.log('asset key: ', assetKey);
+
+      if (!assetKey.startsWith(`pending/${userId}/`)) {
+        return [];
+      }
+
+      const fileName = assetKey.split('/').pop();
+      const newKey = `${userId}/${fileName}`;
+
+      console.log('filename, newKey: ', fileName, newKey);
+
+      await s3Client.send(
+        new CopyObjectCommand({
+          Bucket: s3Bucket,
+          CopySource: `${s3Bucket}/${assetKey}`,
+          Key: newKey,
+          ACL: 'public-read'
+        })
+      );
+
+      await s3Client.send(
+        new DeleteObjectsCommand({
+          Bucket: s3Bucket,
+          Delete: { Objects: [{ Key: assetKey }] }
+        })
+      );
+
+      return {
+        ...file,
+        url: `${s3Base}${newKey}`
+      };
+    })
+  );
+}
+
+export default commitPendingFiles;


### PR DESCRIPTION
### Background

This PR addresses issues with orphaned assets accumulating in the AWS s3 Bucket. Currently, one confirmed cause can be reproduced by:  
1. Creating a New Project. 
2. Uploading an Asset. 
3. Closing the Project Window/Tab without Saving the Project. 
4. Comparing the listed assets within the database vs. the s3 bucket. The asset uploaded to the unsaved project will be visible in AWS, but the project will not exist in the database. 

Another potential cause is when project cloning is disrupted, since it appears that assets are uploaded to s3 before the project is successfully cloned. 

### Changes:

This PR proposes creating a `pending` folder within the S3 bucket that will hold uploaded user assets until a user saves their project. On project save, the asset should be removed from the `pending` folder and be moved to the general bucket. This PR is incomplete, and currently conflicts with other scenarios, such as when a user uploads assets to a saved project. 

This solution altogether is also just a suggestion, so I'm definitely open to other ideas on this as well!

- `aws.controller.js` : Reference `req.user.id` instead of `req.body.userId`. Adds in the `pending` folder when a user uploads an asset.
-  `server/utils/pendingAssets.js`: Adds a util that handles committing any pending assets to the general bucket on project save, which should copy the asset and delete it from the `pending` folder. 
- `server/controllers/project.controller.js`: Adds the `commitPendingAssets` util to the project controller and removes the portion checking for stale files. I felt that this wasn't successfully capturing 
- `client/modules/IDE/actions/project.js`: When a user attempts to clone a project, it will now delete any added s3 files if the project cloning fails. 

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
