### PR TITLE
Hide Add Sketch option for non-owners of collections

### DIFF
--- a/client/modules/IDE/components/CollectionList/CollectionListRow.jsx
+++ b/client/modules/IDE/components/CollectionList/CollectionListRow.jsx
@@ -167,7 +167,7 @@ const CollectionListRowBase = (props) => {
       <TableDropdown
         aria-label={props.t('CollectionListRow.ToggleCollectionOptionsARIA')}
       >
-        <MenuItem onClick={handleAddSketches}>
+        <MenuItem hideIf={!userIsOwner} onClick={handleAddSketches}>
           {props.t('CollectionListRow.AddSketch')}
         </MenuItem>
         <MenuItem hideIf={!userIsOwner} onClick={handleCollectionDelete}>


### PR DESCRIPTION
Summary
Fixes #4148 by hiding the "Add Sketch" option in the collection dropdown for users who do not own the collection.

### Changes
* Added the same ownership check used by Rename and Delete actions to the Add Sketch menu item.
* Non-owners no longer see the Add Sketch option in collection action menus.

### Testing
* Verified collection owners can still access the Add Sketch option.
* Verified the Add Sketch menu item now respects the `userIsOwner` condition.

Fixes #4148

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
