### PR TITLE
fix firefox scrollbar from fractional split pane size

### DIFF
--- a/client/jest.setup.js
+++ b/client/jest.setup.js
@@ -5,3 +5,11 @@ import 'regenerator-runtime/runtime';
 // See: https://github.com/testing-library/jest-dom
 // eslint-disable-next-line import/no-extraneous-dependencies
 import '@testing-library/jest-dom';
+
+global.ResizeObserver = class {
+  observe() {}
+
+  unobserve() {}
+
+  disconnect() {}
+};

--- a/client/modules/IDE/components/PreviewFrame.jsx
+++ b/client/modules/IDE/components/PreviewFrame.jsx
@@ -1,18 +1,18 @@
-import React, { useRef, useEffect } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { getConfig } from '../../../utils/getConfig';
 import { registerFrame } from '../../../utils/dispatcher';
 
 const Frame = styled.iframe`
-  min-height: 100%;
-  min-width: 100%;
+  display: block;
   position: ${(props) => (props.fullView ? 'relative' : 'absolute')};
   border-width: 0;
 `;
 
 function PreviewFrame({ fullView, isOverlayVisible }) {
   const iframe = useRef();
+  const [frameSize, setFrameSize] = useState(null);
   const previewUrl = getConfig('PREVIEW_URL');
   useEffect(() => {
     const unsubscribe = registerFrame(iframe.current.contentWindow, previewUrl);
@@ -20,6 +20,26 @@ function PreviewFrame({ fullView, isOverlayVisible }) {
       unsubscribe();
     };
   });
+
+  useEffect(() => {
+    const parent = iframe.current?.parentElement;
+    if (!parent) {
+      return () => {};
+    }
+    const updateSize = () => {
+      const { width, height } = parent.getBoundingClientRect();
+      setFrameSize({
+        width: Math.floor(width),
+        height: Math.floor(height)
+      });
+    };
+    updateSize();
+    const observer = new ResizeObserver(updateSize);
+    observer.observe(parent);
+    return () => {
+      observer.disconnect();
+    };
+  }, []);
 
   const frameUrl = previewUrl;
   const sandboxAttributes = `allow-forms allow-modals allow-pointer-lock allow-popups 
@@ -45,6 +65,11 @@ function PreviewFrame({ fullView, isOverlayVisible }) {
         frameBorder="0"
         ref={iframe}
         fullView={fullView}
+        style={
+          frameSize
+            ? { width: frameSize.width, height: frameSize.height }
+            : undefined
+        }
       />
     </>
   );

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -120,8 +120,6 @@ const IDEView = () => {
   const [sidebarSize, setSidebarSize] = useState(160);
   const [isOverlayVisible, setIsOverlayVisible] = useState(false);
   const [MaxSize, setMaxSize] = useState(window.innerWidth);
-  const [editorSplitSize, setEditorSplitSize] = useState(null);
-  const editorSplitRatioRef = useRef(0.5);
   const [displayBanner, setDisplayBanner] = useState(false); // set to true if in use
 
   const cmRef = useRef({});
@@ -240,17 +238,6 @@ const IDEView = () => {
     ? consoleSize
     : consoleCollapsedSize;
 
-  const sidebarWidth = ide.sidebarIsExpanded ? sidebarSize : 20;
-  const editorSplitAvailableWidth = MaxSize - sidebarWidth;
-
-  useEffect(() => {
-    if (editorSplitAvailableWidth > 0) {
-      setEditorSplitSize(
-        Math.floor(editorSplitAvailableWidth * editorSplitRatioRef.current)
-      );
-    }
-  }, [editorSplitAvailableWidth]);
-
   return (
     <RootPage>
       <Helmet>
@@ -320,16 +307,8 @@ const IDEView = () => {
               <SplitPane
                 split="vertical"
                 maxSize={MaxSize * 0.965}
-                size={
-                  editorSplitSize ?? Math.floor(editorSplitAvailableWidth * 0.5)
-                }
-                onChange={(size) => {
-                  const rounded = Math.floor(size);
-                  setEditorSplitSize(rounded);
-                  if (editorSplitAvailableWidth > 0) {
-                    editorSplitRatioRef.current =
-                      rounded / editorSplitAvailableWidth;
-                  }
+                defaultSize="50%"
+                onChange={() => {
                   setIsOverlayVisible(true);
                 }}
                 onDragFinished={() => {

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -120,6 +120,8 @@ const IDEView = () => {
   const [sidebarSize, setSidebarSize] = useState(160);
   const [isOverlayVisible, setIsOverlayVisible] = useState(false);
   const [MaxSize, setMaxSize] = useState(window.innerWidth);
+  const [editorSplitSize, setEditorSplitSize] = useState(null);
+  const editorSplitRatioRef = useRef(0.5);
   const [displayBanner, setDisplayBanner] = useState(false); // set to true if in use
 
   const cmRef = useRef({});
@@ -238,6 +240,17 @@ const IDEView = () => {
     ? consoleSize
     : consoleCollapsedSize;
 
+  const sidebarWidth = ide.sidebarIsExpanded ? sidebarSize : 20;
+  const editorSplitAvailableWidth = MaxSize - sidebarWidth;
+
+  useEffect(() => {
+    if (editorSplitAvailableWidth > 0) {
+      setEditorSplitSize(
+        Math.floor(editorSplitAvailableWidth * editorSplitRatioRef.current)
+      );
+    }
+  }, [editorSplitAvailableWidth]);
+
   return (
     <RootPage>
       <Helmet>
@@ -307,8 +320,16 @@ const IDEView = () => {
               <SplitPane
                 split="vertical"
                 maxSize={MaxSize * 0.965}
-                defaultSize="50%"
-                onChange={() => {
+                size={
+                  editorSplitSize ?? Math.floor(editorSplitAvailableWidth * 0.5)
+                }
+                onChange={(size) => {
+                  const rounded = Math.floor(size);
+                  setEditorSplitSize(rounded);
+                  if (editorSplitAvailableWidth > 0) {
+                    editorSplitRatioRef.current =
+                      rounded / editorSplitAvailableWidth;
+                  }
                   setIsOverlayVisible(true);
                 }}
                 onDragFinished={() => {


### PR DESCRIPTION
fixes #4046

the iframe was inheriting fractional pixel dimensions from its flex parent (eg 787.5px), so the sketch inside (which sees an integer 788) overflowed by 0.5px and triggered a scrollbar in firefox/brave.

floored the iframe width and height via a ResizeObserver on its parent and added `display: block`. tested locally in brave, scrollbar is gone, chrome unchanged.