### PR TITLE
Set p5.js v2 to Default

### DIFF
--- a/client/modules/IDE/components/Banner.jsx
+++ b/client/modules/IDE/components/Banner.jsx
@@ -24,7 +24,7 @@ import { CrossIcon } from '../../../common/icons';
 
 const Banner = ({ onClose }) => {
   // URL can be updated depending on the opportunity or announcement.
-  const bannerURL = 'https://github.com/processing/p5.js/issues/8870';
+  const bannerURL = 'https://p5js.org/tutorials/v2_transition';
 
   // currently holds donation copy, will switch back when temp maintenance is done
   const bannerCopy = (

--- a/client/styles/components/_banner.scss
+++ b/client/styles/components/_banner.scss
@@ -3,7 +3,7 @@
   min-height: 2.2rem;
   text-align: center;
   padding: 1rem;
-  background-color: #DFED33; // yellow from p5.js website
+  background-color: #dbe3f5; // blue from p5.js website
   border-bottom: 1px solid #000;
 
   a {

--- a/common/p5Versions.js
+++ b/common/p5Versions.js
@@ -1,11 +1,11 @@
-export const currentP5Version = '1.11.13'; // Don't update to 2.x until 2026
+export const currentP5Version = '2.3.2';
 
 // Generated from https://www.npmjs.com/package/p5?activeTab=versions
 // Run this in the console:
 // JSON.stringify([...document.querySelectorAll('._132722c7')].map(n => n.innerText), null, 2)
 // TODO: use their API for this to grab these at build time?
 export const p5Versions = [
-  { version: '2.3.2', label: '(Beta)' },
+  { version: '2.3.2', label: '(Latest)' },
   '2.3.1',
   '2.3.0',
   '2.2.3',
@@ -20,7 +20,7 @@ export const p5Versions = [
   '2.0.2',
   '2.0.1',
   '2.0.0',
-  { version: '1.11.13', label: '(Default)' },
+  { version: '1.11.13', label: '(Not Maintained)' },
   '1.11.12',
   '1.11.11',
   '1.11.10',

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -56,7 +56,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+    "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Toggle Replace",
@@ -237,7 +237,7 @@
     "TableText": "Table-text",
     "TableOutputARIA": "table output on",
     "LibraryVersion": "p5.js Version",
-    "LibraryVersionInfo": "There's a [new 2.0 release](https://github.com/processing/p5.js/releases/) of p5.js available! It will become default in August, 2026, so take this time to test it out and report bugs. Interested in transitioning sketches from 1.x to 2.0? Check out the [compatibility & transition resources.](https://github.com/processing/p5.js-compatibility)",
+    "LibraryVersionInfo": "If you teach with p5.js v1, be sure to check out this [essential guide](https://p5js.org/tutorials/v2_transition/) to using p5.js v2.",
     "CustomVersionTitle": "Managing your own libraries? Nice!",
     "CustomVersionInfo": "The version of p5.js is currently being managed in the code of index.html. This means it can't be adjusted from this tab.",
     "CustomVersionReset": "If you'd like to use the default libraries, you can replace the script tags in index.html with the following:",

--- a/translations/locales/es-419/translations.json
+++ b/translations/locales/es-419/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+    "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Alternar reemplazar",

--- a/translations/locales/fr-CA/translations.json
+++ b/translations/locales/fr-CA/translations.json
@@ -49,7 +49,7 @@
       }
     },
     "Banner": {
-      "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+      "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
     },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "Activer/désactiver le remplacement",

--- a/translations/locales/hi/translations.json
+++ b/translations/locales/hi/translations.json
@@ -50,7 +50,7 @@
       }
     },
     "Banner": {
-      "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+      "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
     },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "टॉगल बदली करें",

--- a/translations/locales/it/translations.json
+++ b/translations/locales/it/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+    "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Attiva/disattiva Sostituzione",

--- a/translations/locales/ja/translations.json
+++ b/translations/locales/ja/translations.json
@@ -48,7 +48,7 @@
       }
     },
     "Banner": {
-      "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+      "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
     },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "置換の切り替え",

--- a/translations/locales/ko/translations.json
+++ b/translations/locales/ko/translations.json
@@ -49,7 +49,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+    "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
   },
   "LoginForm": {
     "UsernameOrEmail": "이메일 또는 아이디",

--- a/translations/locales/pt-BR/translations.json
+++ b/translations/locales/pt-BR/translations.json
@@ -46,7 +46,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+    "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Alternar entre localizar/substituir",

--- a/translations/locales/sv/translations.json
+++ b/translations/locales/sv/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+    "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Växla ersätt",

--- a/translations/locales/tr/translations.json
+++ b/translations/locales/tr/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+    "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Değiştirme Aç/Kapa",

--- a/translations/locales/uk-UA/translations.json
+++ b/translations/locales/uk-UA/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+    "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "Увімкнути заміну",

--- a/translations/locales/ur/translations.json
+++ b/translations/locales/ur/translations.json
@@ -48,7 +48,7 @@
       }
     },
     "Banner": {
-      "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+      "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
     },
     "CodemirrorFindAndReplace": {
       "ToggleReplace": "تبدیل کرنے کو ٹوگل کریں۔",

--- a/translations/locales/zh-CN/translations.json
+++ b/translations/locales/zh-CN/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+    "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "开关替换选项",

--- a/translations/locales/zh-TW/translations.json
+++ b/translations/locales/zh-TW/translations.json
@@ -48,7 +48,7 @@
     }
   },
   "Banner": {
-    "Copy": "<bold>p5.js v2.0 will become the default editor version this August</bold>! Check out the timeline and ask questions in the linked issue!"
+    "Copy": "<bold>p5.js v2 is now the default</bold>. If you teach with p5, check out this essential guide!"
   },
   "CodemirrorFindAndReplace": {
     "ToggleReplace": "切換取代",


### PR DESCRIPTION
### Changes:
- Updates Banner Copy to reflect p5.js v2 default and provide links to transition guide.
- Sets p5.js v2 to default in version dropdown, and add "Default" and "Not Maintained" labels. Also updates copy in Preferences modal. 

Fixes https://github.com/processing/p5.js-web-editor/issues/4149

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
