### PR TITLE
fix tidy code keyboard shortcut in CM6 editor

### DIFF
--- a/client/modules/IDE/components/Editor/stateUtils.js
+++ b/client/modules/IDE/components/Editor/stateUtils.js
@@ -391,7 +391,7 @@ export function createNewFileState(filename, document, settings) {
   // Depending on the file mode, we have a different tidier function.
   const mode = getFileMode(filename);
   extraKeymaps.push({
-    key: `Shift-Mod-F`,
+    key: `Shift-Mod-f`,
     run: (cmView) => tidyCodeWithPrettier(cmView, mode)
   });
 


### PR DESCRIPTION
### Issue:
Fixes #4133 
fixes the tidy code keyboard shortcut in the CM6 editor.

the shortcut was registered as `Shift-Mod-F`, which prevents the binding from being recognized correctly in CodeMirror 6. changing it to `Shift-Mod-f` restores the expected behavior.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
