### PR TITLE
Enable Autocomplete Hinter by Default

### DIFF
--- a/client/modules/IDE/components/Editor/utils/fileState.test.js
+++ b/client/modules/IDE/components/Editor/utils/fileState.test.js
@@ -7,7 +7,7 @@ import { createNewFileState, getFileMode } from './fileState';
 const defaultSettings = {
   linewrap: false,
   lineNumbers: false,
-  autocomplete: false,
+  autocomplete: true,
   autocloseBracketsQuotes: false,
   onUpdateLinting: () => {},
   onViewUpdate: () => {},
@@ -69,7 +69,7 @@ describe('createNewFileState - Settings', () => {
     const settings = {
       linewrap: true,
       lineNumbers: true,
-      autocomplete: false,
+      autocomplete: true,
       autocloseBracketsQuotes: false,
       onUpdateLinting: jest.fn(),
       onViewUpdate: jest.fn()
@@ -90,7 +90,7 @@ describe('createNewFileState - Settings', () => {
     const settings = {
       linewrap: false,
       lineNumbers: true,
-      autocomplete: false,
+      autocomplete: true,
       autocloseBracketsQuotes: false,
       onUpdateLinting: jest.fn(),
       onViewUpdate: jest.fn()
@@ -111,7 +111,7 @@ describe('createNewFileState - Settings', () => {
     const settings = {
       linewrap: false,
       lineNumbers: true,
-      autocomplete: false,
+      autocomplete: true,
       autocloseBracketsQuotes: false,
       onUpdateLinting: jest.fn(),
       onViewUpdate: jest.fn()
@@ -132,7 +132,7 @@ describe('createNewFileState - Settings', () => {
     const settings = {
       linewrap: false,
       lineNumbers: false,
-      autocomplete: false,
+      autocomplete: true,
       autocloseBracketsQuotes: false,
       onUpdateLinting: jest.fn(),
       onViewUpdate: jest.fn()
@@ -153,7 +153,7 @@ describe('createNewFileState - Settings', () => {
     const settings = {
       linewrap: false,
       lineNumbers: false,
-      autocomplete: false,
+      autocomplete: true,
       autocloseBracketsQuotes: true,
       onUpdateLinting: jest.fn(),
       onViewUpdate: jest.fn()
@@ -172,7 +172,7 @@ describe('createNewFileState - Settings', () => {
     const settings = {
       linewrap: false,
       lineNumbers: false,
-      autocomplete: false,
+      autocomplete: true,
       autocloseBracketsQuotes: false,
       onUpdateLinting: jest.fn(),
       onViewUpdate: jest.fn()

--- a/client/modules/IDE/reducers/preferences.ts
+++ b/client/modules/IDE/reducers/preferences.ts
@@ -24,7 +24,7 @@ export const initialState: PreferencesState = {
   autorefresh: false,
   language: i18n.language,
   autocloseBracketsQuotes: true,
-  autocompleteHinter: false
+  autocompleteHinter: true
 };
 
 export const preferences = (

--- a/client/testData/testServerResponses.js
+++ b/client/testData/testServerResponses.js
@@ -19,7 +19,7 @@ export const userResponse = {
     autorefresh: false,
     language: 'en-US',
     autocloseBracketsQuotes: true,
-    autocompleteHinter: false
+    autocompleteHinter: true
   },
   apiKeys: [],
   verified: 'verified',


### PR DESCRIPTION
### Issue:
Fixes #4099 
Changes the default autocompleteHinter preference from false to true.
This only affects users who have never modified the setting. Existing users who have explicitly enabled or disabled autocomplete will retain their stored preference.

### Changes:
- Set autocompleteHinter default value to true in the preferences.
- Updated preference tests to reflect the new default state.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
