### PR TITLE
fix: AutoComplete hinter should link to p5js.org for v2, and v1.p5js.org

### DIFF
--- a/client/modules/IDE/components/Editor/index.jsx
+++ b/client/modules/IDE/components/Editor/index.jsx
@@ -47,7 +47,7 @@ export function getReferenceBaseUrl(htmlFile) {
   const isV2 =
     /https:\/\/beta\.p5js\.org\b/i.test(html) || /\bp5(@|-)2\./i.test(html);
 
-  return isV2 ? 'https://beta.p5js.org' : 'https://p5js.org';
+  return isV2 ? 'https://p5js.org' : 'https://v1.p5js.org';
 }
 
 function Editor({

--- a/server/scripts/update-p5-hinter.js
+++ b/server/scripts/update-p5-hinter.js
@@ -5,11 +5,11 @@ const axios = require('axios');
 const VERSIONS = [
   {
     version: 'v1',
-    url: 'https://p5js.org/reference/data.json'
+    url: 'https://v1.p5js.org/reference/data.json'
   },
   {
     version: 'v2',
-    url: 'https://beta.p5js.org/reference/data.json'
+    url: 'https://p5js.org/reference/data.json'
   }
 ];
 

--- a/server/scripts/update-p5-hinter.js
+++ b/server/scripts/update-p5-hinter.js
@@ -5,11 +5,11 @@ const axios = require('axios');
 const VERSIONS = [
   {
     version: 'v1',
-    url: 'https://v1.p5js.org/reference/data.json'
+    url: 'https://p5js.org/reference/data.json'
   },
   {
     version: 'v2',
-    url: 'https://p5js.org/reference/data.json'
+    url: 'https://beta.p5js.org/reference/data.json'
   }
 ];
 


### PR DESCRIPTION
Fixes https://github.com/processing/p5.js-web-editor/issues/4233


### Demo:
<!-- Please add a screenshot for UI related changes -->

### Changes:
<!-- Summarise your changes -->

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
