### PR TITLE
[CodeMirror v6] fix stale react state in cm6 update listener

### DIFF
--- a/client/modules/IDE/components/Editor/codemirror.js
+++ b/client/modules/IDE/components/Editor/codemirror.js
@@ -49,18 +49,30 @@ export default function useCodeMirror({
   const fileId = useRef();
   fileId.current = file.id;
 
+  // CM6 update listeners are attached when file states are created and
+  // can outlive React renders. Keep dynamic values in a ref so onChange
+  // always sees the latest state.
+  const latestRef = useRef({});
+  latestRef.current = {
+    autorefresh,
+    project,
+    files
+  };
+
   // When the file changes, update the file content and save status.
   function onChange() {
+    const latest = latestRef.current;
+
     setUnsavedChanges(true);
     updateFileContent(fileId.current, cmView.current.state.doc.toString());
 
     // Save a local backup to localStorage for crash recovery (#3891).
     // This ensures work is recoverable even if the tab crashes
     // (e.g. from an infinite loop) before the server autosave fires.
-    const projectId = project?.id || 'unsaved';
-    saveLocalBackup(projectId, files);
+    const projectId = latest.project?.id || 'unsaved';
+    saveLocalBackup(projectId, latest.files);
 
-    if (autorefresh) {
+    if (latest.autorefresh) {
       clearConsole();
       startSketch();
     }

--- a/client/modules/IDE/components/Editor/codemirror.js
+++ b/client/modules/IDE/components/Editor/codemirror.js
@@ -44,16 +44,11 @@ export default function useCodeMirror({
   // The current codemirror files.
   const fileStates = useRef();
 
-  // We have to create a ref for the file ID, or else the debouncer
-  // will old onto an old version of the fileId and just overrwrite the initial file.
-  const fileId = useRef();
-  fileId.current = file.id;
-
-  // CM6 update listeners are attached when file states are created and
-  // can outlive React renders. Keep dynamic values in a ref so onChange
-  // always sees the latest state.
-  const latestRef = useRef({});
-  latestRef.current = {
+  // We store values used by the debounced onChange callback in a ref.
+  // Otherwise it can hold onto stale React state
+  const onChangeStateRef = useRef({});
+  onChangeStateRef.current = {
+    fileId: file.id,
     autorefresh,
     project,
     files
@@ -61,18 +56,18 @@ export default function useCodeMirror({
 
   // When the file changes, update the file content and save status.
   function onChange() {
-    const latest = latestRef.current;
+    const state = onChangeStateRef.current;
 
     setUnsavedChanges(true);
-    updateFileContent(fileId.current, cmView.current.state.doc.toString());
+    updateFileContent(state.fileId, cmView.current.state.doc.toString());
 
     // Save a local backup to localStorage for crash recovery (#3891).
     // This ensures work is recoverable even if the tab crashes
     // (e.g. from an infinite loop) before the server autosave fires.
-    const projectId = latest.project?.id || 'unsaved';
-    saveLocalBackup(projectId, latest.files);
+    const projectId = state.project?.id || 'unsaved';
+    saveLocalBackup(projectId, state.files);
 
-    if (latest.autorefresh) {
+    if (state.autorefresh) {
       clearConsole();
       startSketch();
     }


### PR DESCRIPTION
### Issue:
Fixes #4155
the listener is installed when file states are created and can outlive subsequent React renders. as a result, callbacks could read stale values for autorefresh, project, and files.

### Changes

- added a ref for dynamic values used by onChange
- read autorefresh, project, and files from the ref instead of the captured closure

### Testing

- Verified autorefresh updates correctly after being enabled
- Verified files reflects newly created files
- Verified project id stays current
