### PR TITLE
Banner for p5.js v2.0 Default Announcement

### DIFF
--- a/client/modules/IDE/components/Banner.jsx
+++ b/client/modules/IDE/components/Banner.jsx
@@ -24,7 +24,7 @@ import { CrossIcon } from '../../../common/icons';
 
 const Banner = ({ onClose }) => {
   // URL can be updated depending on the opportunity or announcement.
-  const bannerURL = 'https://processingfoundation.org/donate';
+  const bannerURL = 'https://github.com/processing/p5.js/issues/8870';
 
   // currently holds donation copy, will switch back when temp maintenance is done
   const bannerCopy = (

--- a/client/modules/IDE/pages/IDEView.jsx
+++ b/client/modules/IDE/pages/IDEView.jsx
@@ -120,7 +120,7 @@ const IDEView = () => {
   const [sidebarSize, setSidebarSize] = useState(160);
   const [isOverlayVisible, setIsOverlayVisible] = useState(false);
   const [MaxSize, setMaxSize] = useState(window.innerWidth);
-  const [displayBanner, setDisplayBanner] = useState(false); // set to true if in use
+  const [displayBanner, setDisplayBanner] = useState(true); // set to true if in use
 
   const cmRef = useRef({});
 
@@ -216,12 +216,12 @@ const IDEView = () => {
     const lastClosedAt = stored ? Number(stored) : null;
 
     if (!lastClosedAt) {
-      setDisplayBanner(false); // set to true if in use
+      setDisplayBanner(true); // set to true if in use
       return;
     }
 
     if (minutesSince(lastClosedAt) >= BANNER_COOLDOWN_MINUTES) {
-      setDisplayBanner(false); // set to true if in use
+      setDisplayBanner(true); // set to true if in use
     } else {
       setDisplayBanner(false);
     }

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -56,7 +56,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Toggle Replace",

--- a/translations/locales/es-419/translations.json
+++ b/translations/locales/es-419/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Alternar reemplazar",

--- a/translations/locales/fr-CA/translations.json
+++ b/translations/locales/fr-CA/translations.json
@@ -49,7 +49,7 @@
       }
     },
     "Banner": {
-      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+      "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
     },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "Activer/désactiver le remplacement",

--- a/translations/locales/hi/translations.json
+++ b/translations/locales/hi/translations.json
@@ -50,7 +50,7 @@
       }
     },
     "Banner": {
-      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+      "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
     },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "टॉगल बदली करें",

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Attiva/disattiva Sostituzione",

--- a/translations/locales/ja/translations.json
+++ b/translations/locales/ja/translations.json
@@ -48,7 +48,7 @@
       }
     },
     "Banner": {
-      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+      "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
     },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "置換の切り替え",

--- a/translations/locales/ko/translations.json
+++ b/translations/locales/ko/translations.json
@@ -49,7 +49,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
   },
   "LoginForm": {
     "UsernameOrEmail": "이메일 또는 아이디",

--- a/translations/locales/pt-BR/translations.json
+++ b/translations/locales/pt-BR/translations.json
@@ -46,7 +46,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Alternar entre localizar/substituir",

--- a/translations/locales/sv/translations.json
+++ b/translations/locales/sv/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Växla ersätt",

--- a/translations/locales/tr/translations.json
+++ b/translations/locales/tr/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Değiştirme Aç/Kapa",

--- a/translations/locales/uk-UA/translations.json
+++ b/translations/locales/uk-UA/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Увімкнути заміну",

--- a/translations/locales/ur/translations.json
+++ b/translations/locales/ur/translations.json
@@ -48,7 +48,7 @@
       }
     },
     "Banner": {
-      "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+      "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
     },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "تبدیل کرنے کو ٹوگل کریں۔",

--- a/translations/locales/zh-CN/translations.json
+++ b/translations/locales/zh-CN/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "开关替换选项",

--- a/translations/locales/zh-TW/translations.json
+++ b/translations/locales/zh-TW/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>Donate Today!</bold> Support p5.js and the Processing Foundation."
+    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "切換取代",


### PR DESCRIPTION
### Demo:
<img width="1253" height="707" alt="Screenshot 2026-07-13 at 1 29 01 PM" src="https://github.com/user-attachments/assets/ed9ead71-b163-402d-aa42-a4e07b5f9fab" />


### Changes:
- Temporarily turns the Banner on within the Editor
- Add banner copy and translations communicating p5.js v2.0 defaulting in August and to check out the linked issue for more information. The linked issue can be accessed by hovering on the banner text. 

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
