### PR TITLE
fix: display all uploaded S3 assets in the assets tab

### DIFF
--- a/server/controllers/aws.controller.js
+++ b/server/controllers/aws.controller.js
@@ -107,7 +107,7 @@ export async function listObjectsInS3ForUser(userId) {
       };
       totalSize += asset.size;
 
-      const wasMatched = projects.some((project) =>
+      projects.some((project) =>
         project.files.some((file) => {
           if (!file.url) return false;
           if (file.url.includes(asset.key)) {
@@ -121,9 +121,7 @@ export async function listObjectsInS3ForUser(userId) {
         })
       );
 
-      if (wasMatched) {
-        projectAssets.push(foundAsset);
-      }
+      projectAssets.push(foundAsset);
     });
 
     return { assets: projectAssets, totalSize };


### PR DESCRIPTION
### Issue:
Fixes #4085 
This PR fixes an issue where some files stored in S3 for a user weren't showing up in their Assets tab, even though the total size calculation correctly increased.

In server/controllers/aws.controller.js, listObjectsInS3ForUser was fetching all objects from S3 but then filtering them to only include assets that could be mapped back to an active sketch project. If an asset wasn't referenced in a sketch (e.g. if it was uploaded but not yet used or if the sketch referencing it was deleted) it was hidden from the UI but still counted against the user's storage quota.
### Before
Even though the image exists in S3, no image is being displayed in the Assets section. However, its size is still being counted toward the storage limit, as shown in the image.

<img width="1308" height="760" alt="Screenshot 2026-06-07 142743" src="https://github.com/user-attachments/assets/430360a5-8d87-41a2-bade-60b94116a8a7" />

### Demo with fix:
https://github.com/user-attachments/assets/6a170a4f-6019-4755-a6c8-49143fdbe6ec

### Changes:
1. Removed the conditional check that filtered out unassociated assets.
2. If an asset maps to a sketch, it still gets enriched with the sketch details (sketchId, sketchName). Otherwise, it safely defaults to rendering without them.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
