### PR TITLE
fix: prevent asset size column text from wrapping on small screens

### DIFF
--- a/client/modules/IDE/components/AssetListRow.jsx
+++ b/client/modules/IDE/components/AssetListRow.jsx
@@ -44,7 +44,7 @@ const AssetListRow = ({ asset, username }) => (
         {asset.name}
       </a>
     </th>
-    <td>{prettyBytes(asset.size)}</td>
+    <td className="asset-table__size-column">{prettyBytes(asset.size)}</td>
     <td>
       {asset.sketchId && (
         <Link to={`/${username}/sketches/${asset.sketchId}`}>

--- a/client/styles/components/_asset-list.scss
+++ b/client/styles/components/_asset-list.scss
@@ -16,6 +16,11 @@
     width: #{math.div(60, $base-font-size)}rem;
     position: relative;
   }
+  & .asset-table__size-column {
+    white-space: nowrap;
+    width: #{math.div(100, $base-font-size)}rem;
+    padding-right: #{math.div(12, $base-font-size)}rem;
+  }
 }
 
 .asset-table thead th {


### PR DESCRIPTION
Fixes #4129

The asset table's Size column had no fixed width or wrapping constraint.
On narrow screens, longer file sizes like "835.46 kB" would break across
two lines, reducing scannability of the assets list.

### Demo:
## Before fix : 
<img width="740" height="171" alt="image" src="https://github.com/user-attachments/assets/1089a4c7-a50e-4fcd-869e-2d6bc9bb691e" />

## After fix : 
<img width="767" height="218" alt="image" src="https://github.com/user-attachments/assets/5eb0bafa-bd4e-4781-9193-8c48348812d1" />


### Changes:
- Added `asset-table__size-column` class to the size `<td>` in `AssetListRow.jsx`
- Added CSS rule for `.asset-table__size-column` with `white-space: nowrap`,
  a fixed width, and right padding to prevent the size text from wrapping
  and to improve spacing between the Size and Sketch columns

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the accessibility guidelines
