### PR TITLE
fix incorrect asset size limit

### DIFF
--- a/server/controllers/__tests__/aws.controller.test.js
+++ b/server/controllers/__tests__/aws.controller.test.js
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment node
+ */
+import Project from '../../models/project';
+import { listObjectsInS3ForUser } from '../aws.controller';
+
+const mockSend = jest.fn();
+
+jest.mock('../../models/project');
+jest.mock('@aws-sdk/client-s3', () => {
+  const actual = jest.requireActual('@aws-sdk/client-s3');
+  return {
+    ...actual,
+    S3Client: jest.fn().mockImplementation(() => ({
+      send: (...args) => mockSend(...args)
+    }))
+  };
+});
+
+describe('listObjectsInS3ForUser()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('excludes unreferenced (orphaned) S3 objects from totalSize', async () => {
+    mockSend.mockResolvedValue({
+      Contents: [
+        { Key: 'user1/referenced.png', Size: 100 },
+        { Key: 'user1/orphan.png', Size: 999 }
+      ]
+    });
+    Project.getProjectsForUserId = jest.fn().mockResolvedValue([
+      {
+        id: 'project-1',
+        name: 'sketch one',
+        files: [
+          {
+            name: 'referenced.png',
+            url: 'https://s3.example.com/user1/referenced.png'
+          }
+        ]
+      }
+    ]);
+
+    const result = await listObjectsInS3ForUser('user1');
+
+    expect(result.totalSize).toBe(100);
+    expect(result.assets).toHaveLength(1);
+    expect(result.assets[0].key).toBe('user1/referenced.png');
+  });
+
+  it('counts every object when they are all referenced', async () => {
+    mockSend.mockResolvedValue({
+      Contents: [
+        { Key: 'user1/a.png', Size: 100 },
+        { Key: 'user1/b.png', Size: 50 }
+      ]
+    });
+    Project.getProjectsForUserId = jest.fn().mockResolvedValue([
+      {
+        id: 'project-1',
+        name: 'sketch one',
+        files: [
+          { name: 'a.png', url: 'https://s3.example.com/user1/a.png' },
+          { name: 'b.png', url: 'https://s3.example.com/user1/b.png' }
+        ]
+      }
+    ]);
+
+    const result = await listObjectsInS3ForUser('user1');
+
+    expect(result.totalSize).toBe(150);
+    expect(result.assets).toHaveLength(2);
+  });
+});

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -105,7 +105,6 @@ export async function listObjectsInS3ForUser(userId) {
         size: asset.size,
         url: `${process.env.S3_BUCKET_URL_BASE}${asset.key}`
       };
-      totalSize += asset.size;
 
       const wasMatched = projects.some((project) =>
         project.files.some((file) => {
@@ -121,8 +120,11 @@ export async function listObjectsInS3ForUser(userId) {
         })
       );
 
+      // Only count referenced assets toward the limit; unreferenced S3
+      // leftovers aren't shown or deletable in "My Assets".
       if (wasMatched) {
         projectAssets.push(foundAsset);
+        totalSize += asset.size;
       }
     });
 


### PR DESCRIPTION
### Issue:
Fixes #4085

the upload size check in `signS3` adds up every object under the user's S3 prefix, including files that aren't referenced by any project. those leftovers don't appear in "My Assets" and the user has no way to delete them, so people get blocked by storage they can't even see. in the issue the account shows ~68MB in My Assets but uploads are rejected against the 250MB limit.

### Demo:
no UI change (server-side size calculation).
before: upload rejected even though My Assets is well under the limit.
after: the limit is checked against the same assets shown in My Assets, so the upload goes through.

### Changes:
- in `listObjectsInS3ForUser` (`server/controllers/aws.controller.js`), an asset's size is only added to `totalSize` when it's actually referenced by a project (moved the `totalSize +=` inside the existing `wasMatched` check).
- this makes the limit in `signS3` match what's shown in My Assets.
- added a unit test covering that orphaned objects are excluded from the total while referenced ones are counted.
- kept it scoped to the size calculation. cleaning up the orphaned files on the delete paths is a separate, already-in-progress effort, so it's intentionally out of scope here.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)