### PR TITLE
GSOC-E2E: Add test to avoid duplicate emails, usernames

### DIFF
--- a/e2e/specs/signup.spec.ts
+++ b/e2e/specs/signup.spec.ts
@@ -11,9 +11,10 @@ test.describe('signup and email verification', () => {
     const uniqueId = `${usernamePrefix()}${Date.now()}`;
     const email = `${uniqueId}${emailSuffix()}`;
 
-    await page.goto('/signup');
-
+    await page.goto('/');
     await dismissCookieBanner(page);
+
+    await page.locator('a[href="/signup"]').click();
 
     await page.locator('#username').fill(uniqueId);
     await page.locator('#email').fill(email);
@@ -41,5 +42,64 @@ test.describe('signup and email verification', () => {
 
     const session = await page.request.get('/editor/session');
     expect((await session.json()).verified).toBe('verified');
+  });
+
+  test('cannot sign up with an already-used username or email', async ({
+    page
+  }) => {
+    const uniqueId = `${usernamePrefix()}${Date.now()}`;
+    const email = `${uniqueId}${emailSuffix()}`;
+
+    await page.goto('/');
+
+    await dismissCookieBanner(page);
+
+    await page.locator('a[href="/signup"]').click();
+
+    await page.locator('#username').fill(uniqueId);
+    await page.locator('#email').fill(email);
+    await page.locator('#password').fill(password());
+    await page.locator('#confirmPassword').fill(password());
+
+    await page.getByRole('button', { name: 'Sign Up', exact: true }).click();
+
+    // Successful signup logs the user in and redirects to the editor
+    await expect(page.locator('.editor-holder')).toBeVisible({
+      timeout: 15_000
+    });
+
+    await page.locator(`button:has-text("${uniqueId}")`).click();
+    await page.locator('#account-logout').click();
+
+    await expect(page.locator('a[href="/signup"]')).toBeVisible({
+      timeout: 5_000
+    });
+    await page.locator('a[href="/signup"]').click();
+
+    // Fill the input field and move away, error appears on blur
+    await page.locator('#username').fill(uniqueId);
+    await page.locator('#email').click();
+    await expect(
+      page
+        .locator('.form-error')
+        .filter({ hasText: 'This username is already taken.' })
+    ).toBeVisible({ timeout: 5_000 });
+    await page.locator('#email').fill(email);
+    await page.locator('#password').click();
+    await expect(
+      page
+        .locator('.form-error')
+        .filter({ hasText: 'This email is already taken.' })
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Now fill passwords — email error will disappear but that's fine
+    // we already asserted on it above
+    await page.locator('#password').fill(password());
+    await page.locator('#confirmPassword').fill(password());
+
+    // Submit button should still be disabled due to duplicate username/email
+    await expect(
+      page.getByRole('button', { name: 'Sign Up', exact: true })
+    ).toBeDisabled();
   });
 });


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->
Adds a test that verifies a user cannot sign up with credentials that are already in use.

### Demo:
<!-- Please add a screenshot for UI related changes -->

https://github.com/user-attachments/assets/0831926f-31b8-4c31-b33d-b8dc044a9092



### Changes:
<!-- Summarise your changes -->

 - Sign up with a fresh unique username and email
 - Verify successful signup and redirect to editor
 - Log out
 - Navigate back to /signup
 - Fill the form with the same username, verify "This username is already taken." error appears on blur
 - Fill the same email, verify "This email is already taken." error appears on blur
 - Fill password fields
 - Verify the submit button stays disabled

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
