### PR TITLE
fix: remove sketch file reference when deleting assets

### DIFF
--- a/client/modules/IDE/actions/assets.js
+++ b/client/modules/IDE/actions/assets.js
@@ -2,6 +2,7 @@ import { apiClient } from '../../../utils/apiClient';
 import * as ActionTypes from '../../../constants';
 import { startLoader, stopLoader } from '../reducers/loading';
 import { assetsActions } from '../reducers/assets';
+import { setProjectSavedTime } from './project';
 
 const { setAssets, deleteAsset } = assetsActions;
 
@@ -27,14 +28,24 @@ export function getAssets() {
   };
 }
 
-export function deleteAssetRequest(assetKey) {
-  return async (dispatch) => {
+export function deleteAssetRequest(asset) {
+  return async (dispatch, getState) => {
     try {
-      const path = assetKey.split('/').pop();
-      await apiClient.delete(
-        `/S3/delete?objectKey=${encodeURIComponent(path)}`
+      const response = await apiClient.delete(
+        `/projects/${asset.sketchId}/files/${asset.fileId}`,
+        { params: { parentId: asset.parentId } }
       );
-      dispatch(deleteAsset(assetKey));
+      dispatch(deleteAsset(asset.key));
+
+      const { project } = getState();
+      if (project.id === asset.sketchId) {
+        dispatch(setProjectSavedTime(response.data.project.updatedAt));
+        dispatch({
+          type: ActionTypes.DELETE_FILE,
+          id: asset.fileId,
+          parentId: asset.parentId
+        });
+      }
     } catch (error) {
       dispatch({
         type: ActionTypes.ERROR

--- a/client/modules/IDE/actions/assets.js
+++ b/client/modules/IDE/actions/assets.js
@@ -2,7 +2,6 @@ import { apiClient } from '../../../utils/apiClient';
 import * as ActionTypes from '../../../constants';
 import { startLoader, stopLoader } from '../reducers/loading';
 import { assetsActions } from '../reducers/assets';
-import { setProjectSavedTime } from './project';
 
 const { setAssets, deleteAsset } = assetsActions;
 
@@ -31,21 +30,26 @@ export function getAssets() {
 export function deleteAssetRequest(asset) {
   return async (dispatch, getState) => {
     try {
-      const response = await apiClient.delete(
-        `/projects/${asset.sketchId}/files/${asset.fileId}`,
-        { params: { parentId: asset.parentId } }
-      );
-      dispatch(deleteAsset(asset.key));
+      if (asset.sketchId) {
+        await apiClient.delete(
+          `/projects/${asset.sketchId}/files/${asset.fileId}`,
+          { params: { parentId: asset.parentId } }
+        );
 
-      const { project } = getState();
-      if (project.id === asset.sketchId) {
-        dispatch(setProjectSavedTime(response.data.project.updatedAt));
-        dispatch({
-          type: ActionTypes.DELETE_FILE,
-          id: asset.fileId,
-          parentId: asset.parentId
+        const { project } = getState();
+        if (project.id === asset.sketchId) {
+          dispatch({
+            type: ActionTypes.DELETE_FILE,
+            id: asset.fileId,
+            parentId: asset.parentId
+          });
+        }
+      } else {
+        await apiClient.delete('/S3/delete', {
+          params: { objectKey: asset.key }
         });
       }
+      dispatch(deleteAsset(asset.key));
     } catch (error) {
       dispatch({
         type: ActionTypes.ERROR

--- a/client/modules/IDE/components/AssetListRow.jsx
+++ b/client/modules/IDE/components/AssetListRow.jsx
@@ -34,9 +34,9 @@ AssetMenu.propTypes = {
     key: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
-    sketchId: PropTypes.string.isRequired,
-    fileId: PropTypes.string.isRequired,
-    parentId: PropTypes.string.isRequired
+    sketchId: PropTypes.string,
+    fileId: PropTypes.string,
+    parentId: PropTypes.string
   }).isRequired
 };
 
@@ -65,10 +65,10 @@ AssetListRow.propTypes = {
   asset: PropTypes.shape({
     key: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
-    sketchId: PropTypes.string.isRequired,
+    sketchId: PropTypes.string,
     sketchName: PropTypes.string,
-    fileId: PropTypes.string.isRequired,
-    parentId: PropTypes.string.isRequired,
+    fileId: PropTypes.string,
+    parentId: PropTypes.string,
     name: PropTypes.string.isRequired,
     size: PropTypes.number.isRequired
   }).isRequired,

--- a/client/modules/IDE/components/AssetListRow.jsx
+++ b/client/modules/IDE/components/AssetListRow.jsx
@@ -13,9 +13,9 @@ const AssetMenu = ({ item: asset }) => {
   const dispatch = useDispatch();
 
   const handleAssetDelete = () => {
-    const { key, name } = asset;
+    const { name } = asset;
     if (window.confirm(t('Common.DeleteConfirmation', { name }))) {
-      dispatch(deleteAssetRequest(key));
+      dispatch(deleteAssetRequest(asset));
     }
   };
 
@@ -33,7 +33,10 @@ AssetMenu.propTypes = {
   item: PropTypes.shape({
     key: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
-    name: PropTypes.string.isRequired
+    name: PropTypes.string.isRequired,
+    sketchId: PropTypes.string.isRequired,
+    fileId: PropTypes.string.isRequired,
+    parentId: PropTypes.string.isRequired
   }).isRequired
 };
 
@@ -62,8 +65,10 @@ AssetListRow.propTypes = {
   asset: PropTypes.shape({
     key: PropTypes.string.isRequired,
     url: PropTypes.string.isRequired,
-    sketchId: PropTypes.string,
+    sketchId: PropTypes.string.isRequired,
     sketchName: PropTypes.string,
+    fileId: PropTypes.string.isRequired,
+    parentId: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,
     size: PropTypes.number.isRequired
   }).isRequired,

--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -111,9 +111,14 @@ export async function listObjectsInS3ForUser(userId) {
         project.files.some((file) => {
           if (!file.url) return false;
           if (file.url.includes(asset.key)) {
+            const parent = project.files.find((f) =>
+              f.children.includes(file.id)
+            );
             foundAsset.name = file.name;
             foundAsset.sketchName = project.name;
             foundAsset.sketchId = project.id;
+            foundAsset.fileId = file.id;
+            foundAsset.parentId = parent?.id;
             foundAsset.url = file.url;
             return true;
           }


### PR DESCRIPTION
### Issue:
Fixes #4160

Asset deletion now uses the same file delete endpoint as the sketch files sidebar, so both the storage object and the project file reference are removed together.

### Before
https://github.com/user-attachments/assets/07b403cf-552d-4114-b3d4-400ae9110953
### After
https://github.com/user-attachments/assets/ba956732-35f5-44ee-89ee-78de68ad73c0
### Changes:
1. Include fileId and parentId in the asset list API response when matching assets to sketch files
2. Update asset deletion to call /projects/:sketchId/files/:fileId instead of /S3/delete
3. Sync Redux state when the currently open sketch matches the deleted asset

### I have verified that this pull request:
* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
