### PR TITLE
Update p5.sound URL to version 0.3.0

### DIFF
--- a/common/p5URLs.js
+++ b/common/p5URLs.js
@@ -1,7 +1,7 @@
 export const p5SoundURLOldTemplate =
   'https://cdn.jsdelivr.net/npm/p5@$VERSION/lib/addons/p5.sound.min.js';
 export const p5SoundURL =
-  'https://cdn.jsdelivr.net/npm/p5.sound@0.2.0/dist/p5.sound.min.js';
+  'https://cdn.jsdelivr.net/npm/p5.sound@0.3.0/dist/p5.sound.min.js';
 export const p5PreloadAddonURL =
   'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/preload.js';
 export const p5ShapesAddonURL =


### PR DESCRIPTION
There is a newer version of p5.sound.js available

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
