### PR TITLE
[CodeMirror v6] fix ctrl/cmd+enter inserting blank line

### DIFF
--- a/client/modules/IDE/components/Editor/utils/keymaps.js
+++ b/client/modules/IDE/components/Editor/utils/keymaps.js
@@ -77,6 +77,10 @@ export function openColorPickerWithKeyboard(view) {
 // Extra custom keymaps.
 // TODO: We need to add sublime mappings + other missing extra mappings here.
 export const extraKeymaps = [
+  {
+    key: 'Mod-Enter',
+    run: () => true
+  },
   { key: 'ArrowRight', run: focusOnReferenceArrow },
   { key: 'Tab', run: insertTab, shift: indentLess }
 ];


### PR DESCRIPTION
### Issue:
Fixes #4157 
CodeMirror 6's `defaultKeymap` binds `Ctrl/Cmd+Enter` to `insertBlankLine`.

the editor also uses `Ctrl/Cmd+Enter` to run sketches via the global IDE keyboard handler. as a result, running a sketch inserts an unintended blank line into the editor.

this change overrides the editor binding using `Mod-Enter`, preventing CodeMirror from executing `insertBlankLine`.

## Changes
- added a `Mod-Enter` keymap override before `defaultKeymap`

## Testing
- Verified `Ctrl+Enter` runs the sketch without modifying editor contents
- Verified `Ctrl+Shift+Enter` continues to stop sketches