### PR TITLE
[CodeMirror v6] improve cm6 visual parity with current editor

### DIFF
--- a/client/modules/IDE/components/ConsoleInput.jsx
+++ b/client/modules/IDE/components/ConsoleInput.jsx
@@ -2,11 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useRef, useEffect } from 'react';
 import { EditorState } from '@codemirror/state';
 import { EditorView, highlightSpecialChars, keymap } from '@codemirror/view';
-import {
-  bracketMatching,
-  syntaxHighlighting,
-  defaultHighlightStyle
-} from '@codemirror/language';
+import { bracketMatching, syntaxHighlighting } from '@codemirror/language';
 import { closeBrackets, closeBracketsKeymap } from '@codemirror/autocomplete';
 import { defaultKeymap, history, historyKeymap } from '@codemirror/commands';
 import { javascript } from '@codemirror/lang-javascript';
@@ -17,6 +13,7 @@ import { Encode } from 'console-feed';
 import RightArrowIcon from '../../../images/right-arrow.svg';
 import { dispatchConsoleEvent } from '../actions/console';
 import { dispatchMessage, MessageTypes } from '../../../utils/dispatcher';
+import { highlightStyle } from './Editor/utils/highlightStyle';
 
 // heavily inspired by
 // https://github.com/codesandbox/codesandbox-client/blob/92a1131f4ded6f7d9c16945dc7c18aa97c8ada27/packages/app/src/app/components/Preview/DevTools/Console/Input/index.tsx
@@ -119,7 +116,7 @@ function ConsoleInput({ theme, fontSize }) {
         highlightSpecialChars(),
         bracketMatching(),
         closeBrackets(),
-        syntaxHighlighting(defaultHighlightStyle),
+        syntaxHighlighting(highlightStyle),
         javascript(),
         keymap.of([
           enterKeymap,

--- a/client/modules/IDE/components/Editor/utils/fileState.js
+++ b/client/modules/IDE/components/Editor/utils/fileState.js
@@ -19,7 +19,7 @@ import {
   syntaxHighlighting
 } from '@codemirror/language';
 import { autocompletion, closeBrackets } from '@codemirror/autocomplete';
-import { highlightSelectionMatches, search } from '@codemirror/search';
+import { search } from '@codemirror/search';
 import { history } from '@codemirror/commands';
 import { lintGutter, linter } from '@codemirror/lint';
 import {
@@ -174,7 +174,6 @@ export function createNewFileState(filename, document, settings) {
     highlightActiveLine(),
     highlightActiveLineGutter(),
     highlightSpecialChars(),
-    highlightSelectionMatches(),
     syntaxHighlighting(highlightStyle),
     // Selection extensions
     drawSelection(),

--- a/client/styles/components/_console-input.scss
+++ b/client/styles/components/_console-input.scss
@@ -32,22 +32,22 @@
 .console__editor {
   margin-left: #{math.div(15, $base-font-size)}rem;
   flex: 1;
-  & .CodeMirror {
+  .cm-editor {
     height: auto;
   }
-  & .CodeMirror-lines {
+  .cm-content {
     padding-top: #{math.div(2, $base-font-size)}rem;
   }
 }
 
-.console__editor .CodeMirror {
+.console__editor .cm-editor {
   border: none;
   font-family: Inconsolata,monospace;
   @include themify() {
     background-color: getThemifyVariable('console-input-background-color');
   }
 
-  .CodeMirror-line {
+  .cm-line {
     @include themify() {
       color: getThemifyVariable('console-color');
     }

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -18,9 +18,6 @@
 
     .cm-line {
       padding: 0 #{math.div(4, $base-font-size)}rem;
-      .emmet-tracker{
-        text-decoration: none;
-      }
     }
 
     .cm-activeLine {
@@ -62,10 +59,6 @@
     @include themify() {
       border-left-color: getThemifyVariable('primary-text-color');
     }
-  }
-
-  &.cm-focused {
-    outline: none;
   }
 }
 

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -16,6 +16,13 @@
   .cm-content {
     padding-top: #{math.div(25, $base-font-size)}rem;
 
+    .cm-line {
+      padding: 0 #{math.div(4, $base-font-size)}rem;
+      .emmet-tracker{
+        text-decoration: none;
+      }
+    }
+
     .cm-activeLine {
       // Needed to place the active line highlight behind the selection highlight.
       position: relative;
@@ -55,6 +62,10 @@
     @include themify() {
       border-left-color: getThemifyVariable('primary-text-color');
     }
+  }
+
+  &.cm-focused {
+    outline: none;
   }
 }
 


### PR DESCRIPTION
### Issue:
Fixes #4163 
This PR resolves several visual inconsistencies between CodeMirror 6 and the current editor implementation.

### Changes+Demo:

- apply the p5.js syntax highlighting style to the console input.
<img width="266" height="151" alt="image" src="https://github.com/user-attachments/assets/cc23e26b-26dd-4764-9b2b-9dded960be98" />

---

- remove selection match highlighting from cm6.
<img width="254" height="164" alt="image" src="https://github.com/user-attachments/assets/42baaeaf-ae92-48b6-b277-20b01ae7cc9a" />

---

- remove emmet text decoration styling.
<img width="184" height="90" alt="image" src="https://github.com/user-attachments/assets/a26dbc8b-1eca-4358-adfe-dc7a6df1312d" />

---

- update cm6 line styling to better match the current editor.
<img width="288" height="173" alt="image" src="https://github.com/user-attachments/assets/f08c4e71-2ecd-496c-a678-11cab6f0a421" />

---

- remove the editor focus outline.
<img width="606" height="252" alt="image" src="https://github.com/user-attachments/assets/a23e6837-edfc-4e36-abf7-1e4db9fb3c04" />

---

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
* [x] verified all the changes