### PR TITLE
Fix link accessibility

### DIFF
--- a/client/modules/About/About.styles.ts
+++ b/client/modules/About/About.styles.ts
@@ -177,7 +177,7 @@ export const ContactHandles = styled.p`
   width: 50%;
 
   & a {
-    color: ${prop('logoColor')};
+    color: ${prop('linkTextColor')};
     text-decoration: underline;
 
     &:hover {
@@ -204,7 +204,7 @@ export const Footer = styled.div`
 
   & a {
     margin: ${remSize(20)} 9.5% 0 0;
-    color: ${prop('logoColor')};
+    color: ${prop('linkTextColor')};
     text-decoration: underline;
 
     &:hover {

--- a/client/styles/abstracts/_placeholders.scss
+++ b/client/styles/abstracts/_placeholders.scss
@@ -173,16 +173,16 @@
 %link {
 	@include themify() {
 		text-decoration: none;
-		color: getThemifyVariable('inactive-text-color');
+		color: getThemifyVariable('link-text-color');
 		cursor: pointer;
 		& g, & path {
-			fill: getThemifyVariable('inactive-text-color');
+			fill: getThemifyVariable('link-text-color');
 		}
 		&:hover {
 			text-decoration: none;
-			color: getThemifyVariable('heavy-text-color');
+			color: getThemifyVariable('link-text-color');
 			& g, & path {
-				fill: getThemifyVariable('heavy-text-color');
+				fill: getThemifyVariable('link-text-color');
 			}
 		}
 	}

--- a/client/styles/abstracts/_placeholders.scss
+++ b/client/styles/abstracts/_placeholders.scss
@@ -180,9 +180,9 @@
 		}
 		&:hover {
 			text-decoration: none;
-			color: getThemifyVariable('link-text-color');
+			color: getThemifyVariable('heavy-text-color');
 			& g, & path {
-				fill: getThemifyVariable('link-text-color');
+				fill: getThemifyVariable('heavy-text-color');
 			}
 		}
 	}

--- a/client/styles/abstracts/_variables.scss
+++ b/client/styles/abstracts/_variables.scss
@@ -8,7 +8,8 @@ $white: #fff;
 $black: #000;
 $yellow: #F5DC23;
 $dodgerblue: #1E90FF;
-$p5-contrast-pink: #FFA9D9;
+$p5-contrast-light-pink: #ffa9d9;
+$p5-contrast-dark-pink: #b20046;
 
 $outline-color: #0F9DD7;
 
@@ -31,8 +32,9 @@ $darkest: #000;
 
 $themes: (
   light: (
+    link-text-color: $p5-contrast-dark-pink,
     admonition-background: #E4F8FF,
-    admonition-border: #22C8ED,
+    admonition-border: #22C8ED, 
     admonition-text: #075769,
     background-color: $lighter,
     button-active-color: $lightest,
@@ -129,6 +131,7 @@ $themes: (
     toolbar-button-color: $dark,
   ),
   dark: (
+    link-text-color: $p5-contrast-light-pink,
     admonition-background: #105A7F,
     admonition-border: #22C8ED,
     admonition-text: #FFFFFF,
@@ -226,6 +229,7 @@ $themes: (
     toolbar-button-color: $lightest,
   ),
   contrast: (
+    link-text-color: $p5-contrast-light-pink,
     admonition-background: #000000,
     admonition-border: #22C8ED,
     admonition-text: #ffffff,
@@ -249,7 +253,7 @@ $themes: (
     console-header-color: $lightest,
     console-input-background-color: $darker,
     editor-gutter-color: $darker,
-    error-color: $p5-contrast-pink,
+    error-color: $p5-contrast-light-pink,
     file-hover-color: $dark,
     file-selected-color: $medium-dark,
     form-navigation-options-color: $middle-light,

--- a/client/styles/components/_preferences.scss
+++ b/client/styles/components/_preferences.scss
@@ -73,7 +73,7 @@
   & a {
     text-decoration: underline;
     @include themify() {
-      color: getThemifyVariable('button-background-hover-color');
+      color: getThemifyVariable('link-text-color');
     }
   }
   & a:hover {
@@ -154,7 +154,7 @@
     display: contents;
     & a {
       text-decoration: underline;
-      color: getThemifyVariable('button-background-hover-color');
+      color: getThemifyVariable('link-text-color');
     }
     & a:hover {
       text-decoration: underline;

--- a/client/theme.js
+++ b/client/theme.js
@@ -19,7 +19,8 @@ export const colors = {
   red: '#ff0000',
   lightsteelblue: '#B0C4DE',
   dodgerblue: '#1E90FF',
-  p5ContrastPink: ' #FFA9D9',
+  p5ContrastLightPink: '#FFA9D9',
+  p5ContrastDarkPink: '#B20046',
   p5ContrastYellow: '#fff001',
   borderColor: ' #B5B5B5',
   outlineColor: '#0F9DD7'
@@ -71,6 +72,7 @@ const baseThemes = {
   [Theme.light]: {
     colors,
     ...common,
+    linkTextColor: colors.p5ContrastDarkPink,
     primaryTextColor: grays.dark,
     inactiveTextColor: grays.middleDark,
     backgroundColor: grays.lighter,
@@ -166,6 +168,7 @@ const baseThemes = {
   [Theme.dark]: {
     colors,
     ...common,
+    linkTextColor: colors.p5ContrastLightPink,
     primaryTextColor: grays.lightest,
     inactiveTextColor: grays.middleLight,
     backgroundColor: grays.darker,
@@ -269,6 +272,7 @@ export default {
     toolbarTextColor: grays.dark,
     toolbarBackgroundColor: grays.light,
     toolbarTextHoverColor: grays.dark,
+    linkTextColor: colors.p5ContrastLightPink,
 
     Button: {
       primary: {


### PR DESCRIPTION
Resolves #4126 

## Changes

### Accessibility color updates
- Renamed `p5-contrast-pink` to `p5-contrast-light-pink` (`#FFA9D9`)
- Added a new `p5-contrast-dark-pink` color (`#B20046`)
- Updated existing references to use `p5-contrast-light-pink`

### Theme-specific link colors
- Light theme links now use `p5-contrast-dark-pink`
- Dark theme links now use `p5-contrast-light-pink`
- Contrast theme links continue to use `p5-contrast-light-pink`

### Link styling updates
- Updated shared link styling to use the theme-specific `link-text-color` variable instead of hardcoded color values
- Updated About page contact/footer links to use the accessibility-compliant theme link color
- Preserved existing hover and underline behavior

## Why

This change improves link accessibility by ensuring link colors meet WCAG contrast requirements for small text while maintaining consistent behavior across themes.

## QA Steps

1. Start the web editor locally.
2. Switch to **Light Mode**.
   - Verify links appear in dark pink (`#B20046`).
3. Switch to **Dark Mode**.
   - Verify links appear in light pink (`#FFA9D9`).
4. Switch to **Contrast Mode**.
   - Verify links appear in light pink (`#FFA9D9`).
5. Open the **Preferences** dialog and verify links use the correct theme color.
6. Open the **About** page and verify contact/footer links use the correct theme color.
7. Confirm links remain underlined and visually distinguishable from surrounding text in all themes.

## Screenshots

### Light Mode
<img width="1903" height="907" alt="Screenshot 2026-06-06 154218" src="https://github.com/user-attachments/assets/3be36588-393e-4d23-96d7-ebcb72573cab" />


### Dark Mode
<img width="1917" height="912" alt="Screenshot 2026-06-06 154305" src="https://github.com/user-attachments/assets/09fc39dd-db8d-4e36-ade2-3d7126359798" />
<img width="1350" height="830" alt="image" src="https://github.com/user-attachments/assets/0a5e2b26-17d0-4f10-9c46-00bb6aa67be8" />