### PR TITLE
refactor: replace hardcoded MongoDB URLs with process.env.MONGO_URL

### DIFF
--- a/server/migrations/db_reformat.js
+++ b/server/migrations/db_reformat.js
@@ -4,7 +4,7 @@ import path from 'path';
 import { uniqWith, isEqual } from 'lodash';
 require('dotenv').config({ path: path.resolve('.env') });
 const ObjectId = mongoose.Types.ObjectId;
-mongoose.connect('mongodb://localhost:27017/p5js-web-editor');
+mongoose.connect(process.env.MONGO_URL);
 mongoose.connection.on('error', () => {
   console.error(
     'MongoDB Connection Error. Please make sure that MongoDB is running.'

--- a/server/migrations/moveBucket.js
+++ b/server/migrations/moveBucket.js
@@ -6,7 +6,7 @@ import { User } from '../models/user';
 import Project from '../models/project';
 import async from 'async';
 require('dotenv').config({ path: path.resolve('.env') });
-mongoose.connect('mongodb://localhost:27017/p5js-web-editor');
+mongoose.connect(process.env.MONGO_URL);
 mongoose.connection.on('error', () => {
   console.error(
     'MongoDB Connection Error. Please make sure that MongoDB is running.'

--- a/server/migrations/s3UnderUser.js
+++ b/server/migrations/s3UnderUser.js
@@ -14,7 +14,7 @@ import dotenv from 'dotenv';
 dotenv.config({ path: path.resolve('.env') });
 
 async function main() {
-  mongoose.connect('mongodb://localhost:27017/p5js-web-editor');
+  mongoose.connect(process.env.MONGO_URL);
   mongoose.connection.on('error', () => {
     console.error(
       'MongoDB Connection Error. Please make sure that MongoDB is running.'


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->
This is a cleanup task identified during E2E testing infrastructure work.

### Demo:
<!-- Please add a screenshot for UI related changes -->

### Changes:
<!-- Summarise your changes -->
Replaced hardcoded `mongodb://localhost:27017/p5js-web-editor` connection strings in migration scripts with `process.env.MONGO_URL`. No behaviour change for existing setups.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
