### PR TITLE
fix: restore CM6 editor visual consistency#4144

### DIFF
--- a/client/modules/IDE/components/Editor/codemirror.js
+++ b/client/modules/IDE/components/Editor/codemirror.js
@@ -99,7 +99,16 @@ export default function useCodeMirror({
 
   // When settings change, we pass those changes into CodeMirror.
   useEffect(() => {
-    cmView.current.dom.style['font-size'] = `${fontSize}px`;
+    const reconfigureEffect = (fileState) =>
+      fileState.fontSizeCpt.reconfigure(
+        EditorView.theme({ '&': { fontSize: `${fontSize}px` } })
+      );
+    updateFileStates({
+      fileStates: fileStates.current,
+      cmView: cmView.current,
+      file,
+      reconfigureEffect
+    });
   }, [fontSize]);
   useEffect(() => {
     const reconfigureEffect = (fileState) =>
@@ -171,7 +180,8 @@ export default function useCodeMirror({
             autocomplete: autocompleteHinter,
             onUpdateLinting,
             onViewUpdate,
-            referenceBaseUrl
+            referenceBaseUrl,
+            fontSize
           }
         );
       }

--- a/client/modules/IDE/components/Editor/stateUtils.js
+++ b/client/modules/IDE/components/Editor/stateUtils.js
@@ -402,6 +402,14 @@ export const createAutocompleteOptions = (referenceBaseUrl) => ({
   ]
 });
 
+// Uses window.document explicitly to avoid shadowing by the `document`
+// parameter in createNewFileState below.
+function createFoldMarker(open) {
+  const span = window.document.createElement('span');
+  span.className = open ? 'cm-fold-open' : 'cm-fold-closed';
+  return span;
+}
+
 /**
  * Creates a new CodeMirror editor state with configurations,
  * extensions, and keymaps tailored to the file type and settings.
@@ -416,12 +424,14 @@ export function createNewFileState(filename, document, settings) {
     autocloseBracketsQuotes,
     onUpdateLinting,
     onViewUpdate,
-    referenceBaseUrl
+    referenceBaseUrl,
+    fontSize
   } = settings;
   const lineNumbersCpt = new Compartment();
   const lineWrappingCpt = new Compartment();
   const closeBracketsCpt = new Compartment();
   const autocompleteCpt = new Compartment();
+  const fontSizeCpt = new Compartment();
 
   // Depending on the file mode, we have a different tidier function.
   // Keep this binding local to each file state so modes don't accumulate
@@ -469,6 +479,7 @@ export function createNewFileState(filename, document, settings) {
   // https://github.com/codemirror/basic-setup/blob/main/src/codemirror.ts
   const extensions = [
     // The first few extensions can be toggled on or off.
+    fontSizeCpt.of(EditorView.theme({ '&': { fontSize: `${fontSize}px` } })),
     lineNumbersCpt.of(lineNumbers ? lineNumbersExt() : []),
     lineWrappingCpt.of(linewrap ? EditorView.lineWrapping : []),
     closeBracketsCpt.of(autocloseBracketsQuotes ? closeBrackets() : []),
@@ -495,7 +506,7 @@ export function createNewFileState(filename, document, settings) {
     EditorState.allowMultipleSelections.of(true),
     // Gutter extensions
     gutters({ fixed: false }),
-    foldGutter(),
+    foldGutter({ markerDOM: createFoldMarker }),
     // Misc extensions
     indentOnInput(),
     bracketMatching(),
@@ -557,7 +568,8 @@ export function createNewFileState(filename, document, settings) {
     lineNumbersCpt,
     lineWrappingCpt,
     closeBracketsCpt,
-    autocompleteCpt
+    autocompleteCpt,
+    fontSizeCpt
   };
 }
 

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -162,10 +162,9 @@
 
 .cm-foldGutter .cm-gutterElement {
   cursor: pointer;
-  // !important needed to override CM6's inline display style on gutter elements
-  display: flex !important;
-  align-items: center !important;
-  justify-content: center !important;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 // CM5: .CodeMirror-foldgutter-open:after / .CodeMirror-foldgutter-folded:after

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -155,7 +155,60 @@
   }
 }
 
-// TODO: Add fold gutter styling back.
+// CM5: .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded
+.cm-foldGutter {
+  padding-right: #{math.div(3, $base-font-size)}rem;
+}
+
+.cm-foldGutter .cm-gutterElement {
+  cursor: pointer;
+  // !important needed to override CM6's inline display style on gutter elements
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+}
+
+// CM5: .CodeMirror-foldgutter-open:after / .CodeMirror-foldgutter-folded:after
+.cm-fold-open,
+.cm-fold-closed {
+  display: inline-block;
+  width: #{math.div(10, $base-font-size)}rem;
+  height: #{math.div(10, $base-font-size)}rem;
+  background-size: #{math.div(10, $base-font-size)}rem #{math.div(10, $base-font-size)}rem;
+  background-repeat: no-repeat;
+  background-position: center center;
+  opacity: 0.4;
+}
+
+.cm-fold-open {
+  @include themify() {
+    background-image: getThemifyVariable('codefold-icon-open');
+  }
+}
+
+.cm-fold-closed {
+  @include themify() {
+    background-image: getThemifyVariable('codefold-icon-closed');
+  }
+}
+
+// CM5: .CodeMirror-foldmarker
+.cm-foldPlaceholder {
+  display: inline-block;
+  vertical-align: middle;
+  height: 0.85em;
+  line-height: 0.7;
+  border-radius: 5px;
+  padding: 0 #{math.div(5, $base-font-size)}rem;
+  font-family: serif;
+  cursor: pointer;
+  opacity: 0.75;
+
+  @include themify() {
+    background-color: getThemifyVariable('primary-text-color');
+    color: getThemifyVariable('background-color');
+  }
+}
 
 .editor-holder {
   height: calc(100% - #{math.div(29, $base-font-size)}rem);


### PR DESCRIPTION
### Issue:
Fixes #4144

The CM6 branch had three visual inconsistencies compared to the current CM5 editor: temporary layout compression during font-size changes, missing fold gutter styling, and the fold collapsed placeholder not matching CM5's appearance.

### Demo:
#### Befor : 

https://github.com/user-attachments/assets/1eb210ec-4811-4542-8c79-4b383cc7cbbb

#### After : 
https://github.com/user-attachments/assets/0431dd8e-3155-4741-a0ed-02dde2eecf0c

### Changes:
- **`stateUtils.js`** — Added `fontSizeCpt` Compartment using `EditorView.theme()` so font-size changes go through CM6's state system instead of direct DOM manipulation, preventing layout compression. Added `createFoldMarker` using the official `foldGutter({ markerDOM })` API to render fold arrows using the same SVG icons as CM5 (`codefold-icon-open` / `codefold-icon-closed`). Used `window.document` explicitly to avoid shadowing by the `document` parameter in `createNewFileState`.
- **`codemirror.js`** — Wired `fontSizeCpt` reconfigure on font-size preference change, following the same Compartment pattern as `lineNumbersCpt`, `lineWrappingCpt` etc.
- **`_editor.scss`** — Added fold gutter styles translated from CM5 (`.CodeMirror-foldgutter-*` → `.cm-foldGutter`, `.cm-fold-open`, `.cm-fold-closed`) and fold placeholder styles (`.CodeMirror-foldmarker` → `.cm-foldPlaceholder`) using the same theme variables.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #4144`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)