### PR TITLE
GSOC-E2E: Add test for nav dropdown redirects

### DIFF
--- a/e2e/specs/editor.spec.ts
+++ b/e2e/specs/editor.spec.ts
@@ -1,3 +1,4 @@
+import type { BrowserContext, Page } from '@playwright/test';
 import { test, expect } from '../fixtures';
 import { dismissCookieBanner } from '../helpers/cookie-banner';
 
@@ -111,44 +112,55 @@ test.describe('editor page', () => {
     ).toBeVisible();
   });
 
-  test('nav dropdown items redirect to the right place', async ({
-    page,
-    context
-  }) => {
-    // File > Examples — internal link, same tab
-    await page.getByRole('menuitem', { name: 'File' }).click();
-    await page.locator('#file-examples').click();
-    await expect(page).toHaveURL(/\/p5\/sketches/, { timeout: 10_000 });
+  test.describe('nav dropdown redirects', () => {
+    // Reused by the two Help items that open an external link in a new tab.
+    const expectHelpLinkOpensNewTab = async (
+      page: Page,
+      context: BrowserContext,
+      locatorId: string,
+      urlSubstring: string
+    ) => {
+      await page.getByRole('menuitem', { name: 'Help' }).click();
+      const [newTab] = await Promise.all([
+        context.waitForEvent('page'),
+        page.locator(locatorId).click()
+      ]);
+      await newTab.waitForLoadState();
+      expect(newTab.url()).toContain(urlSubstring);
+      await newTab.close();
+    };
 
-    // Help > About — internal link, same tab
-    await page.goto('/');
-    await dismissCookieBanner(page);
-    await page.getByRole('menuitem', { name: 'Help' }).click();
-    await page.locator('#help-about').click();
-    await expect(page).toHaveURL(/\/about/, { timeout: 10_000 });
+    test('File > Examples opens in the same tab', async ({ page }) => {
+      await page.getByRole('menuitem', { name: 'File' }).click();
+      await page.locator('#file-examples').click();
+      await expect(page).toHaveURL(/\/p5\/sketches/, { timeout: 10_000 });
+    });
 
-    // Help > Reference — external link, opens in a new tab
-    await page.goto('/');
-    await dismissCookieBanner(page);
-    await page.getByRole('menuitem', { name: 'Help' }).click();
-    const [referencePage] = await Promise.all([
-      context.waitForEvent('page'),
-      page.locator('#help-reference').click()
-    ]);
-    await referencePage.waitForLoadState();
-    expect(referencePage.url()).toContain('p5js.org/reference');
-    await referencePage.close();
+    test('Help > About opens in the same tab', async ({ page }) => {
+      await page.getByRole('menuitem', { name: 'Help' }).click();
+      await page.locator('#help-about').click();
+      await expect(page).toHaveURL(/\/about/, { timeout: 10_000 });
+    });
 
-    // Help > Post on the Forum — external link, opens in a new tab
-    await page.goto('/');
-    await dismissCookieBanner(page);
-    await page.getByRole('menuitem', { name: 'Help' }).click();
-    const [forumPage] = await Promise.all([
-      context.waitForEvent('page'),
-      page.locator('#help-forum').click()
-    ]);
-    await forumPage.waitForLoadState();
-    expect(forumPage.url()).toContain('discourse.processing.org/c/p5js/10');
-    await forumPage.close();
+    test('Help > Reference opens in a new tab', async ({ page, context }) => {
+      await expectHelpLinkOpensNewTab(
+        page,
+        context,
+        '#help-reference',
+        'p5js.org/reference'
+      );
+    });
+
+    test('Help > Post on the Forum opens in a new tab', async ({
+      page,
+      context
+    }) => {
+      await expectHelpLinkOpensNewTab(
+        page,
+        context,
+        '#help-forum',
+        'discourse.processing.org/c/p5js/10'
+      );
+    });
   });
 });

--- a/e2e/specs/editor.spec.ts
+++ b/e2e/specs/editor.spec.ts
@@ -110,4 +110,45 @@ test.describe('editor page', () => {
       )
     ).toBeVisible();
   });
+
+  test('nav dropdown items redirect to the right place', async ({
+    page,
+    context
+  }) => {
+    // File > Examples — internal link, same tab
+    await page.getByRole('menuitem', { name: 'File' }).click();
+    await page.locator('#file-examples').click();
+    await expect(page).toHaveURL(/\/p5\/sketches/, { timeout: 10_000 });
+
+    // Help > About — internal link, same tab
+    await page.goto('/');
+    await dismissCookieBanner(page);
+    await page.getByRole('menuitem', { name: 'Help' }).click();
+    await page.locator('#help-about').click();
+    await expect(page).toHaveURL(/\/about/, { timeout: 10_000 });
+
+    // Help > Reference — external link, opens in a new tab
+    await page.goto('/');
+    await dismissCookieBanner(page);
+    await page.getByRole('menuitem', { name: 'Help' }).click();
+    const [referencePage] = await Promise.all([
+      context.waitForEvent('page'),
+      page.locator('#help-reference').click()
+    ]);
+    await referencePage.waitForLoadState();
+    expect(referencePage.url()).toContain('p5js.org/reference');
+    await referencePage.close();
+
+    // Help > Post on the Forum — external link, opens in a new tab
+    await page.goto('/');
+    await dismissCookieBanner(page);
+    await page.getByRole('menuitem', { name: 'Help' }).click();
+    const [forumPage] = await Promise.all([
+      context.waitForEvent('page'),
+      page.locator('#help-forum').click()
+    ]);
+    await forumPage.waitForLoadState();
+    expect(forumPage.url()).toContain('discourse.processing.org/c/p5js/10');
+    await forumPage.close();
+  });
 });


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->
Adds a test that verifies nav dropdown items redirect to the correct destinations.

### Demo:
<!-- Please add a screenshot for UI related changes -->

https://github.com/user-attachments/assets/389e778d-e881-4fda-a955-7449349b8e27



### Changes:
<!-- Summarise your changes -->
 - File > Examples — internal link, navigates to /p5/sketches in the same tab
 - Help > About — internal link, navigates to /about in the same tab
 - Help > Reference — external link, opens p5js.org/reference in a new tab
 - Help > Post on the Forum — external link, opens discourse.processing.org/c/p5js/10 in a new tab

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
