### PR TITLE
Add duplicate-line and scroll-without-moving-cursor shortcuts

### DIFF
--- a/client/modules/IDE/components/Editor/utils/keymaps.js
+++ b/client/modules/IDE/components/Editor/utils/keymaps.js
@@ -10,7 +10,8 @@ import {
   historyKeymap,
   indentWithTab,
   moveLineUp,
-  moveLineDown
+  moveLineDown,
+  copyLineDown
 } from '@codemirror/commands';
 import { foldKeymap } from '@codemirror/language';
 import { searchKeymap } from '@codemirror/search';
@@ -77,6 +78,11 @@ export function openColorPickerWithKeyboard(view) {
   return true;
 }
 
+function scrollLine(view, direction) {
+  view.scrollDOM.scrollTop += direction * view.defaultLineHeight;
+  return true;
+}
+
 // Extra custom keymaps.
 // TODO: We need to add sublime mappings + other missing extra mappings here.
 export const extraKeymaps = [
@@ -87,7 +93,18 @@ export const extraKeymaps = [
   { key: 'ArrowRight', run: focusOnReferenceArrow },
   indentWithTab,
   { key: 'Ctrl-Shift-ArrowUp', mac: 'Cmd-Ctrl-ArrowUp', run: moveLineUp },
-  { key: 'Ctrl-Shift-ArrowDown', mac: 'Cmd-Ctrl-ArrowDown', run: moveLineDown }
+  { key: 'Ctrl-Shift-ArrowDown', mac: 'Cmd-Ctrl-ArrowDown', run: moveLineDown },
+  { key: 'Shift-Ctrl-d', mac: 'Shift-Cmd-d', run: copyLineDown },
+  {
+    key: 'Ctrl-ArrowUp',
+    mac: 'Ctrl-Alt-ArrowUp',
+    run: (view) => scrollLine(view, -1)
+  },
+  {
+    key: 'Ctrl-ArrowDown',
+    mac: 'Ctrl-Alt-ArrowDown',
+    run: (view) => scrollLine(view, 1)
+  }
 ];
 
 export const emmetKeymaps = [{ key: 'Tab', run: expandAbbreviation }];


### PR DESCRIPTION
## Summary
Follow-up to #4222 — adds two of the "easy" tier bindings identified
in the Sublime keymap gap analysis there, per @khanniie's suggestion
to tackle that tier next.

- `Shift-Ctrl-D` / `Shift-Cmd-D`: duplicate the current line, using
  CodeMirror's existing `copyLineDown` command.
- `Ctrl-Up/Down` (`Ctrl-Alt-Up/Down` on Mac, matching Sublime's actual
  Mac binding): scroll the viewport by one line without moving the
  cursor.

`Ctrl-J` (join lines) is intentionally left out — it has no
CodeMirror 6 built-in and would need custom logic, so deferring it to
a smaller, separate follow-up rather than scope-creeping this PR.

Note: this PR only adds the keybindings themselves. Updating
`KeyboardShortcutModal.jsx` to document them (along with the broken
Replace shortcut and #4222's move-line shortcut) is tracked separately
in #4253.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test -- client/modules/IDE/components/Editor` passes
- [x] Manually verified in the running dev server: `Shift-Ctrl-D`
      duplicates the current line; `Ctrl-Up/Down` scrolls the viewport
      without moving the cursor/selection

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)