### PR TITLE
Document select-next-occurrence, multi-cursor, delete-line, go-to-line, matching-bracket, and duplicate-line-up shortcuts

### DIFF
--- a/client/modules/IDE/components/KeyboardShortcutModal.jsx
+++ b/client/modules/IDE/components/KeyboardShortcutModal.jsx
@@ -9,6 +9,21 @@ function KeyboardShortcutModal() {
   const newFileCommand =
     metaKey === 'Ctrl' ? `${metaKeyName} + Alt + N` : `${metaKeyName} + ⌥ + N`;
   const renameCommand = metaKey === 'Ctrl' ? 'F2' : 'Ctrl + F2';
+  const selectNextOccurrenceCommand = `${metaKeyName} + D`;
+  const addCursorAboveCommand =
+    metaKey === 'Ctrl'
+      ? `${metaKeyName} + Alt + Up`
+      : `${metaKeyName} + ⌥ + Up`;
+  const addCursorBelowCommand =
+    metaKey === 'Ctrl'
+      ? `${metaKeyName} + Alt + Down`
+      : `${metaKeyName} + ⌥ + Down`;
+  const deleteLineCommand = `${metaKeyName} + Shift + K`;
+  const goToLineCommand =
+    metaKey === 'Ctrl' ? `${metaKeyName} + Alt + G` : `${metaKeyName} + ⌥ + G`;
+  const matchingBracketCommand = `${metaKeyName} + Shift + \\`;
+  const duplicateLineUpCommand =
+    metaKey === 'Ctrl' ? 'Shift + Alt + Up' : 'Shift + ⌥ + Up';
   return (
     <div className="keyboard-shortcuts">
       <h3 className="keyboard-shortcuts__title">
@@ -79,6 +94,46 @@ function KeyboardShortcutModal() {
         <li className="keyboard-shortcut-item">
           <span className="keyboard-shortcut__command">{renameCommand}</span>
           <span>{t('KeyboardShortcuts.CodeEditing.RenameVariable')}</span>
+        </li>
+        <li className="keyboard-shortcut-item">
+          <span className="keyboard-shortcut__command">
+            {selectNextOccurrenceCommand}
+          </span>
+          <span>{t('KeyboardShortcuts.CodeEditing.SelectNextOccurrence')}</span>
+        </li>
+        <li className="keyboard-shortcut-item">
+          <span className="keyboard-shortcut__command">
+            {addCursorAboveCommand}
+          </span>
+          <span>{t('KeyboardShortcuts.CodeEditing.AddCursorAbove')}</span>
+        </li>
+        <li className="keyboard-shortcut-item">
+          <span className="keyboard-shortcut__command">
+            {addCursorBelowCommand}
+          </span>
+          <span>{t('KeyboardShortcuts.CodeEditing.AddCursorBelow')}</span>
+        </li>
+        <li className="keyboard-shortcut-item">
+          <span className="keyboard-shortcut__command">
+            {deleteLineCommand}
+          </span>
+          <span>{t('KeyboardShortcuts.CodeEditing.DeleteLine')}</span>
+        </li>
+        <li className="keyboard-shortcut-item">
+          <span className="keyboard-shortcut__command">{goToLineCommand}</span>
+          <span>{t('KeyboardShortcuts.CodeEditing.GoToLine')}</span>
+        </li>
+        <li className="keyboard-shortcut-item">
+          <span className="keyboard-shortcut__command">
+            {matchingBracketCommand}
+          </span>
+          <span>{t('KeyboardShortcuts.CodeEditing.MatchingBracket')}</span>
+        </li>
+        <li className="keyboard-shortcut-item">
+          <span className="keyboard-shortcut__command">
+            {duplicateLineUpCommand}
+          </span>
+          <span>{t('KeyboardShortcuts.CodeEditing.DuplicateLineUp')}</span>
         </li>
       </ul>
       <h3 className="keyboard-shortcuts__title">

--- a/translations/locales/en-US/translations.json
+++ b/translations/locales/en-US/translations.json
@@ -269,7 +269,14 @@
       "CodeEditing": "Code Editing",
       "ColorPicker": "Show Inline Color Picker",
       "CreateNewFile": "Create New File",
-      "RenameVariable": "Rename Variable"
+      "RenameVariable": "Rename Variable",
+      "SelectNextOccurrence": "Select Next Occurrence",
+      "AddCursorAbove": "Add Cursor Above",
+      "AddCursorBelow": "Add Cursor Below",
+      "DeleteLine": "Delete Line",
+      "GoToLine": "Go to Line",
+      "MatchingBracket": "Jump to Matching Bracket",
+      "DuplicateLineUp": "Duplicate Line Up"
     },
     "General": "General",
     "GeneralSelection": {


### PR DESCRIPTION
## Summary
Follow-up to #4253 — documents six real, currently-working shortcuts that were never added to `KeyboardShortcutModal.jsx`:

- `Mod-D` — select next occurrence
- `Mod-Alt-Up/Down` — add cursor above/below
- `Shift-Mod-K` — delete line
- `Mod-Alt-G` — go to line
- `Shift-Mod-\` — jump to matching bracket
- `Shift-Alt-Up` — duplicate line up (complements the `Shift-Ctrl-D`
  alias added in #4254, which only covers the down direction)

All six already work today via CodeMirror 6 defaults — this PR is documentation-only, no behavior changes.

Deliberately left out `Mod-Z`/`Mod-Y` (undo/redo) and `Tab`/`Shift-Tab`
(indent) as universally expected defaults not specific to this editor.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test -- client/modules/IDE/components/Editor` passes
- [x] Manually verified in the running dev server: all six entries
      display correctly with the right platform-specific key combo

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)