### PR TITLE
GSOC-E2E: Add unsaved changes warning test

### DIFF
--- a/e2e/specs/unsaved_changes.spec.ts
+++ b/e2e/specs/unsaved_changes.spec.ts
@@ -1,15 +1,13 @@
-import type { Dialog, Page } from '@playwright/test';
+import type { Page } from '@playwright/test';
 import { test, expect } from '../fixtures';
 import { dismissCookieBanner } from '../helpers/cookie-banner';
 import { createTestUser, loginAs, TestUser } from '../helpers/auth';
 
-/**
- * Renders off state.ide.unsavedChanges (see UnsavedChangesIndicator.jsx) —
- * the same state that gates both the <Prompt> and the beforeunload listener.
- */
+// Renders off state.ide.unsavedChanges (see UnsavedChangesIndicator.jsx).
 const unsavedIndicator = (page: Page) =>
   page.getByRole('img', { name: 'Sketch has unsaved changes' });
 
+// Covers the unsaved changes warning that appears when navigating away from the editor with unsaved changes.
 test.describe('unsaved changes warning', () => {
   let testUser: TestUser;
 
@@ -21,54 +19,76 @@ test.describe('unsaved changes warning', () => {
     await page.goto('/login');
     await dismissCookieBanner(page);
     await loginAs(page, testUser);
-  });
 
-  // Covers the <Prompt> in IDEView.jsx, which guards in-app navigation and
-  // shows the app's own message via window.confirm(). The sibling
-  // beforeunload handler (full page unload, e.g. reload/close) is a separate
-  // guard on the same state, not covered here.
-  // Note the Prompt deliberately allows /login, /signup and /feedback through
-  // without warning, so this navigates to the user's sketches instead.
-  test('warns before navigating away from the editor with unsaved changes', async ({
-    page
-  }) => {
     const editor = page.locator('.editor-holder');
     await editor.click();
     await page.keyboard.press('ControlOrMeta+A');
     await page.keyboard.type('function setup() {createCanvas(400, 400);}', {
       delay: 5
     });
-
-    // Wait for the app to actually register the unsaved change rather than
-    // sleeping past CodeMirror's 1s debounce. This indicator renders off
-    // state.ide.unsavedChanges — the same state that gates both guards.
     await expect(unsavedIndicator(page)).toBeVisible({ timeout: 10_000 });
+  });
 
-    // Dismissing the warning should keep us in the editor
+  const navigateToSketches = async (page: Page) => {
+    await page.getByRole('menuitem', { name: testUser.username }).click();
+    await page.locator('#account-sketches').click();
+  };
+
+  test('warns before navigating away from the editor with unsaved changes', async ({
+    page
+  }) => {
     let dialogMessage = '';
-    page.once('dialog', async (dialog) => {
+    page.once('dialog', (dialog) => {
       dialogMessage = dialog.message();
-      await dialog.dismiss();
+      return dialog.dismiss();
     });
 
-    await page.getByRole('menuitem', { name: testUser.username }).click();
-    await page.locator('#account-sketches').click();
+    await navigateToSketches(page);
 
-    await expect
-      .poll(() => dialogMessage)
-      .toContain('You have unsaved changes');
-    await expect(editor).toBeVisible();
+    expect(dialogMessage).toContain('You have unsaved changes');
+  });
 
-    await page.waitForTimeout(1000);
+  test('blocks navigation if the warning is dismissed', async ({ page }) => {
+    const urlBeforeNav = page.url();
+    page.once('dialog', (dialog) => dialog.dismiss());
 
-    // Accepting it should let the navigation through
+    await navigateToSketches(page);
+
+    expect(page.url()).toBe(urlBeforeNav);
+    await expect(page.locator('.editor-holder')).toBeVisible();
+  });
+
+  test('allows navigation if the warning is accepted', async ({ page }) => {
     page.once('dialog', (dialog) => dialog.accept());
 
-    await page.getByRole('menuitem', { name: testUser.username }).click();
-    await page.locator('#account-sketches').click();
+    await navigateToSketches(page);
 
     await expect(page).toHaveURL(new RegExp(`/${testUser.username}/sketches`), {
       timeout: 10_000
     });
+  });
+
+  test('does not appear when a sketch is saved before navigating', async ({
+    page
+  }) => {
+    await page.locator('.editor-holder').click();
+    await page.keyboard.press('Control+S');
+    await expect(page.getByText('Sketch saved.')).toBeVisible({
+      timeout: 10_000
+    });
+    await expect(unsavedIndicator(page)).toBeHidden();
+
+    let dialogFired = false;
+    page.once('dialog', (dialog) => {
+      dialogFired = true;
+      return dialog.accept();
+    });
+
+    await navigateToSketches(page);
+
+    await expect(page).toHaveURL(new RegExp(`/${testUser.username}/sketches`), {
+      timeout: 10_000
+    });
+    expect(dialogFired).toBe(false);
   });
 });

--- a/e2e/specs/unsaved_changes.spec.ts
+++ b/e2e/specs/unsaved_changes.spec.ts
@@ -1,0 +1,75 @@
+import type { Dialog, Page } from '@playwright/test';
+import { test, expect } from '../fixtures';
+import { dismissCookieBanner } from '../helpers/cookie-banner';
+import { createTestUser, loginAs, TestUser } from '../helpers/auth';
+
+/**
+ * Renders off state.ide.unsavedChanges (see UnsavedChangesIndicator.jsx) —
+ * the same state that gates both the <Prompt> and the beforeunload listener.
+ */
+const unsavedIndicator = (page: Page) =>
+  page.getByRole('img', { name: 'Sketch has unsaved changes' });
+
+test.describe('unsaved changes warning', () => {
+  let testUser: TestUser;
+
+  test.beforeAll(async ({ request }) => {
+    testUser = await createTestUser(request);
+  });
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/login');
+    await dismissCookieBanner(page);
+    await loginAs(page, testUser);
+  });
+
+  // Covers the <Prompt> in IDEView.jsx, which guards in-app navigation and
+  // shows the app's own message via window.confirm(). The sibling
+  // beforeunload handler (full page unload) isn't covered here: the browser
+  // discards the app's message and substitutes its own text, and Playwright
+  // auto-dismisses those dialogs, so there'd be nothing of ours to assert on.
+  // Note the Prompt deliberately allows /login, /signup and /feedback through
+  // without warning, so this navigates to the user's sketches instead.
+  test('warns before navigating away from the editor with unsaved changes', async ({
+    page
+  }) => {
+    const editor = page.locator('.editor-holder');
+    await editor.click();
+    await page.keyboard.press('ControlOrMeta+A');
+    await page.keyboard.type('function setup() {createCanvas(400, 400);}', {
+      delay: 5
+    });
+
+    // Wait for the app to actually register the unsaved change rather than
+    // sleeping past CodeMirror's 1s debounce. This indicator renders off
+    // state.ide.unsavedChanges — the same state that gates both guards.
+    await expect(unsavedIndicator(page)).toBeVisible({ timeout: 10_000 });
+
+    // Dismissing the warning should keep us in the editor
+    let dialogMessage = '';
+    page.once('dialog', async (dialog) => {
+      dialogMessage = dialog.message();
+      await dialog.dismiss();
+    });
+
+    await page.getByRole('menuitem', { name: testUser.username }).click();
+    await page.locator('#account-sketches').click();
+
+    await expect
+      .poll(() => dialogMessage)
+      .toContain('You have unsaved changes');
+    await expect(editor).toBeVisible();
+
+    await page.waitForTimeout(1000);
+
+    // Accepting it should let the navigation through
+    page.once('dialog', (dialog) => dialog.accept());
+
+    await page.getByRole('menuitem', { name: testUser.username }).click();
+    await page.locator('#account-sketches').click();
+
+    await expect(page).toHaveURL(new RegExp(`/${testUser.username}/sketches`), {
+      timeout: 10_000
+    });
+  });
+});

--- a/e2e/specs/unsaved_changes.spec.ts
+++ b/e2e/specs/unsaved_changes.spec.ts
@@ -25,9 +25,8 @@ test.describe('unsaved changes warning', () => {
 
   // Covers the <Prompt> in IDEView.jsx, which guards in-app navigation and
   // shows the app's own message via window.confirm(). The sibling
-  // beforeunload handler (full page unload) isn't covered here: the browser
-  // discards the app's message and substitutes its own text, and Playwright
-  // auto-dismisses those dialogs, so there'd be nothing of ours to assert on.
+  // beforeunload handler (full page unload, e.g. reload/close) is a separate
+  // guard on the same state, not covered here.
   // Note the Prompt deliberately allows /login, /signup and /feedback through
   // without warning, so this navigates to the user's sketches instead.
   test('warns before navigating away from the editor with unsaved changes', async ({


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->
Adds a test that verifies the editor warns users before navigating away with unsaved changes.

### Demo:
<!-- Please add a screenshot for UI related changes -->

https://github.com/user-attachments/assets/7133de99-c33f-4f3f-9cd8-ccdc9152935e



### Changes:
<!-- Summarise your changes -->
 - Log in as a test user
 - Type code into the editor without saving
 - Wait for the unsaved changes indicator to appear (the star icon that renders off state.ide.unsavedChanges), more reliable
 than an arbitrary timeout
 - Attempt to navigate to the sketches page via the nav dropdown
 - Verify the unsaved changes dialog appears with the correct message
 - Dismiss the dialog, confirm the editor is still visible (navigation was blocked)
 - Accept the dialog on the second attempt, confirm navigation goes through to the sketches page

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
