### PR TITLE
[CodeMirror v6] position fold gutter absolute + fix

### DIFF
--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -75,6 +75,8 @@
       color: getThemifyVariable('inactive-text-color');
     }
     pointer-events: none;
+    position:absolute;
+    right: 20%;
   }
 
   .cm-activeLineGutter {
@@ -162,14 +164,8 @@
 
 // CM5: .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded
 .cm-foldGutter {
-  padding-right: #{math.div(3, $base-font-size)}rem;
-}
-
-.cm-foldGutter .cm-gutterElement {
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  position: absolute;
+  right: 1px;
 }
 
 // CM5: .CodeMirror-foldgutter-open:after / .CodeMirror-foldgutter-folded:after
@@ -184,7 +180,7 @@
     )}rem;
   background-repeat: no-repeat;
   background-position: center center;
-  opacity: 0.4;
+  opacity: 0.2;
 }
 
 .cm-fold-open {

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -164,6 +164,7 @@
 
 // CM5: .CodeMirror-foldgutter-open, .CodeMirror-foldgutter-folded
 .cm-foldGutter {
+  cursor: pointer;
   position: absolute;
   right: 1px;
 }


### PR DESCRIPTION
### Issue:
Fixes #4165 

### Demo:
<img width="326" height="204" alt="image" src="https://github.com/user-attachments/assets/58e5f38a-eaed-4934-9e2d-c43fbd47c794" />


### Changes:
- absolutely position the fold gutter and line number to prevent movement when line numbers are toggled
- reduce fold marker opacity

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
