### PR TITLE
[CodeMirror v6] cm6 autocomplete parity with current editor

### DIFF
--- a/client/modules/IDE/components/Editor/utils/completionPreview.js
+++ b/client/modules/IDE/components/Editor/utils/completionPreview.js
@@ -105,7 +105,7 @@ export const completionPreviewTheme = EditorView.theme({
     opacity: '0.55',
     fontStyle: 'italic',
     pointerEvents: 'none',
-    whiteSpace: 'pre'
+    whiteSpace: 'pre-wrap'
   }
 });
 

--- a/client/modules/IDE/components/Editor/utils/extensionCustomStyles.js
+++ b/client/modules/IDE/components/Editor/utils/extensionCustomStyles.js
@@ -8,7 +8,8 @@
  * stateUtils when creating a new file state.
  */
 export const createAutocompleteOptions = (referenceBaseUrl) => ({
-  selectOnOpen: false,
+  defaultKeymap: false,
+  selectOnOpen: true,
   tooltipClass: () => 'CodeMirror-hints',
   closeOnBlur: false,
   icons: false,

--- a/client/modules/IDE/components/Editor/utils/keymaps.js
+++ b/client/modules/IDE/components/Editor/utils/keymaps.js
@@ -1,7 +1,9 @@
 import {
   completionStatus,
   selectedCompletionIndex,
-  closeBracketsKeymap
+  closeBracketsKeymap,
+  completionKeymap,
+  acceptCompletion
 } from '@codemirror/autocomplete';
 import {
   insertTab,
@@ -87,6 +89,13 @@ export const extraKeymaps = [
 
 export const emmetKeymaps = [{ key: 'Tab', run: expandAbbreviation }];
 
+function createAutocompleteKeymap() {
+  return [
+    ...completionKeymap.filter((binding) => binding.key !== 'Ctrl-Space'),
+    { key: 'Tab', run: acceptCompletion }
+  ];
+}
+
 function createColorPickerKeymap(mode) {
   const colorPickerKeymap = [];
   if (mode === 'css' || mode === 'javascript') {
@@ -120,10 +129,12 @@ function createFileTidyKeymap(mode) {
 }
 
 export function buildKeymaps(mode) {
+  const autocompleteKeymap = createAutocompleteKeymap();
   const colorPickerKeymap = createColorPickerKeymap(mode);
   const fileTidyKeymap = createFileTidyKeymap(mode);
 
   return [
+    autocompleteKeymap,
     extraKeymaps,
     colorPickerKeymap,
     fileTidyKeymap,

--- a/client/modules/IDE/components/Editor/utils/p5JavaScript.js
+++ b/client/modules/IDE/components/Editor/utils/p5JavaScript.js
@@ -56,7 +56,7 @@ const p5Highlight = ViewPlugin.fromClass(
 
 function addCompletions(context) {
   const word = context.matchBefore(/\w*/);
-  const isValidWord = word?.text && word.text.trim().length >= 2;
+  const isValidWord = word?.text && word.text.trim().length >= 1;
   if (!isValidWord && !context.explicit) {
     return null;
   }

--- a/client/styles/components/_hints.scss
+++ b/client/styles/components/_hints.scss
@@ -5,6 +5,7 @@
   border: #{math.div(1, $base-font-size)}rem solid #A6A6A6;
   font-family: Inconsolata, monospace;
   font-size: 1rem;
+  z-index: 1001;
 
   @include themify() {
     background: getThemifyVariable('hint-background-color');
@@ -65,11 +66,12 @@
   .cm-completionLabel {
     grid-column: 1;
     justify-self: start;
-    margin-left: #{math.div(12, $base-font-size)}rem;
+    margin-left: #{math.div(6, $base-font-size)}rem;
     line-height: 1.1;
-    font-weight: 600;
+    font-weight: bold;
     color: inherit;
     background: transparent;
+    padding: 0 0.5rem;
   }
 
   .cm-completionMatchedText {
@@ -138,8 +140,8 @@
   }
 
   // label colors
-  li.hint-type-method,
-  li.hint-type-obj {
+  li.hint-type-method:not([aria-selected='true']),
+  li.hint-type-obj:not([aria-selected='true']) {
     .cm-completionLabel,
     .cm-completionMatchedText {
       @include themify() {
@@ -148,9 +150,9 @@
     }
   }
 
-  li.hint-type-variable,
-  li.hint-type-constant,
-  li.hint-type-boolean {
+  li.hint-type-variable:not([aria-selected='true']),
+  li.hint-type-constant:not([aria-selected='true']),
+  li.hint-type-boolean:not([aria-selected='true']) {
     .cm-completionLabel,
     .cm-completionMatchedText {
       @include themify() {
@@ -159,92 +161,92 @@
     }
   }
 
-  li.hint-type-keyword {
+  li.hint-type-keyword:not([aria-selected='true']) {
     .cm-completionLabel,
     .cm-completionMatchedText {
       @include themify() {
         color: getThemifyVariable('hint-keyword-text-color');
-      }
     }
   }
+}
 
-  // highlighted completion label colors
-  li.hint-type-method[aria-selected='true'],
-  li.hint-type-obj[aria-selected='true'] {
-    .cm-completionLabel {
-      @include themify() {
-        background: getThemifyVariable('hint-fun-text-color');
-        color: getThemifyVariable('hint-item-active-text-color');
-        border-bottom: #{math.div(1, $base-font-size)}rem solid
-          getThemifyVariable('hint-fun-active-border-bottom-color');
-      }
-    }
-  }
-
-  li.hint-type-variable[aria-selected='true'],
-  li.hint-type-constant[aria-selected='true'],
-  li.hint-type-boolean[aria-selected='true'] {
-    .cm-completionLabel {
-      @include themify() {
-        background: getThemifyVariable('hint-var-text-color');
-        color: getThemifyVariable('hint-item-active-text-color');
-        border-bottom: #{math.div(1, $base-font-size)}rem solid
-          getThemifyVariable('hint-var-active-border-bottom-color');
-      }
-    }
-  }
-
-  li.hint-type-keyword[aria-selected='true'] {
-    .cm-completionLabel {
-      @include themify() {
-        background: getThemifyVariable('hint-keyword-text-color');
-        color: getThemifyVariable('hint-item-active-text-color');
-      }
-    }
-  }
-
-  .cm-completionWarning {
-    grid-column: 1 / 4;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    width: fit-content;
-    margin: 0.35rem 0.75rem 0.5rem 0.75rem;
-    padding: 0.32rem 0.55rem;
-    border: 1px solid #d9a300;
-    border-radius: 0.45rem;
-    background: #f3e7b7;
-    color: #9a6b00;
-    font-size: 0.8rem;
-    line-height: 1.1;
-    white-space: nowrap;
-  }
-
-  .cm-completionWarningIcon {
-    flex: 0 0 auto;
-    font-size: 1rem;
-  }
-
-  .cm-completionWarningText {
-    line-height: 1.1;
-  }
-
-  .cm-ghostCompletion {
+// highlighted completion label colors
+li.hint-type-method[aria-selected='true'],
+li.hint-type-obj[aria-selected='true'] {
+  .cm-completionLabel {
     @include themify() {
-      color: getThemifyVariable('hint-inline-text-color');
+      background: getThemifyVariable('hint-fun-text-color');
+      color: getThemifyVariable('hint-item-active-text-color');
+      border-bottom: #{math.div(1, $base-font-size)}rem solid
+        getThemifyVariable('hint-fun-active-border-bottom-color');
     }
   }
+}
 
-  .cm-ghostCompletion.cm-ghostCompletion--light {
+li.hint-type-variable[aria-selected='true'],
+li.hint-type-constant[aria-selected='true'],
+li.hint-type-boolean[aria-selected='true'] {
+  .cm-completionLabel {
     @include themify() {
-      color: getThemifyVariable('hint-inline-text-color-light');
+      background: getThemifyVariable('hint-var-text-color');
+      color: getThemifyVariable('hint-item-active-text-color');
+      border-bottom: #{math.div(1, $base-font-size)}rem solid
+        getThemifyVariable('hint-var-active-border-bottom-color');
     }
   }
+}
 
-  .hint-hidden {
+li.hint-type-keyword[aria-selected='true'] {
+  .cm-completionLabel {
     @include themify() {
-      @extend %hidden-element;
-      display: none;
+      background: getThemifyVariable('hint-keyword-text-color');
+      color: getThemifyVariable('hint-item-active-text-color');
     }
+  }
+}
+
+.cm-completionWarning {
+  grid-column: 1 / 4;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  width: fit-content;
+  margin: 0.35rem 0.75rem 0.5rem 0.75rem;
+  padding: 0.32rem 0.55rem;
+  border: 1px solid #d9a300;
+  border-radius: 0.45rem;
+  background: #f3e7b7;
+  color: #9a6b00;
+  font-size: 0.8rem;
+  line-height: 1.1;
+  white-space: nowrap;
+}
+
+.cm-completionWarningIcon {
+  flex: 0 0 auto;
+  font-size: 1rem;
+}
+
+.cm-completionWarningText {
+  line-height: 1.1;
+}
+
+.cm-ghostCompletion {
+  @include themify() {
+    color: getThemifyVariable('hint-inline-text-color');
+  }
+}
+
+.cm-ghostCompletion.cm-ghostCompletion--light {
+  @include themify() {
+    color: getThemifyVariable('hint-inline-text-color-light');
+  }
+}
+
+.hint-hidden {
+  @include themify() {
+    @extend %hidden-element;
+    display: none;
+  }
   }
 }

--- a/client/styles/components/_hints.scss
+++ b/client/styles/components/_hints.scss
@@ -2,7 +2,7 @@
 
 .cm-tooltip-autocomplete.CodeMirror-hints {
   box-shadow: 0 0 #{math.div(18, $base-font-size)}rem 0 rgba(0, 0, 0, 0.16);
-  border: #{math.div(1, $base-font-size)}rem solid #A6A6A6;
+  border: #{math.div(1, $base-font-size)}rem solid #a6a6a6;
   font-family: Inconsolata, monospace;
   font-size: 1rem;
   z-index: 1001;
@@ -166,87 +166,87 @@
     .cm-completionMatchedText {
       @include themify() {
         color: getThemifyVariable('hint-keyword-text-color');
+      }
     }
   }
-}
 
-// highlighted completion label colors
-li.hint-type-method[aria-selected='true'],
-li.hint-type-obj[aria-selected='true'] {
-  .cm-completionLabel {
+  // highlighted completion label colors
+  li.hint-type-method[aria-selected='true'],
+  li.hint-type-obj[aria-selected='true'] {
+    .cm-completionLabel {
+      @include themify() {
+        background: getThemifyVariable('hint-fun-text-color');
+        color: getThemifyVariable('hint-item-active-text-color');
+        border-bottom: #{math.div(1, $base-font-size)}rem solid
+          getThemifyVariable('hint-fun-active-border-bottom-color');
+      }
+    }
+  }
+
+  li.hint-type-variable[aria-selected='true'],
+  li.hint-type-constant[aria-selected='true'],
+  li.hint-type-boolean[aria-selected='true'] {
+    .cm-completionLabel {
+      @include themify() {
+        background: getThemifyVariable('hint-var-text-color');
+        color: getThemifyVariable('hint-item-active-text-color');
+        border-bottom: #{math.div(1, $base-font-size)}rem solid
+          getThemifyVariable('hint-var-active-border-bottom-color');
+      }
+    }
+  }
+
+  li.hint-type-keyword[aria-selected='true'] {
+    .cm-completionLabel {
+      @include themify() {
+        background: getThemifyVariable('hint-keyword-text-color');
+        color: getThemifyVariable('hint-item-active-text-color');
+      }
+    }
+  }
+
+  .cm-completionWarning {
+    grid-column: 1 / 4;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    width: fit-content;
+    margin: 0.35rem 0.75rem 0.5rem 0.75rem;
+    padding: 0.32rem 0.55rem;
+    border: 1px solid #d9a300;
+    border-radius: 0.45rem;
+    background: #f3e7b7;
+    color: #9a6b00;
+    font-size: 0.8rem;
+    line-height: 1.1;
+    white-space: nowrap;
+  }
+
+  .cm-completionWarningIcon {
+    flex: 0 0 auto;
+    font-size: 1rem;
+  }
+
+  .cm-completionWarningText {
+    line-height: 1.1;
+  }
+
+  .cm-ghostCompletion {
     @include themify() {
-      background: getThemifyVariable('hint-fun-text-color');
-      color: getThemifyVariable('hint-item-active-text-color');
-      border-bottom: #{math.div(1, $base-font-size)}rem solid
-        getThemifyVariable('hint-fun-active-border-bottom-color');
+      color: getThemifyVariable('hint-inline-text-color');
     }
   }
-}
 
-li.hint-type-variable[aria-selected='true'],
-li.hint-type-constant[aria-selected='true'],
-li.hint-type-boolean[aria-selected='true'] {
-  .cm-completionLabel {
+  .cm-ghostCompletion.cm-ghostCompletion--light {
     @include themify() {
-      background: getThemifyVariable('hint-var-text-color');
-      color: getThemifyVariable('hint-item-active-text-color');
-      border-bottom: #{math.div(1, $base-font-size)}rem solid
-        getThemifyVariable('hint-var-active-border-bottom-color');
+      color: getThemifyVariable('hint-inline-text-color-light');
     }
   }
-}
 
-li.hint-type-keyword[aria-selected='true'] {
-  .cm-completionLabel {
+  .hint-hidden {
     @include themify() {
-      background: getThemifyVariable('hint-keyword-text-color');
-      color: getThemifyVariable('hint-item-active-text-color');
+      @extend %hidden-element;
+      display: none;
     }
-  }
-}
-
-.cm-completionWarning {
-  grid-column: 1 / 4;
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  width: fit-content;
-  margin: 0.35rem 0.75rem 0.5rem 0.75rem;
-  padding: 0.32rem 0.55rem;
-  border: 1px solid #d9a300;
-  border-radius: 0.45rem;
-  background: #f3e7b7;
-  color: #9a6b00;
-  font-size: 0.8rem;
-  line-height: 1.1;
-  white-space: nowrap;
-}
-
-.cm-completionWarningIcon {
-  flex: 0 0 auto;
-  font-size: 1rem;
-}
-
-.cm-completionWarningText {
-  line-height: 1.1;
-}
-
-.cm-ghostCompletion {
-  @include themify() {
-    color: getThemifyVariable('hint-inline-text-color');
-  }
-}
-
-.cm-ghostCompletion.cm-ghostCompletion--light {
-  @include themify() {
-    color: getThemifyVariable('hint-inline-text-color-light');
-  }
-}
-
-.hint-hidden {
-  @include themify() {
-    @extend %hidden-element;
-    display: none;
-  }
   }
 }


### PR DESCRIPTION
### Issue:
Fixes #4167 

### Demo:
<img width="395" height="211" alt="Image" src="https://github.com/user-attachments/assets/ac93f0e0-e4e1-470d-a4c5-eced2117e8af" />

### Changes:
- fixed active completion item text color.
- updated autocomplete styling for parity with the current editor.
- fixed autocomplete popup appearing behind the console by adjusting z-index.
- disabled Ctrl+Space autocomplete trigger to match current editor behavior.
- preserved tab-based completion acceptance.
- enabled wrapping of ghost completion text to prevent horizontal scrolling.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
* [x] verified and ensured consistency with the current editor.