### PR TITLE
Update p5Versions to include version 2.3.0

### DIFF
--- a/common/p5Versions.js
+++ b/common/p5Versions.js
@@ -5,7 +5,8 @@ export const currentP5Version = '1.11.13'; // Don't update to 2.x until 2026
 // JSON.stringify([...document.querySelectorAll('._132722c7')].map(n => n.innerText), null, 2)
 // TODO: use their API for this to grab these at build time?
 export const p5Versions = [
-  { version: '2.2.3', label: '(Beta)' },
+  { version: '2.3.0', label: '(Beta)' },
+  '2.2.3',
   '2.2.2',
   '2.2.1',
   '2.2.0',


### PR DESCRIPTION
New version of p5.js has been released: https://github.com/processing/p5.js/releases/tag/v2.3.0 this adds it to the editor.

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
