### PR TITLE
Update p5Versions with 2.3.0 and p5 sound URL to 0.3.0

### DIFF
--- a/common/p5URLs.js
+++ b/common/p5URLs.js
@@ -1,7 +1,7 @@
 export const p5SoundURLOldTemplate =
   'https://cdn.jsdelivr.net/npm/p5@$VERSION/lib/addons/p5.sound.min.js';
 export const p5SoundURL =
-  'https://cdn.jsdelivr.net/npm/p5.sound@0.2.0/dist/p5.sound.min.js';
+  'https://cdn.jsdelivr.net/npm/p5.sound@0.3.0/dist/p5.sound.min.js';
 export const p5PreloadAddonURL =
   'https://cdn.jsdelivr.net/npm/p5.js-compatibility@0.2.0/src/preload.js';
 export const p5ShapesAddonURL =

--- a/common/p5Versions.js
+++ b/common/p5Versions.js
@@ -5,7 +5,8 @@ export const currentP5Version = '1.11.13'; // Don't update to 2.x until 2026
 // JSON.stringify([...document.querySelectorAll('._132722c7')].map(n => n.innerText), null, 2)
 // TODO: use their API for this to grab these at build time?
 export const p5Versions = [
-  { version: '2.2.3', label: '(Beta)' },
+  { version: '2.3.0', label: '(Beta)' },
+  '2.2.3',
   '2.2.2',
   '2.2.1',
   '2.2.0',


### PR DESCRIPTION
### Changes:
- Creates a new PR for changes from https://github.com/processing/p5.js-web-editor/pull/4139 and https://github.com/processing/p5.js-web-editor/pull/4140, which add p5.js version 2.3.0 to the version picker and p5 sound version 0.3.0 to the new sketch template. 
- This PR branches off of `release`. The PRs above were branched from `develop`, which is currently not ready to be deployed. 

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
