### PR TITLE
fix(client): validate file extension whitelist on rename

### DIFF
--- a/client/modules/IDE/components/FileNode.jsx
+++ b/client/modules/IDE/components/FileNode.jsx
@@ -7,6 +7,8 @@ import { useSelector } from 'react-redux';
 
 import * as IDEActions from '../actions/ide';
 import * as FileActions from '../actions/files';
+import { showToast as showToastAction } from '../actions/toast';
+import { CREATE_FILE_REGEX } from '../../../../server/utils/fileUtils';
 import DownArrowIcon from '../../../images/down-filled-triangle.svg';
 import FolderRightIcon from '../../../images/triangle-arrow-right.svg';
 import FolderDownIcon from '../../../images/triangle-arrow-down.svg';
@@ -82,7 +84,8 @@ const FileNode = ({
   canEdit,
   openUploadFileModal,
   authenticated,
-  onClickFile
+  onClickFile,
+  showToast
 }) => {
   const [isOptionsOpen, setIsOptionsOpen] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
@@ -195,6 +198,13 @@ const FileNode = ({
     const hasEmptyFilename = updatedName.trim() === '';
     const hasOnlyExtension =
       newFileExtension && updatedName.trim() === newFileExtension[0];
+
+    if (fileType === 'file' && !updatedName.match(CREATE_FILE_REGEX)) {
+      showToast(t('NewFileModal.InvalidType'));
+      setUpdatedName(currentName);
+      return;
+    }
+
     if (
       hasEmptyFilename ||
       hasNoExtension ||
@@ -412,7 +422,8 @@ FileNode.propTypes = {
   canEdit: PropTypes.bool.isRequired,
   openUploadFileModal: PropTypes.func.isRequired,
   authenticated: PropTypes.bool.isRequired,
-  onClickFile: PropTypes.func
+  onClickFile: PropTypes.func,
+  showToast: PropTypes.func.isRequired
 };
 
 FileNode.defaultProps = {
@@ -433,7 +444,11 @@ function mapStateToProps(state, ownProps) {
   });
 }
 
-const mapDispatchToProps = { ...FileActions, ...IDEActions };
+const mapDispatchToProps = {
+  ...FileActions,
+  ...IDEActions,
+  showToast: showToastAction
+};
 
 const ConnectedFileNode = connect(
   mapStateToProps,

--- a/client/modules/IDE/components/FileNode.unit.test.jsx
+++ b/client/modules/IDE/components/FileNode.unit.test.jsx
@@ -33,7 +33,7 @@ describe('<FileNode />', () => {
     const props = {
       ...extraProps,
       id: '0',
-      name: fileType === 'folder' ? 'afolder' : 'test.jsx',
+      name: fileType === 'folder' ? 'afolder' : 'test.js',
       fileType,
       canEdit: true,
       children: [],
@@ -48,7 +48,8 @@ describe('<FileNode />', () => {
       showFolderChildren: jest.fn(),
       hideFolderChildren: jest.fn(),
       openUploadFileModal: jest.fn(),
-      setProjectName: jest.fn()
+      setProjectName: jest.fn(),
+      showToast: jest.fn()
     };
 
     const mockFiles = [
@@ -100,7 +101,7 @@ describe('<FileNode />', () => {
     });
 
     it('can change to a valid filename', async () => {
-      const newName = 'newname.jsx';
+      const newName = 'newname.js';
       const props = renderFileNode('file');
 
       changeName(newName);
@@ -125,7 +126,7 @@ describe('<FileNode />', () => {
       const mockConfirm = jest.fn(() => true);
       window.confirm = mockConfirm;
 
-      const newName = 'newname.gif';
+      const newName = 'newname.json';
       const props = renderFileNode('file');
 
       changeName(newName);
@@ -137,8 +138,19 @@ describe('<FileNode />', () => {
       await expectFileNameToBe(props.name);
     });
 
+    it('cannot change to an invalid extension', async () => {
+      const newName = 'newname.obj';
+      const props = renderFileNode('file');
+
+      changeName(newName);
+
+      await waitFor(() => expect(props.updateFileName).not.toHaveBeenCalled());
+      expect(props.showToast).toHaveBeenCalled();
+      await expectFileNameToBe(props.name);
+    });
+
     it('cannot be just an extension', async () => {
-      const newName = '.jsx';
+      const newName = '.js';
       const props = renderFileNode('file');
 
       changeName(newName);
@@ -171,7 +183,7 @@ describe('<FileNode />', () => {
     });
 
     it('cannot have a file extension', async () => {
-      const newName = 'foldername.jsx';
+      const newName = 'foldername.js';
       const props = renderFileNode('folder');
 
       changeName(newName);


### PR DESCRIPTION
### Issue:
Fixes #4102

Currently, the p5.js Web Editor blocks invalid file extensions (such as `.obj`) during file creation via the file modal. However, it does not perform the same validation when renaming a file. This allows users to bypass the file extension whitelist entirely by creating a valid file (e.g., `test.js`) and then renaming it to an invalid extension (e.g., `test.obj`). 

This PR fixes the bypass by validating file extensions against the whitelist during the rename operation.

### Demo:
*(No complex UI layout modifications—it triggers the pre-existing toast error message when an invalid extension is supplied during rename, identical to the behavior in the file creation modal, and reverts the file to its previous valid name).*

### Changes:
- **FileNode.jsx**:
  - Imported `CREATE_FILE_REGEX` (from `server/utils/fileUtils.js`) and `showToast` (mapped as `showToastAction` to resolve ESLint `no-shadow` rules).
  - Destructured `showToast` in component props and declared it in `propTypes`.
  - Updated the `validateFileName` method to check that renaming a file matches `CREATE_FILE_REGEX`.
  - If the validation fails, it triggers `showToast` with the translation key `NewFileModal.InvalidType` and reverts the filename.
- **FileNode.unit.test.jsx**:
  - Mocked the `showToast` prop in the test setup.
  - Adjusted unit tests to use valid whitelisted extensions (`.js` and `.json`) for renaming scenarios.
  - Added a new unit test case `cannot change to an invalid extension` to verify that invalid renames are blocked and trigger `showToast`.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #4102`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
