### PR TITLE
GSOC-E2E-2: Add unauthenticated save flow test

### DIFF
--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -57,4 +57,31 @@ test.describe('editor page', () => {
       page.locator('.preview-console__messages')
     ).toContainText('hi from sketch', { timeout: 15_000 });
   });
+
+  test('unauthenticated users cannot save sketches', async ({ page }) => {
+    // Verify save option is disabled in File menu
+    await page.getByRole('menuitem', { name: 'File' }).click();
+
+    const saveButton = page.locator('#file-save');
+
+    await expect(saveButton).toHaveAttribute('aria-disabled', 'true');
+    await expect(saveButton).toHaveAttribute(
+      'aria-label',
+      'Log in to save your sketch'
+    );
+
+    // Close menu if needed
+    await page.keyboard.press('Escape');
+
+    // Attempt save via keyboard shortcut
+    await page.locator('.editor-holder').click();
+    await page.keyboard.press('ControlOrMeta+S');
+
+    // Verify login prompt appears
+    await expect(
+      page.getByText(
+        'In order to save sketches, you must be logged in. Please Login or Sign Up.'
+      )
+    ).toBeVisible();
+  });
 });


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->

### Demo:
<!-- Please add a screenshot for UI related changes -->

https://github.com/user-attachments/assets/bacfff2b-38c0-481e-b00b-cf2e26aa6014



### Changes:
An end-to-end Playwright test covering the unauthenticated save flow.
verifies:
- The editor loads successfully for an unauthenticated user.
- The Save option in the File menu is disabled when the user is not logged in.
- The disabled Save action includes an accessibility label indicating that login is required.
- Attempting to save a sketch using the keyboard shortcut (Ctrl+S) displays the expected authentication prompt.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
