### PR TITLE
GSOC-E2E: Update flow 1 to check looping works as expected- #11

### DIFF
--- a/e2e/specs/editor.spec.ts
+++ b/e2e/specs/editor.spec.ts
@@ -38,7 +38,14 @@ test.describe('editor page', () => {
     await page.keyboard.press('ControlOrMeta+A');
     await page.keyboard.type(newCode, { delay: 5 }); // Purposely using .type instead of .insert (.insert does not work with the redux state management)
 
-    // Click Play
+    const logRow = page
+      .locator('.preview-console__messages [data-method="log"]')
+      .filter({ hasText: 'hi from sketch' });
+
+    // Confirm count starts as 0, before the sketch has run at all
+    await expect(logRow).toHaveCount(0);
+
+    // Click Play (start the loop)
     await page.locator('#play-sketch').click({ force: true });
 
     // Wait for the sketch iframe src to confirm the sketch actually started
@@ -54,22 +61,18 @@ test.describe('editor page', () => {
     // Let sketch run for 2 seconds
     await page.waitForTimeout(2000);
 
-    const logRow = page
-      .locator('.preview-console__messages [data-method="log"]')
-      .filter({ hasText: 'hi from sketch' })
-      .last();
-    const countDiv = logRow.locator('div').first();
+    const countDiv = logRow.last().locator('div').first();
     const count = Number(await countDiv.textContent());
 
-    // Wide tolerance: exact frame count depends on browser/CI scheduling, not just frameRate(10) math.
-    // Ideally its supposed to be 20 frames in 2 seconds.
+    // Confirm count is ~20 frames. Wide tolerance: exact frame count depends
+    // on browser/CI scheduling, not just frameRate(10) math.
     expect(count).toBeGreaterThan(15);
     expect(count).toBeLessThan(30);
 
     // Stop the sketch
     await page.locator('[aria-label="Stop sketch"]').click();
 
-    // Wait and confirm count is frozen
+    // Wait and confirm count did not increase
     await page.waitForTimeout(1000);
     await expect(countDiv).toHaveText(count.toString());
   });

--- a/e2e/specs/editor.spec.ts
+++ b/e2e/specs/editor.spec.ts
@@ -20,15 +20,18 @@ test.describe('editor page', () => {
   });
 
   test('can run sketch code written in the editor', async ({ page }) => {
+    const LOG = 'hi from sketch';
+    const FRAME_RATE = 10;
+
     const newCode = [
       'function setup() {',
       '  createCanvas(400, 400);',
-      ' frameRate(10);',
+      ` frameRate(${FRAME_RATE});`,
       '}',
       '',
       'function draw() {',
       '  background(220);',
-      "  console.log('hi from sketch');",
+      `  console.log('${LOG}');`,
       '}'
     ].join(''); // Purposely joining without '\n' to avoid triggering the autocomplete with keyboard.type & creating extra brackets
 
@@ -40,7 +43,7 @@ test.describe('editor page', () => {
 
     const logRow = page
       .locator('.preview-console__messages [data-method="log"]')
-      .filter({ hasText: 'hi from sketch' });
+      .filter({ hasText: LOG });
 
     // Confirm count starts as 0, before the sketch has run at all
     await expect(logRow).toHaveCount(0);
@@ -54,12 +57,16 @@ test.describe('editor page', () => {
     ).toHaveAttribute('src', /9002/, { timeout: 10_000 });
 
     // Assert console output
-    await expect(
-      page.locator('.preview-console__messages')
-    ).toContainText('hi from sketch', { timeout: 15_000 });
+    await expect(page.locator('.preview-console__messages')).toContainText(
+      LOG,
+      { timeout: 15_000 }
+    );
 
     // Let sketch run for 2 seconds
     await page.waitForTimeout(2000);
+
+    // Stop the sketch
+    await page.locator('[aria-label="Stop sketch"]').click();
 
     const countDiv = logRow.last().locator('div').first();
     const count = Number(await countDiv.textContent());
@@ -68,9 +75,6 @@ test.describe('editor page', () => {
     // on browser/CI scheduling, not just frameRate(10) math.
     expect(count).toBeGreaterThan(15);
     expect(count).toBeLessThan(30);
-
-    // Stop the sketch
-    await page.locator('[aria-label="Stop sketch"]').click();
 
     // Wait and confirm count did not increase
     await page.waitForTimeout(1000);

--- a/e2e/specs/editor.spec.ts
+++ b/e2e/specs/editor.spec.ts
@@ -23,6 +23,7 @@ test.describe('editor page', () => {
     const newCode = [
       'function setup() {',
       '  createCanvas(400, 400);',
+      ' frameRate(10);',
       '}',
       '',
       'function draw() {',
@@ -53,11 +54,17 @@ test.describe('editor page', () => {
     // Let sketch run for 2 seconds
     await page.waitForTimeout(2000);
 
-    const countDiv = page
-      .locator('.preview-console__messages [data-method="log"] div')
-      .first();
+    const logRow = page
+      .locator('.preview-console__messages [data-method="log"]')
+      .filter({ hasText: 'hi from sketch' })
+      .last();
+    const countDiv = logRow.locator('div').first();
     const count = Number(await countDiv.textContent());
-    expect(count).toBeGreaterThan(1);
+
+    // Wide tolerance: exact frame count depends on browser/CI scheduling, not just frameRate(10) math.
+    // Ideally its supposed to be 20 frames in 2 seconds.
+    expect(count).toBeGreaterThan(15);
+    expect(count).toBeLessThan(30);
 
     // Stop the sketch
     await page.locator('[aria-label="Stop sketch"]').click();

--- a/e2e/specs/editor.spec.ts
+++ b/e2e/specs/editor.spec.ts
@@ -28,7 +28,6 @@ test.describe('editor page', () => {
       'function draw() {',
       '  background(220);',
       "  console.log('hi from sketch');",
-      '  noLoop();',
       '}'
     ].join(''); // Purposely joining without '\n' to avoid triggering the autocomplete with keyboard.type & creating extra brackets
 
@@ -50,6 +49,22 @@ test.describe('editor page', () => {
     await expect(
       page.locator('.preview-console__messages')
     ).toContainText('hi from sketch', { timeout: 15_000 });
+
+    // Let sketch run for 2 seconds
+    await page.waitForTimeout(2000);
+
+    const countDiv = page
+      .locator('.preview-console__messages [data-method="log"] div')
+      .first();
+    const count = Number(await countDiv.textContent());
+    expect(count).toBeGreaterThan(1);
+
+    // Stop the sketch
+    await page.locator('[aria-label="Stop sketch"]').click();
+
+    // Wait and confirm count is frozen
+    await page.waitForTimeout(1000);
+    await expect(countDiv).toHaveText(count.toString());
   });
 
   test('unauthenticated users cannot save sketches', async ({ page }) => {


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->
Extends the sketch execution test to verify that draw() loops correctly and the stop button halts execution.

### Demo:
<!-- Please add a screenshot for UI related changes -->

https://github.com/user-attachments/assets/ee637997-d645-4a29-aabd-a2780763dce2



### Changes:
<!-- Summarise your changes -->
 - Removed noLoop() from the sketch code so draw() runs continuously
  - After confirming initial console output, waits 2 seconds and checks the repeat count is greater than 1,, proves draw() is actually looping
 - Clicks the Stop button and confirms the repeat count is frozen after 1 second, proves the sketch actually stopped

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
