### PR TITLE
GSOC-E2E: Add IME composition input test

### DIFF
--- a/e2e/specs/editor.spec.ts
+++ b/e2e/specs/editor.spec.ts
@@ -163,4 +163,46 @@ test.describe('editor page', () => {
       );
     });
   });
+
+  // Composition is driven via CDP since dispatched CompositionEvents don't
+  // actually insert text into a contenteditable.
+  test('IME composition leaves only the final character in the editor', async ({
+    page
+  }) => {
+    const intermediate = 'nihao';
+    const final = '你好';
+
+    const editor = page.locator('.editor-holder');
+    await editor.click();
+    await page.keyboard.press('ControlOrMeta+A');
+    await page.keyboard.press('Delete');
+
+    const cdp = await page.context().newCDPSession(page);
+
+    // compositionstart + the intermediate pinyin, as the user types "nihao"
+    await editor.dispatchEvent('compositionstart', { data: '' });
+    await cdp.send('Input.imeSetComposition', {
+      text: intermediate,
+      selectionStart: intermediate.length,
+      selectionEnd: intermediate.length
+    });
+
+    await expect(editor.locator('.cm-content')).toContainText(intermediate, {
+      timeout: 5_000
+    });
+
+    // The user presses a number key to select 你好, replacing the pinyin
+    await cdp.send('Input.imeSetComposition', {
+      text: final,
+      selectionStart: final.length,
+      selectionEnd: final.length,
+      replacementStart: 0,
+      replacementEnd: intermediate.length
+    });
+    await editor.dispatchEvent('compositionend', { data: final });
+
+    const content = editor.locator('.cm-content');
+    await expect(content).toContainText(final, { timeout: 5_000 });
+    await expect(content).not.toContainText(intermediate);
+  });
 });


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->
Adds a test that verifies IME composition input leaves only the final character in the editor.

### Demo:
<!-- Please add a screenshot for UI related changes -->

https://github.com/user-attachments/assets/46726639-58ed-4977-983a-0600d5e25d24



### Changes:
<!-- Summarise your changes -->
 - Clears the editor
 - Opens a CDP session to simulate IME at the browser level
 - Sends Input.imeSetComposition with intermediate Pinyin text nihao
 - Verifies nihao appears in the editor as the composition in progress
 - Sends a second Input.imeSetComposition with the final character 你好 and a replacement range covering nihao
 - Fires compositionend to commit the composition
 - Asserts the editor contains 你好 and does NOT contain nihao

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
