### PR TITLE
Restore updateFileContent controller API in CodeMirror 6 editor

### DIFF
--- a/client/modules/IDE/components/Editor/codemirror.js
+++ b/client/modules/IDE/components/Editor/codemirror.js
@@ -229,12 +229,31 @@ export default function useCodeMirror({
     tidyCodeWithPrettier(cmView.current, fileMode);
   };
 
+  const updateEditorFileContent = (id, src) => {
+    const fileState = fileStates.current?.[id];
+
+    if (!fileState) return;
+
+    fileState.cmState = fileState.cmState.update({
+      changes: {
+        from: 0,
+        to: fileState.cmState.doc.length,
+        insert: src
+      }
+    }).state;
+
+    if (id === file.id) {
+      cmView.current.setState(fileState.cmState);
+    }
+  };
+
   return {
     setupCodeMirrorOnContainerMounted,
     teardownCodeMirror,
     getContent,
     tidyCode,
     showSearch,
+    updateEditorFileContent,
     codemirrorView: cmView
   };
 }

--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -101,7 +101,8 @@ function Editor({
     codemirrorView,
     getContent,
     tidyCode,
-    showSearch
+    showSearch,
+    updateEditorFileContent
   } = useCodeMirror({
     project,
     lineNumbers,
@@ -126,9 +127,10 @@ function Editor({
     provideController({
       tidyCode,
       getContent,
-      showSearch
+      showSearch,
+      updateFileContent: updateEditorFileContent
     });
-  }, [tidyCode, showSearch, getContent]);
+  }, [tidyCode, showSearch, getContent, updateEditorFileContent]);
 
   // When the CM container div mounts, we set up CodeMirror.
   const onContainerMounted = useCallback(setupCodeMirrorOnContainerMounted, []);


### PR DESCRIPTION
### Issue:

The CodeMirror 5 editor exposed an "updateFileContent" method through the editor controller. During the CodeMirror 6 migration this method was not carried over, causing calls to "cmRef.current.updateFileContent(...)" to fail.

This affects features that programmatically update "index.html", including the p5.js version selector and loop protection toggle. 

### Changes:

- Reintroduced "updateFileContent" in the CodeMirror 6 editor controller.
- Restored parity with the previous CodeMirror 5 controller API.

I have verified that this pull request:

* [ ] has no linting errors ("npm run lint")
* [ ] has no test errors ("npm run test")
* [ ] has no typecheck errors ("npm run typecheck")
* [ ] is from a uniquely-named feature branch and is up to date with the "develop" branch.
* [ ] is descriptively named and links to an issue number, i.e. "Fixes #123"
* [ ] meets the standards outlined in the accessibility guidelines