### PR TITLE
GSOC-E2E-1: Add Playwright CI workflow and sketch execution test

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -1,0 +1,39 @@
+API_URL=/editor
+CORS_ALLOW_LOCALHOST=true
+TRANSLATIONS_ENABLED=true
+UI_ACCESS_TOKEN_ENABLED=false
+UPLOAD_LIMIT=250000000
+PORT=8000
+PREVIEW_PORT=8002
+EDITOR_URL=http://localhost:8000
+PREVIEW_URL=http://localhost:8002
+MONGO_URL=mongodb://localhost:27017/p5js-web-editor
+SESSION_SECRET=ci-session-secret
+EMAIL_VERIFY_SECRET_TOKEN=ci-verify-token
+# These accounts are used by the app to serve examples.
+# Real values not needed for E2E tests — dummy strings prevent crashes.
+EMAIL_SENDER=ci@example.com
+EXAMPLE_USER_EMAIL=examples@p5js.org
+EXAMPLE_USER_PASSWORD=hellop5js
+GG_EXAMPLES_USERNAME=generativedesign
+GG_EXAMPLES_EMAIL=benedikt.gross@generative-gestaltung.de
+GG_EXAMPLES_PASS=generativedesign
+ML5_LIBRARY_USERNAME=ml5
+ML5_LIBRARY_EMAIL=examples@ml5js.org
+ML5_LIBRARY_PASS=helloml5
+# Mailgun — non-empty string required to pass the startup check in
+# server/utils/mail.ts. No emails are sent during E2E tests.
+MAILGUN_KEY=dummy-mailgun-key
+MAILGUN_DOMAIN=dummy.mailgun.org
+# AWS S3 — non-empty strings required. No file uploads in E2E tests.
+AWS_ACCESS_KEY=dummy-aws-access-key
+AWS_SECRET_KEY=dummy-aws-secret-key
+AWS_REGION=us-east-1
+S3_BUCKET=dummy-bucket
+S3_BUCKET_URL_BASE=https://dummy-bucket.s3.amazonaws.com
+# GitHub OAuth — not tested in E2E suite, dummy values prevent crash.
+GITHUB_ID=dummy-github-id
+GITHUB_SECRET=dummy-github-secret
+# Google OAuth — not tested in E2E suite, dummy values prevent crash.
+GOOGLE_ID=dummy-google-id
+GOOGLE_SECRET=dummy-google-secret

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,4 +1,5 @@
 name: E2E Tests
+
 on:
   pull_request:
     branches:
@@ -8,20 +9,104 @@ jobs:
   e2e:
     name: End-to-end tests
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: '18.20.x'
-      - run: npm install
+          cache: 'npm'
+
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1.10.0
+        with:
+          mongodb-version: '6.0'
+
+      - name: Create .env file
+        run: |
+          cat > .env << 'EOF'
+          API_URL=/editor
+          CORS_ALLOW_LOCALHOST=true
+          TRANSLATIONS_ENABLED=true
+          UI_ACCESS_TOKEN_ENABLED=false
+          UPLOAD_LIMIT=250000000
+
+          PORT=8000
+          PREVIEW_PORT=8002
+          EDITOR_URL=http://localhost:8000
+          PREVIEW_URL=http://localhost:8002
+
+          MONGO_URL=mongodb://localhost:27017/p5js-web-editor
+
+          SESSION_SECRET=ci-session-secret
+          EMAIL_VERIFY_SECRET_TOKEN=ci-verify-token
+
+          # These accounts are used by the app to serve examples.
+          # Real values not needed for E2E tests — dummy strings prevent crashes.
+          EMAIL_SENDER=ci@example.com
+          EXAMPLE_USER_EMAIL=examples@p5js.org
+          EXAMPLE_USER_PASSWORD=hellop5js
+          GG_EXAMPLES_USERNAME=generativedesign
+          GG_EXAMPLES_EMAIL=benedikt.gross@generative-gestaltung.de
+          GG_EXAMPLES_PASS=generativedesign
+          ML5_LIBRARY_USERNAME=ml5
+          ML5_LIBRARY_EMAIL=examples@ml5js.org
+          ML5_LIBRARY_PASS=helloml5
+
+          # Mailgun — non-empty string required to pass the startup check in
+          # server/utils/mail.ts. No emails are sent during E2E tests.
+          MAILGUN_KEY=dummy-mailgun-key
+          MAILGUN_DOMAIN=dummy.mailgun.org
+
+          # AWS S3 — non-empty strings required. No file uploads in E2E tests.
+          AWS_ACCESS_KEY=dummy-aws-access-key
+          AWS_SECRET_KEY=dummy-aws-secret-key
+          AWS_REGION=us-east-1
+          S3_BUCKET=dummy-bucket
+          S3_BUCKET_URL_BASE=https://dummy-bucket.s3.amazonaws.com
+
+          # GitHub OAuth — not tested in E2E suite, dummy values prevent crash.
+          GITHUB_ID=dummy-github-id
+          GITHUB_SECRET=dummy-github-secret
+
+          # Google OAuth — not tested in E2E suite, dummy values prevent crash.
+          GOOGLE_ID=dummy-google-id
+          GOOGLE_SECRET=dummy-google-secret
+          EOF
+
+      - name: Install dependencies
+        run: npm install
+
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
+
       - name: Start the app
         run: npm run start &
-        env:
-          NODE_ENV: test
+
       - name: Wait for app to be ready
-        run: npx wait-on http://localhost:8000 --timeout 60000
+        run: |
+          for i in $(seq 1 120); do
+            if curl -sf http://localhost:8000 | grep -q "p5"; then
+              echo "App fully ready"
+              exit 0
+            fi
+
+            echo "Still bundling... $i/120"
+            sleep 5
+          done
+
+          echo "App did not become ready"
+          exit 1
+
       - name: Run E2E tests
-        run: npx playwright test
+        run: npx playwright test --config=playwright.config.ts
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   e2e:
     name: End-to-end tests
+    environment: e2e-tests
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -78,7 +78,7 @@ jobs:
           EOF
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,27 @@
+name: E2E Tests
+on:
+  pull_request:
+    branches:
+      - develop
+
+jobs:
+  e2e:
+    name: End-to-end tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: '18.20.x'
+      - run: npm install
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+      - name: Start the app
+        run: npm run start &
+        env:
+          NODE_ENV: test
+      - name: Wait for app to be ready
+        run: npx wait-on http://localhost:8000 --timeout 60000
+      - name: Run E2E tests
+        run: npx playwright test

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,67 +1,80 @@
-name: E2E Tests
-
+name: E2E Testing
 on:
+  workflow_dispatch:
   pull_request:
-    branches:
-      - develop
-
+    branches: [develop]
+  issue_comment:
+    types: [created]
 jobs:
-  e2e:
-    name: End-to-end tests
-    environment: e2e-tests
+  test-e2e:
+    if: >
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'pull_request' ||
+      (
+        github.event.issue.pull_request &&
+        github.event.comment.body == '/e2e' &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
+      )
+    timeout-minutes: 60
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+    - name: Resolve PR head ref
+      if: github.event_name == 'issue_comment'
+      id: pr
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const { data: pr } = await github.rest.pulls.get({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          });
+          core.setOutput('sha', pr.head.sha);
 
-      - name: Use Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18.20.x'
-          cache: 'npm'
+    - name: Checkout code
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event_name == 'issue_comment' && steps.pr.outputs.sha || github.ref }}
 
-      - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1.10.0
-        with:
-          mongodb-version: '6.0'
+    - name: Set up node
+      uses: actions/setup-node@v4
+      with:
+        node-version: '18.20.x'
 
-      - name: Create .env file
-        run: cp .env.e2e .env
+    - name: Create .env file
+      run: cp .env.e2e .env
 
-      - name: Install dependencies
-        run: npm ci
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.10.0
+      with:
+        mongodb-version: '6.0'
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+    - name: Install dependencies
+      run: npm ci
 
-      - name: Start the app
-        run: npm run start &
+    - name: Install Playwright Browsers
+      run: npx playwright install --with-deps chromium
 
-      - name: Wait for app to be ready
-        run: |
-          for i in $(seq 1 120); do
-            if curl -sf http://localhost:8000 | grep -q "p5"; then
-              echo "App fully ready"
-              exit 0
-            fi
+    - name: Start app
+      run: npm start > app.log 2>&1 &
 
-            echo "Still bundling... $i/120"
-            sleep 5
-          done
-
-          echo "App did not become ready"
+    - name: Wait for app to be ready
+      run: |
+        npx wait-on@7 http://localhost:8000 --timeout 180000 || {
+          echo "::error::App failed to become ready at http://localhost:8000 within 180s"
+          echo "----- app.log -----"
+          cat app.log
           exit 1
+        }
 
-      - name: Run E2E tests
-        run: npm run e2e:ci
-        env:
-          CI: true
-
-      - name: Upload Playwright report on failure
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 7
-
+    - name: Run Playwright tests
+      run: npm run e2e:ci
+      
+    - name: Upload artifacts
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: playwright-report
+        path: playwright-report/
+        retention-days: 30

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -26,56 +26,7 @@ jobs:
           mongodb-version: '6.0'
 
       - name: Create .env file
-        run: |
-          cat > .env << 'EOF'
-          API_URL=/editor
-          CORS_ALLOW_LOCALHOST=true
-          TRANSLATIONS_ENABLED=true
-          UI_ACCESS_TOKEN_ENABLED=false
-          UPLOAD_LIMIT=250000000
-
-          PORT=8000
-          PREVIEW_PORT=8002
-          EDITOR_URL=http://localhost:8000
-          PREVIEW_URL=http://localhost:8002
-
-          MONGO_URL=mongodb://localhost:27017/p5js-web-editor
-
-          SESSION_SECRET=ci-session-secret
-          EMAIL_VERIFY_SECRET_TOKEN=ci-verify-token
-
-          # These accounts are used by the app to serve examples.
-          # Real values not needed for E2E tests — dummy strings prevent crashes.
-          EMAIL_SENDER=ci@example.com
-          EXAMPLE_USER_EMAIL=examples@p5js.org
-          EXAMPLE_USER_PASSWORD=hellop5js
-          GG_EXAMPLES_USERNAME=generativedesign
-          GG_EXAMPLES_EMAIL=benedikt.gross@generative-gestaltung.de
-          GG_EXAMPLES_PASS=generativedesign
-          ML5_LIBRARY_USERNAME=ml5
-          ML5_LIBRARY_EMAIL=examples@ml5js.org
-          ML5_LIBRARY_PASS=helloml5
-
-          # Mailgun — non-empty string required to pass the startup check in
-          # server/utils/mail.ts. No emails are sent during E2E tests.
-          MAILGUN_KEY=dummy-mailgun-key
-          MAILGUN_DOMAIN=dummy.mailgun.org
-
-          # AWS S3 — non-empty strings required. No file uploads in E2E tests.
-          AWS_ACCESS_KEY=dummy-aws-access-key
-          AWS_SECRET_KEY=dummy-aws-secret-key
-          AWS_REGION=us-east-1
-          S3_BUCKET=dummy-bucket
-          S3_BUCKET_URL_BASE=https://dummy-bucket.s3.amazonaws.com
-
-          # GitHub OAuth — not tested in E2E suite, dummy values prevent crash.
-          GITHUB_ID=dummy-github-id
-          GITHUB_SECRET=dummy-github-secret
-
-          # Google OAuth — not tested in E2E suite, dummy values prevent crash.
-          GOOGLE_ID=dummy-google-id
-          GOOGLE_SECRET=dummy-google-secret
-          EOF
+        run: cp .env.e2e .env
 
       - name: Install dependencies
         run: npm ci
@@ -102,7 +53,9 @@ jobs:
           exit 1
 
       - name: Run E2E tests
-        run: npx playwright test --config=playwright.config.ts
+        run: npm run e2e:ci
+        env:
+          CI: true
 
       - name: Upload Playwright report on failure
         if: failure()
@@ -111,3 +64,4 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ localhost.key
 privkey.pem
 terraform/.terraform/
 
+# Playwright
+test-results/
+playwright-report/
+.playwright/
+
 storybook-static
 duplicates.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -147,6 +147,7 @@
         "@babel/preset-env": "^7.14.7",
         "@babel/preset-react": "^7.14.5",
         "@babel/preset-typescript": "^7.27.1",
+        "@playwright/test": "^1.60.0",
         "@storybook/addon-actions": "^7.6.8",
         "@storybook/addon-docs": "^7.6.8",
         "@storybook/addon-essentials": "^7.6.8",
@@ -7858,6 +7859,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -30296,6 +30313,38 @@
         "node": ">=6"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/please-upgrade-node": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
@@ -42290,6 +42339,15 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "dev": true,
       "optional": true
+    },
+    "@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "requires": {
+        "playwright": "1.60.0"
+      }
     },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.11",
@@ -58550,6 +58608,22 @@
       "requires": {
         "find-up": "^3.0.0"
       }
+    },
+    "playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.60.0"
+      }
+    },
+    "playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true
     },
     "please-upgrade-node": {
       "version": "3.2.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "test": "NODE_ENV=test jest",
     "test:watch": "NODE_ENV=test jest --watch",
     "test:ci": "npm run lint && npm run test",
+    "e2e": "playwright test --headed", 
+    "e2e:ci": "playwright test", 
     "fetch-examples": "cross-env NODE_ENV=development node ./server/scripts/fetch-examples.js",
     "fetch-examples-gg": "cross-env NODE_ENV=development node ./server/scripts/fetch-examples-gg.js",
     "fetch-examples-ml5": "cross-env NODE_ENV=development node ./server/scripts/fetch-examples-ml5.js",

--- a/package.json
+++ b/package.json
@@ -121,6 +121,7 @@
     "@babel/preset-env": "^7.14.7",
     "@babel/preset-react": "^7.14.5",
     "@babel/preset-typescript": "^7.27.1",
+    "@playwright/test": "^1.60.0",
     "@storybook/addon-actions": "^7.6.8",
     "@storybook/addon-docs": "^7.6.8",
     "@storybook/addon-essentials": "^7.6.8",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './tests/playwright',
   testMatch: '**/*.spec.ts',
-  timeout: 30000,
+ timeout: 120_000,
 
   use: {
     baseURL: 'http://localhost:8000',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/playwright',
+  testMatch: '**/*.spec.ts',
+  timeout: 30000,
+
+  use: {
+    baseURL: 'http://localhost:8000',
+    headless: true,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ]
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './tests/playwright',
   testMatch: '**/*.spec.ts',
-  timeout: 120_000,
+  timeout: 300_000,
 
   use: {
     baseURL: 'http://localhost:8000'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './tests/playwright',
   testMatch: '**/*.spec.ts',
-  timeout: 300_000,
+  timeout: 600_000,
 
   use: {
     baseURL: 'http://localhost:8000'

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,7 +3,7 @@ import { defineConfig, devices } from '@playwright/test';
 export default defineConfig({
   testDir: './tests/playwright',
   testMatch: '**/*.spec.ts',
- timeout: 120_000,
+  timeout: 120_000,
 
   use: {
     baseURL: 'http://localhost:8000',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,9 +6,9 @@ export default defineConfig({
   timeout: 120_000,
 
   use: {
-    baseURL: 'http://localhost:8000',
-    headless: true,
+    baseURL: 'http://localhost:8000'
   },
+
   projects: [
     {
       name: 'chromium',

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -36,8 +36,8 @@ test.describe('p5.js Editor – Playwright E2E', () => {
       '}'
     ].join(''); // Avoid newlines to prevent autocomplete from inserting unnecessary brackets
 
-    await page.click('.CodeMirror-code', { force: true });
-
+    const editor = page.locator('.editor-holder');
+    await editor.click();
     await page.keyboard.press('ControlOrMeta+A');
     await page.keyboard.type(newCode, { delay: 5 });
 

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -32,50 +32,15 @@ test.describe('p5.js Editor – Playwright E2E', () => {
       "  console.log('hi from sketch');",
       '  noLoop();',
       '}'
-    ].join('\n');
+    ].join(''); // Avoid newlines to prevent autocomplete from inserting unnecessary brackets
 
     // Wait for CodeMirror to be ready
-    await page.waitForFunction(
-      () => {
-        const wrapper = document.querySelector('.CodeMirror') as any;
-        return (wrapper?.CodeMirror?.getValue?.() ?? '').length > 0;
-      },
-      { timeout: 30_000 }
-    );
+    const editor = page.locator('.CodeMirror');
+    await expect(editor).toBeVisible({ timeout: 30_000 });
+    await editor.click();
 
-    // Update code via CodeMirror API + Redux dispatch
-    // (confirmed working approach from earlier diagnostic work)
-    await page.evaluate((code) => {
-      const cm = (document.querySelector('.CodeMirror') as any).CodeMirror;
-      cm.setValue(code);
-      cm.refresh();
-
-      const root = document.querySelector('#root') as any;
-      const fiberKey = Object.keys(root).find((k) =>
-        k.startsWith('__reactContainer')
-      );
-      let node = root[fiberKey];
-      let store: any = null;
-      while (node) {
-        if (node.memoizedProps?.store) {
-          store = node.memoizedProps.store;
-          break;
-        }
-        node = node.child;
-      }
-      if (!store) throw new Error('Redux store not found');
-
-      const selectedFile = store
-        .getState()
-        .files.find((f: any) => f.isSelectedFile);
-      if (!selectedFile) throw new Error('No selected file');
-
-      store.dispatch({
-        type: 'UPDATE_FILE_CONTENT',
-        id: selectedFile.id,
-        content: code
-      });
-    }, newCode);
+    await page.keyboard.press('Control+A');
+    await page.keyboard.type(newCode, { delay: 5 });
 
     await page.waitForTimeout(500);
 

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, Page } from '@playwright/test';
+
+async function dismissCookies(page: Page) {
+  try {
+    await page.waitForSelector('button', { timeout: 3_000 });
+    await page.evaluate(() => {
+      const btn = Array.from(document.querySelectorAll('button')).find((b) =>
+        /allow all|allow essential/i.test(b.textContent ?? '')
+      ) as HTMLElement | undefined;
+      btn?.click();
+    });
+    await page.waitForTimeout(400);
+  } catch {
+    /* no banner */
+  }
+}
+
+test.describe('p5.js Editor – Playwright E2E', () => {
+  test('editor loads and has a sketch iframe', async ({ page }) => {
+    await page.goto('http://localhost:8000', {
+      waitUntil: 'domcontentloaded',
+      timeout: 30_000
+    });
+    await dismissCookies(page);
+    await page.evaluate(() => {
+      (document.querySelector(
+        '[aria-label="Play sketch"]'
+      ) as HTMLElement)?.click();
+    });
+    const iframeHandle = await page.waitForSelector('iframe', {
+      timeout: 15_000
+    });
+    expect(iframeHandle).toBeTruthy();
+  });
+
+  test('can access iframe content frame', async ({ page }) => {
+    await page.goto('http://localhost:8000');
+    await dismissCookies(page);
+    await page.waitForSelector('iframe');
+    const body = page.frameLocator('iframe').first().locator('body');
+    await expect(body).toBeAttached({ timeout: 10_000 });
+  });
+
+  test('run button triggers sketch in iframe', async ({ page }) => {
+    await page.goto('http://localhost:8000');
+    await dismissCookies(page);
+    await page.evaluate(() => {
+      (document.querySelector(
+        '[aria-label="Play sketch"]'
+      ) as HTMLElement)?.click();
+    });
+    await page.waitForSelector('iframe', { timeout: 10_000 });
+    const iframeSrc = await page.locator('iframe').getAttribute('src');
+    console.log('iframe src:', iframeSrc);
+    expect(iframeSrc).toBeTruthy();
+    await expect(page.locator('iframe')).toBeVisible({ timeout: 10_000 });
+  });
+
+  test.skip('sketch execution via postMessage', async () => {
+    // FINDING: postMessage interception via page.evaluate() returns empty.
+    // The sketch iframe (localhost:8002) sends messages via window.parent.parent
+    // but these do not surface in Playwright's main page context.
+    // Testing sketch output would require CDP or a dedicated message relay
+    // — a candidate for GSoC implementation.
+  });
+
+  test('sketch console.log appears in editor console', async ({ page }) => {
+    await page.goto('http://localhost:8000');
+
+    await dismissCookies(page);
+
+    await page.waitForFunction(() => {
+      const wrapper = document.querySelector('.CodeMirror') as any;
+      return !!wrapper?.CodeMirror;
+    });
+
+    await page.evaluate(
+      (newCode) => {
+        const cm = (document.querySelector('.CodeMirror') as any)?.CodeMirror;
+
+        if (!cm) {
+          throw new Error('CodeMirror not found');
+        }
+
+        cm.setValue(newCode);
+        cm.refresh();
+
+        const root = document.querySelector('#root') as any;
+
+        const fiberKey = Object.keys(root).find((k) =>
+          k.startsWith('__reactContainer')
+        );
+
+        let node = root[fiberKey];
+        let store: any = null;
+
+        while (node) {
+          if (node.memoizedProps?.store) {
+            store = node.memoizedProps.store;
+            break;
+          }
+
+          node = node.child;
+        }
+
+        if (!store) {
+          throw new Error('Redux store not found');
+        }
+
+        const selectedFile = store
+          .getState()
+          .files.find((f: any) => f.isSelectedFile);
+
+        if (!selectedFile) {
+          throw new Error('Selected file not found');
+        }
+
+        store.dispatch({
+          type: 'UPDATE_FILE_CONTENT',
+          id: selectedFile.id,
+          content: newCode
+        });
+      },
+      `
+function setup() {
+  createCanvas(400, 400);
+}
+
+function draw() {
+  background(220);
+  console.log('hi from sketch');
+  noLoop();
+}
+`
+    );
+
+    await page.waitForTimeout(1000);
+
+    await page.locator('#play-sketch').click();
+
+    const openConsoleButton = page.locator('[aria-label="Open console"]');
+
+    if (await openConsoleButton.isVisible()) {
+      await openConsoleButton.click();
+    }
+
+    await expect
+      .poll(() => page.locator('.preview-console__messages').textContent(), {
+        timeout: 15000
+      })
+      .toContain('hi from sketch');
+  });
+});

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -5,7 +5,7 @@ test.describe('p5.js Editor – Playwright E2E', () => {
     await page.goto('/');
 
     // Wait for the page to be interactive before checking for the banner
-    await page.waitForSelector('.CodeMirror', { timeout: 30_000 });
+    await page.waitForSelector('.CodeMirror', { timeout: 180_000 });
 
     // Dismiss cookie banner via JS — handles the case where the button
     // is outside the viewport due to the Redux DevTools sidebar
@@ -35,14 +35,11 @@ test.describe('p5.js Editor – Playwright E2E', () => {
     ].join(''); // Avoid newlines to prevent autocomplete from inserting unnecessary brackets
 
     // Wait for CodeMirror to be ready
-    const editor = page.locator('.CodeMirror');
-    await expect(editor).toBeVisible({ timeout: 30_000 });
-    await editor.click();
+    await expect(page.locator('.CodeMirror')).toBeVisible({ timeout: 30_000 });
+    await page.click('.CodeMirror-code', { force: true });
 
     await page.keyboard.press('Control+A');
     await page.keyboard.type(newCode, { delay: 5 });
-
-    await page.waitForTimeout(500);
 
     // Click Play
     await page.locator('#play-sketch').click();

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -1,153 +1,105 @@
-import { test, expect, Page } from '@playwright/test';
+import { test, expect } from '@playwright/test';
 
-async function dismissCookies(page: Page) {
-  try {
-    await page.waitForSelector('button', { timeout: 3_000 });
+test.describe('p5.js Editor – Playwright E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+
+    // Wait for the page to be interactive before checking for the banner
+    await page.waitForSelector('.CodeMirror', { timeout: 30_000 });
+
+    // Dismiss cookie banner via JS — handles the case where the button
+    // is outside the viewport due to the Redux DevTools sidebar
     await page.evaluate(() => {
       const btn = Array.from(document.querySelectorAll('button')).find((b) =>
-        /allow all|allow essential/i.test(b.textContent ?? '')
+        /allow essential|allow all/i.test(b.textContent ?? '')
       ) as HTMLElement | undefined;
       btn?.click();
     });
+
     await page.waitForTimeout(400);
-  } catch {
-    /* no banner */
-  }
-}
-
-test.describe('p5.js Editor – Playwright E2E', () => {
-  test('editor loads and has a sketch iframe', async ({ page }) => {
-    await page.goto('http://localhost:8000', {
-      waitUntil: 'domcontentloaded',
-      timeout: 30_000
-    });
-    await dismissCookies(page);
-    await page.evaluate(() => {
-      (document.querySelector(
-        '[aria-label="Play sketch"]'
-      ) as HTMLElement)?.click();
-    });
-    const iframeHandle = await page.waitForSelector('iframe', {
-      timeout: 15_000
-    });
-    expect(iframeHandle).toBeTruthy();
   });
 
-  test('can access iframe content frame', async ({ page }) => {
-    await page.goto('http://localhost:8000');
-    await dismissCookies(page);
-    await page.waitForSelector('iframe');
-    const body = page.frameLocator('iframe').first().locator('body');
-    await expect(body).toBeAttached({ timeout: 10_000 });
-  });
+  test('can execute code from the editor by clicking the Play button', async ({
+    page
+  }) => {
+    const newCode = [
+      'function setup() {',
+      '  createCanvas(400, 400);',
+      '}',
+      '',
+      'function draw() {',
+      '  background(220);',
+      "  console.log('hi from sketch');",
+      '  noLoop();',
+      '}'
+    ].join('\n');
 
-  test('run button triggers sketch in iframe', async ({ page }) => {
-    await page.goto('http://localhost:8000');
-    await dismissCookies(page);
-    await page.evaluate(() => {
-      (document.querySelector(
-        '[aria-label="Play sketch"]'
-      ) as HTMLElement)?.click();
-    });
-    await page.waitForSelector('iframe', { timeout: 10_000 });
-    const iframeSrc = await page.locator('iframe').getAttribute('src');
-    console.log('iframe src:', iframeSrc);
-    expect(iframeSrc).toBeTruthy();
-    await expect(page.locator('iframe')).toBeVisible({ timeout: 10_000 });
-  });
-
-  test.skip('sketch execution via postMessage', async () => {
-    // FINDING: postMessage interception via page.evaluate() returns empty.
-    // The sketch iframe (localhost:8002) sends messages via window.parent.parent
-    // but these do not surface in Playwright's main page context.
-    // Testing sketch output would require CDP or a dedicated message relay
-    // — a candidate for GSoC implementation.
-  });
-
-  test('sketch console.log appears in editor console', async ({ page }) => {
-    await page.goto('http://localhost:8000');
-
-    await dismissCookies(page);
-
-    await page.waitForFunction(() => {
-      const wrapper = document.querySelector('.CodeMirror') as any;
-      return !!wrapper?.CodeMirror;
-    });
-
-    await page.evaluate(
-      (newCode) => {
-        const cm = (document.querySelector('.CodeMirror') as any)?.CodeMirror;
-
-        if (!cm) {
-          throw new Error('CodeMirror not found');
-        }
-
-        cm.setValue(newCode);
-        cm.refresh();
-
-        const root = document.querySelector('#root') as any;
-
-        const fiberKey = Object.keys(root).find((k) =>
-          k.startsWith('__reactContainer')
-        );
-
-        let node = root[fiberKey];
-        let store: any = null;
-
-        while (node) {
-          if (node.memoizedProps?.store) {
-            store = node.memoizedProps.store;
-            break;
-          }
-
-          node = node.child;
-        }
-
-        if (!store) {
-          throw new Error('Redux store not found');
-        }
-
-        const selectedFile = store
-          .getState()
-          .files.find((f: any) => f.isSelectedFile);
-
-        if (!selectedFile) {
-          throw new Error('Selected file not found');
-        }
-
-        store.dispatch({
-          type: 'UPDATE_FILE_CONTENT',
-          id: selectedFile.id,
-          content: newCode
-        });
+    // Wait for CodeMirror to be ready
+    await page.waitForFunction(
+      () => {
+        const wrapper = document.querySelector('.CodeMirror') as any;
+        return (wrapper?.CodeMirror?.getValue?.() ?? '').length > 0;
       },
-      `
-function setup() {
-  createCanvas(400, 400);
-}
-
-function draw() {
-  background(220);
-  console.log('hi from sketch');
-  noLoop();
-}
-`
+      { timeout: 30_000 }
     );
 
-    await page.waitForTimeout(1000);
+    // Update code via CodeMirror API + Redux dispatch
+    // (confirmed working approach from earlier diagnostic work)
+    await page.evaluate((code) => {
+      const cm = (document.querySelector('.CodeMirror') as any).CodeMirror;
+      cm.setValue(code);
+      cm.refresh();
 
+      const root = document.querySelector('#root') as any;
+      const fiberKey = Object.keys(root).find((k) =>
+        k.startsWith('__reactContainer')
+      );
+      let node = root[fiberKey];
+      let store: any = null;
+      while (node) {
+        if (node.memoizedProps?.store) {
+          store = node.memoizedProps.store;
+          break;
+        }
+        node = node.child;
+      }
+      if (!store) throw new Error('Redux store not found');
+
+      const selectedFile = store
+        .getState()
+        .files.find((f: any) => f.isSelectedFile);
+      if (!selectedFile) throw new Error('No selected file');
+
+      store.dispatch({
+        type: 'UPDATE_FILE_CONTENT',
+        id: selectedFile.id,
+        content: code
+      });
+    }, newCode);
+
+    await page.waitForTimeout(500);
+
+    // Click Play
     await page.locator('#play-sketch').click();
 
-    const openConsoleButton = page.locator('[aria-label="Open console"]');
+    // Wait for the sketch iframe to confirm the sketch actually started
+    await page.waitForFunction(
+      () =>
+        Array.from(document.querySelectorAll('iframe')).some((f) =>
+          (f as HTMLIFrameElement).src.includes('8002')
+        ),
+      { timeout: 10_000 }
+    );
 
-    if (await openConsoleButton.isVisible()) {
-      await openConsoleButton.click();
+    // Open console if collapsed
+    const openConsole = page.getByLabel('Open console');
+    if (await openConsole.isVisible().catch(() => false)) {
+      await openConsole.click();
     }
 
-    await expect
-      .poll(() => page.locator('.preview-console__messages').textContent(), {
-        timeout: 15000
-      })
-      .toContain('hi from sketch');
+    // Assert console output
+    await expect(
+      page.locator('.preview-console__messages')
+    ).toContainText('hi from sketch', { timeout: 15_000 });
   });
 });

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -5,7 +5,7 @@ test.describe('p5.js Editor – Playwright E2E', () => {
     await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     // Wait for the page to be interactive before checking for the banner
-    await page.waitForSelector('.CodeMirror', { timeout: 180_000 });
+    await page.waitForSelector('.CodeMirror', { timeout: 600_000 });
 
     // Dismiss cookie banner via JS — handles the case where the button
     // is outside the viewport due to the Redux DevTools sidebar

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -36,13 +36,13 @@ test.describe('p5.js Editor – Playwright E2E', () => {
 
     // Wait for CodeMirror to be ready
     await expect(page.locator('.CodeMirror')).toBeVisible({ timeout: 30_000 });
-    await page.click('.CodeMirror-code', { force: true });
+    await page.click('.CodeMirror', { force: true });
 
-    await page.keyboard.press('Control+A');
+    await page.keyboard.press('Meta+A');
     await page.keyboard.type(newCode, { delay: 5 });
 
     // Click Play
-    await page.locator('#play-sketch').click();
+    await page.locator('#play-sketch').click({ force: true });
 
     // Wait for the sketch iframe to confirm the sketch actually started
     await page.waitForFunction(

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -2,10 +2,12 @@ import { test, expect } from '@playwright/test';
 
 test.describe('p5.js Editor – Playwright E2E', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await page.goto('/');
 
-    // Wait for the page to be interactive before checking for the banner
-    await page.waitForSelector('.CodeMirror', { timeout: 600_000 });
+    // Wait for app to fully render — skip link only appears after React mounts
+    await expect(
+      page.locator('a.skip_link[href="#play-sketch"]')
+    ).toHaveText('Skip to Play Sketch', { timeout: 60_000 });
 
     // Dismiss cookie banner via JS — handles the case where the button
     // is outside the viewport due to the Redux DevTools sidebar
@@ -34,7 +36,7 @@ test.describe('p5.js Editor – Playwright E2E', () => {
       '}'
     ].join(''); // Avoid newlines to prevent autocomplete from inserting unnecessary brackets
 
-    await page.waitForSelector('.CodeMirror-code', { timeout: 600_000 });
+    await page.waitForSelector('.CodeMirror-code', { timeout: 60_000 });
     await page.click('.CodeMirror-code', { force: true });
 
     await page.keyboard.press('ControlOrMeta+A');

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -34,9 +34,8 @@ test.describe('p5.js Editor – Playwright E2E', () => {
       '}'
     ].join(''); // Avoid newlines to prevent autocomplete from inserting unnecessary brackets
 
-    // Wait for CodeMirror to be ready
-    await expect(page.locator('.CodeMirror')).toBeVisible({ timeout: 30_000 });
-    await page.click('.CodeMirror', { force: true });
+    await page.waitForSelector('.CodeMirror-code', { timeout: 600_000 });
+    await page.click('.CodeMirror-code', { force: true });
 
     await page.keyboard.press('Meta+A');
     await page.keyboard.type(newCode, { delay: 5 });

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 
 test.describe('p5.js Editor – Playwright E2E', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
 
     // Wait for the page to be interactive before checking for the banner
     await page.waitForSelector('.CodeMirror', { timeout: 180_000 });

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -91,12 +91,6 @@ test.describe('p5.js Editor – Playwright E2E', () => {
       { timeout: 10_000 }
     );
 
-    // Open console if collapsed
-    const openConsole = page.getByLabel('Open console');
-    if (await openConsole.isVisible().catch(() => false)) {
-      await openConsole.click();
-    }
-
     // Assert console output
     await expect(
       page.locator('.preview-console__messages')

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -36,7 +36,6 @@ test.describe('p5.js Editor – Playwright E2E', () => {
       '}'
     ].join(''); // Avoid newlines to prevent autocomplete from inserting unnecessary brackets
 
-    await page.waitForSelector('.CodeMirror-code', { timeout: 60_000 });
     await page.click('.CodeMirror-code', { force: true });
 
     await page.keyboard.press('ControlOrMeta+A');

--- a/tests/playwright/editor.spec.ts
+++ b/tests/playwright/editor.spec.ts
@@ -38,7 +38,7 @@ test.describe('p5.js Editor – Playwright E2E', () => {
     await expect(page.locator('.CodeMirror')).toBeVisible({ timeout: 30_000 });
     await page.click('.CodeMirror-code', { force: true });
 
-    await page.keyboard.press('Control+A');
+    await page.keyboard.press('ControlOrMeta+A');
     await page.keyboard.type(newCode, { delay: 5 });
 
     // Click Play


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->

### Demo:



https://github.com/user-attachments/assets/36dc541b-8993-4478-a725-0514bc004fff





<!-- Please add a screenshot for UI related changes -->

### Changes:
This PR introduces an initial Playwright E2E testing setup for the p5.js Web Editor.

- Added Playwright configuration (playwright.config.ts)
- Added GitHub Actions workflow for Playwright E2E execution
- Added initial Playwright E2E tests covering:
- Sketch execution and console output validation
    - Populate CodeMirror via keyboard input
    - Run sketch through the Play button
    - Verify sketch startup and console output

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
