### PR TITLE
Improve speed of CI tests with cacheing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,8 @@ on:
     branches: [develop]
   issue_comment:
     types: [created]
+env:
+  WAIT_ON_VERSION: '7'
 jobs:
   test-e2e:
     # temporary while new e2e environment is not yet created:
@@ -82,12 +84,23 @@ jobs:
       if: steps.playwright-cache.outputs.cache-hit == 'true'
       run: npx playwright install-deps chromium
 
+    - name: Cache wait-on
+      uses: actions/cache@v4
+      id: wait-on-cache
+      with:
+        path: ~/.npm/_npx
+        key: npx-wait-on-${{ env.WAIT_ON_VERSION }}-${{ runner.os }}
+
+    - name: Install wait-on
+      if: steps.wait-on-cache.outputs.cache-hit != 'true'
+      run: npx -y wait-on@$WAIT_ON_VERSION --version
+
     - name: Start app
       run: npm start > app.log 2>&1 &
 
     - name: Wait for app to be ready
       run: |
-        npx wait-on@7 http://localhost:8000 --timeout 180000 || {
+        npx wait-on@$WAIT_ON_VERSION http://localhost:8000 --timeout 180000 || {
           echo "::error::App failed to become ready at http://localhost:8000 within 180s"
           echo "----- app.log -----"
           cat app.log

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -45,7 +45,7 @@ jobs:
     - name: Set up node
       uses: actions/setup-node@v4
       with:
-        node-version: '18.20.x'
+        node-version-file: '.nvmrc'
         cache: 'npm'
 
     - name: Create .env file
@@ -56,7 +56,15 @@ jobs:
       with:
         mongodb-version: '6.0'
 
+    - name: Cache node_modules
+      uses: actions/cache@v4
+      id: node-modules-cache
+      with:
+        path: node_modules
+        key: node-modules-${{ runner.os }}-node-${{ hashFiles('.nvmrc') }}-${{ hashFiles('package-lock.json') }}
+
     - name: Install dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
       run: npm ci
 
     - name: Cache Playwright browsers

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,29 @@ jobs:
     name: Test and lint code base
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js
-        uses: actions/setup-node@v1
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up node
+        uses: actions/setup-node@v4
         with:
-          node-version: '18.20.x'
-      - run: npm install
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Create .env file
+        run: cp .env.example .env
+      
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        id: node-modules-cache
+        with:
+          path: node_modules
+          key: node-modules-${{ runner.os }}-node-${{ hashFiles('.nvmrc') }}-${{ hashFiles('package-lock.json') }}
+
+      - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
+        run: npm ci
+
       - run: npm run test
       - run: npm run typecheck
       - run: npm run lint


### PR DESCRIPTION
### Issue:
Fixes # 
- e2e.yml has some cacheing but test.yml has none
- These can both be improved in speed by cacheing node_modules
  - If anything in package-lock.json is updated, the cache is invalid & we do a full install instead

### Demo:

**test.yml** before vs after hitting the node_modules cache
<img width="1401" height="261" alt="Screenshot 2026-07-19 at 01 01 58" src="https://github.com/user-attachments/assets/8f6d2f53-a609-4411-beec-ec9576d56f17" />

**e2e.yml** before and after hitting the node_modules cache
<img width="1405" height="282" alt="Screenshot 2026-07-19 at 01 01 29" src="https://github.com/user-attachments/assets/bdef152e-e218-4d9b-87e8-114529bbfc85" />


### Changes:
<!-- Summarise your changes -->

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
