### PR TITLE
fix switching p5.js version deactivates syntax highlighting

### DIFF
--- a/client/modules/IDE/components/Editor/codemirror.js
+++ b/client/modules/IDE/components/Editor/codemirror.js
@@ -168,7 +168,7 @@ export default function useCodeMirror({
   }, [autocompleteHinter, referenceBaseUrl]);
   useEffect(() => {
     const reconfigureEffect = (fileState) => {
-      const fileMode = getFileMode(file.name);
+      const fileMode = getFileMode(fileState.filename);
 
       if (fileMode !== 'javascript') {
         return [];

--- a/client/modules/IDE/components/Editor/codemirror.js
+++ b/client/modules/IDE/components/Editor/codemirror.js
@@ -170,7 +170,7 @@ export default function useCodeMirror({
     const reconfigureEffect = (fileState) => {
       const fileMode = getFileMode(file.name);
 
-      if (fileMode !== 'javascript' && !p5Version) {
+      if (fileMode !== 'javascript') {
         return [];
       }
 

--- a/client/modules/IDE/components/Editor/codemirror.js
+++ b/client/modules/IDE/components/Editor/codemirror.js
@@ -167,10 +167,15 @@ export default function useCodeMirror({
     });
   }, [autocompleteHinter, referenceBaseUrl]);
   useEffect(() => {
-    const reconfigureEffect = (fileState) =>
-      fileState.languageCpt.reconfigure(
-        p5Version ? p5JavaScript(p5Version) : []
-      );
+    const reconfigureEffect = (fileState) => {
+      const fileMode = getFileMode(file.name);
+
+      if (fileMode !== 'javascript' && !p5Version) {
+        return [];
+      }
+
+      return fileState.languageCpt.reconfigure(p5JavaScript(p5Version));
+    };
 
     updateFileStates({
       fileStates: fileStates.current,

--- a/client/modules/IDE/components/Editor/codemirror.js
+++ b/client/modules/IDE/components/Editor/codemirror.js
@@ -169,7 +169,7 @@ export default function useCodeMirror({
   useEffect(() => {
     const reconfigureEffect = (fileState) =>
       fileState.languageCpt.reconfigure(
-        autocompleteHinter ? p5JavaScript(p5Version) : []
+        p5Version ? p5JavaScript(p5Version) : []
       );
 
     updateFileStates({

--- a/client/modules/IDE/components/Editor/utils/fileState.js
+++ b/client/modules/IDE/components/Editor/utils/fileState.js
@@ -247,6 +247,7 @@ export function createNewFileState(filename, document, settings) {
   const cmState = EditorState.create(stateOptions);
   return {
     cmState,
+    filename,
     lineNumbersCpt,
     lineWrappingCpt,
     closeBracketsCpt,


### PR DESCRIPTION
### Issue:
Fixes #4191

my bad. i was checking for autocompleteHinter instead of p5Version earlier to configure the language, which also includes highlighting.

as a result, the highlight didn't work when switching versions if autocomplete was off.