### PR TITLE
GSOC: e2e.yml add environment: e2e-tests to gate test runs via reviewer approval

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,44 +3,22 @@ on:
   workflow_dispatch:
   pull_request:
     branches: [develop]
-  issue_comment:
-    types: [created]
 jobs:
   test-e2e:
-    # temporary while new e2e environment is not yet created:
-    # only trigger on workflow_dispatch, maintainer comment, or if PR is from GSOC project mentor or mentee
+    environment: e2e-tests
+    # only trigger on workflow_dispatch, or if PR is from GSOC project mentor or mentee
     if: >
       github.event_name == 'workflow_dispatch' ||
       (
         github.event_name == 'pull_request' &&
         contains(fromJSON('["Geethegreat", "clairep94"]'), github.event.pull_request.user.login)
-      ) ||
-      (
-        github.event.issue.pull_request &&
-        github.event.comment.body == '/e2e' &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
       )
     timeout-minutes: 60
     runs-on: ubuntu-latest
 
     steps:
-    - name: Resolve PR head ref
-      if: github.event_name == 'issue_comment'
-      id: pr
-      uses: actions/github-script@v7
-      with:
-        script: |
-          const { data: pr } = await github.rest.pulls.get({
-            owner: context.repo.owner,
-            repo: context.repo.repo,
-            pull_number: context.issue.number
-          });
-          core.setOutput('sha', pr.head.sha);
-
     - name: Checkout code
       uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event_name == 'issue_comment' && steps.pr.outputs.sha || github.ref }}
 
     - name: Set up node
       uses: actions/setup-node@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,13 +6,6 @@ on:
 jobs:
   test-e2e:
     environment: e2e-tests
-    # only trigger on workflow_dispatch, or if PR is from GSOC project mentor or mentee
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'pull_request' &&
-        contains(fromJSON('["Geethegreat", "clairep94"]'), github.event.pull_request.user.login)
-      )
     timeout-minutes: 60
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Issue:
Fixes # GSOC project setup

### Demo:
<img width="1710" height="763" alt="Screenshot 2026-07-18 at 18 14 24" src="https://github.com/user-attachments/assets/a0ff2ba6-c97b-4653-b90d-bdc774454938" />


### Changes:
- [x] Adds `environment: e2e-tests` to e2e.yml file --> this env has been configured on the github UI for "Required Reviewers" to be @Geethegreat, @clairep94, @khanniie or @raclim for the remainder of GSOC
- [x] Removes temporary comment trigger & gating of workflow via PR author

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
