### PR TITLE
fix out-of-date values in console

### DIFF
--- a/client/utils/hookConsoleSync.js
+++ b/client/utils/hookConsoleSync.js
@@ -1,0 +1,21 @@
+import parse from 'console-feed/lib/Hook/parse';
+import methods from 'console-feed/lib/definitions/Methods';
+import { Encode } from 'console-feed';
+
+/**
+ * Synchronous replacement for console-feed's Hook. Encodes function
+ * arguments immediately, so the values of mutable arguments are
+ * captured accurately.
+ *
+ * (See https://github.com/samdenty/console-feed/pull/77.)
+ */
+export default function hookConsoleSync(targetConsole, callback) {
+  methods.forEach((method) => {
+    const native = targetConsole[method];
+    targetConsole[method] = function patched(...args) {
+      native.apply(this, args);
+      const parsed = parse(method, args);
+      if (parsed) callback(Encode(parsed));
+    };
+  });
+}

--- a/client/utils/previewEntry.js
+++ b/client/utils/previewEntry.js
@@ -1,6 +1,7 @@
-import { Hook, Decode, Encode } from 'console-feed';
+import { Decode, Encode } from 'console-feed';
 import StackTrace from 'stacktrace-js';
 import { evaluateExpression } from './evaluateExpression';
+import hookConsoleSync from './hookConsoleSync';
 
 // should postMessage user the dispatcher? does the parent window need to
 // be registered as a frame? or a just a listener?
@@ -56,7 +57,7 @@ window.loopProtect = {
 
 const consoleBuffer = [];
 const LOGWAIT = 500;
-Hook(window.console, (log) => {
+hookConsoleSync(window.console, (log) => {
   consoleBuffer.push({
     log
   });


### PR DESCRIPTION
### Issue:
Fixes #1203: out-of-date values printed in console messages due to console-feed library's asynchronicity.

### Demo:

Before on left, after on right. (You can ignore the HMR noise.)

<img width="921" height="527" alt="Screenshot 2026-05-12 at 9 08 02 PM" src="https://github.com/user-attachments/assets/bfbfb5e9-9806-43be-bf4f-7d5e3ec601bc" />

### Changes:
Instead of using console-feed's built-in Hook function, which uses setTimeout, I switch to a simpler hookConsoleSync which parses function arguments and calls the callback synchronously.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
