### PR TITLE
fix: preserve file selection when project saves asynchronously

### DIFF
--- a/client/modules/IDE/reducers/files.js
+++ b/client/modules/IDE/reducers/files.js
@@ -178,6 +178,9 @@ const files = (state, action) => {
           const isFolderClosed = corrospondingObj.isFolderClosed || false;
           return { ...file, isFolderClosed };
         }
+        if (corrospondingObj) {
+          return { ...file, isSelectedFile: corrospondingObj.isSelectedFile };
+        }
         return file;
       });
       return setFilePaths(newFiles);


### PR DESCRIPTION
### Issue:
Fixes #4128

When a user saved a sketch and quickly switched to another file before
the save completed, the editor would snap back to the original file once
the save response arrived.

**Root cause:** `isSelectedFile` is stored inside each file object. When
the save response arrives, `SET_PROJECT` replaces the files array with
the server response, which has `isSelectedFile: true` on whichever file
was selected at save time — overriding the user's new selection.

**Fix:** In the `SET_PROJECT` reducer case, preserve `isSelectedFile`
from the current Redux state instead of taking it from the server
response. The server has no business dictating which file is selected on
the client.

### Demo:
## Before fix : 
https://github.com/user-attachments/assets/0b932f94-0dbf-43a6-b88d-fe892833dd90
## After fix : 
https://github.com/user-attachments/assets/6a5e9901-8f88-4e3b-a3bb-60743720f75a

### Changes:
- `client/modules/IDE/reducers/files.js` — preserve `isSelectedFile`
  from current state when handling `SET_PROJECT`

### I have verified that this pull request:
* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the accessibility guidelines
