### PR TITLE
GSOC-E2E-4: Add login-logout test

### DIFF
--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,0 +1,57 @@
+import type { APIRequestContext, Page } from '@playwright/test';
+import { expect } from '../fixtures';
+import { usernamePrefix, emailSuffix, password } from './env';
+
+export interface TestUser {
+  username: string;
+  email: string;
+}
+
+/**
+ * Creates a test user via a direct API call rather than the UI signup flow —
+ * login doesn't require a verified email (see
+ * server/controllers/user.controller/signup.ts), so this is a faster, more
+ * focused way to get a test user for tests that aren't testing signup itself.
+ */
+export async function createTestUser(
+  request: APIRequestContext
+): Promise<TestUser> {
+  const username = `${usernamePrefix()}${Date.now().toString(36)}`;
+  const email = `${username}${emailSuffix()}`;
+
+  const res = await request.post('/editor/signup', {
+    headers: { 'Content-Type': 'application/json' },
+    data: {
+      username,
+      email,
+      password: password(),
+      confirmPassword: password()
+    }
+  });
+
+  if (!res.ok()) {
+    throw new Error(
+      `createTestUser: failed to create test user — ${res.status()}\n${await res.text()}`
+    );
+  }
+
+  return { username, email };
+}
+
+/**
+ * Logs in via the UI form. Assumes the page is already on /login.
+ */
+export async function loginAs(page: Page, user: TestUser): Promise<void> {
+  await page.fill('input[name="email"]', user.email);
+  await page.fill('input[name="password"]', password());
+  await expect(page.locator('button[type="submit"]')).toBeEnabled({
+    timeout: 5_000
+  });
+  await page.click('button[type="submit"]');
+
+  // Successful login redirects to the editor — a screen-visible signal
+  // rather than asserting on the URL.
+  await expect(page.locator('.editor-holder')).toBeVisible({
+    timeout: 15_000
+  });
+}

--- a/e2e/helpers/auth.ts
+++ b/e2e/helpers/auth.ts
@@ -1,6 +1,6 @@
 import type { APIRequestContext, Page } from '@playwright/test';
 import { expect } from '../fixtures';
-import { usernamePrefix, emailSuffix, password } from './env';
+import { usernamePrefix, emailSuffix, password } from './test-user';
 
 export interface TestUser {
   username: string;

--- a/e2e/specs/login.spec.ts
+++ b/e2e/specs/login.spec.ts
@@ -11,13 +11,15 @@ test.describe('login', () => {
   });
 
   test.beforeEach(async ({ page }) => {
-    await page.goto('/login');
+    await page.goto('/');
     await dismissCookieBanner(page);
   });
 
   test('existing user can log in with username and password', async ({
     page
   }) => {
+    await page.locator('a[href="/login"]').click();
+
     await expect(page.locator('h2.form-container__title')).toHaveText('Log In');
 
     // Passport's usernameField is 'email' the input accepts either

--- a/e2e/specs/login.spec.ts
+++ b/e2e/specs/login.spec.ts
@@ -1,33 +1,13 @@
 import { test, expect } from '../fixtures';
 import { dismissCookieBanner } from '../helpers/cookie-banner';
-import { usernamePrefix, emailSuffix, password } from '../helpers/env';
+import { password } from '../helpers/env';
+import { createTestUser, TestUser } from '../helpers/auth';
 
 test.describe('login', () => {
-  const testUser = {
-    username: `${usernamePrefix()}${Date.now().toString(36)}`,
-    email: ''
-  };
-  testUser.email = `${testUser.username}${emailSuffix()}`;
+  let testUser: TestUser;
 
-  // Created via a direct API call rather than the UI signup flow login
-  // doesn't require a verified email (see server/controllers/user.controller
-  // /signup.ts), so this is a faster, more focused way to get a test user.
   test.beforeAll(async ({ request }) => {
-    const res = await request.post('/editor/signup', {
-      headers: { 'Content-Type': 'application/json' },
-      data: {
-        username: testUser.username,
-        email: testUser.email,
-        password: password(),
-        confirmPassword: password()
-      }
-    });
-
-    if (!res.ok()) {
-      throw new Error(
-        `beforeAll: failed to create test user — ${res.status()}\n${await res.text()}`
-      );
-    }
+    testUser = await createTestUser(request);
   });
 
   test.beforeEach(async ({ page }) => {

--- a/e2e/specs/login.spec.ts
+++ b/e2e/specs/login.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '../fixtures';
 import { dismissCookieBanner } from '../helpers/cookie-banner';
-import { password } from '../helpers/env';
+import { password } from '../helpers/test-user';
 import { createTestUser, TestUser } from '../helpers/auth';
 
 test.describe('login', () => {

--- a/e2e/specs/login.spec.ts
+++ b/e2e/specs/login.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '../fixtures';
+import { dismissCookieBanner } from '../helpers/cookie-banner';
+import { usernamePrefix, emailSuffix, password } from '../helpers/env';
+
+test.describe('login', () => {
+  const testUser = {
+    username: `${usernamePrefix()}${Date.now().toString(36)}`,
+    email: ''
+  };
+  testUser.email = `${testUser.username}${emailSuffix()}`;
+
+  // Created via a direct API call rather than the UI signup flow login
+  // doesn't require a verified email (see server/controllers/user.controller
+  // /signup.ts), so this is a faster, more focused way to get a test user.
+  test.beforeAll(async ({ request }) => {
+    const res = await request.post('/editor/signup', {
+      headers: { 'Content-Type': 'application/json' },
+      data: {
+        username: testUser.username,
+        email: testUser.email,
+        password: password(),
+        confirmPassword: password()
+      }
+    });
+
+    if (!res.ok()) {
+      throw new Error(
+        `beforeAll: failed to create test user — ${res.status()}\n${await res.text()}`
+      );
+    }
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await dismissCookieBanner(page);
+  });
+
+  test('existing user can log in with username and password', async ({
+    page
+  }) => {
+    await expect(page.locator('h2.form-container__title')).toHaveText('Log In');
+
+    // Passport's usernameField is 'email' the input accepts either
+    // username or email as the value but the field name is 'email'
+    await page.fill('input[name="email"]', testUser.email);
+    await page.fill('input[name="password"]', password());
+
+    await expect(page.locator('button[type="submit"]')).toBeEnabled({
+      timeout: 5_000
+    });
+    await page.click('button[type="submit"]');
+
+    // Successful login redirects to the editor. A screen-visible signal
+    // rather than asserting on the URL.
+    await expect(page.locator('.editor-holder')).toBeVisible({
+      timeout: 15_000
+    });
+
+    await expect(page.locator('a[href="/login"]')).toHaveCount(0, {
+      timeout: 5_000
+    });
+    await expect(
+      page.locator(`text=${testUser.username}`).first()
+    ).toBeVisible({ timeout: 5_000 });
+
+    // logout flow
+    await page.locator(`button:has-text("${testUser.username}")`).click();
+    await page.locator('#account-logout').click();
+    await expect(page.locator('a[href="/login"]')).toBeVisible({
+      timeout: 5_000
+    });
+    await expect(page.locator(`text=${testUser.username}`)).toHaveCount(0, {
+      timeout: 5_000
+    });
+  });
+});


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->
Adds a test for the authenticated login flow
### Demo:
<!-- Please add a screenshot for UI related changes -->

https://github.com/user-attachments/assets/d1c20491-1497-4848-9e04-17921fac2427



### Changes:
<!-- Summarise your changes -->
 - Navigate to /login
 - Fill email and password fields with credentials from a test user created in beforeAll
 - Submit and verify the editor loads
 - Verify the username appears in the nav and "Log in" link is gone
 - Open the user dropdown and click "Log Out"
 - Verify the "Log in" link reappears

This covers the full login → use editor → logout cycle as a real user would experience it.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
