### PR TITLE
Update `deploy-staging` to trigger only after successful test run instead of test completion

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,6 +14,7 @@ env:
   IMAGE: ${{ secrets.DOCKER_USERNAME }}/p5.js-web-editor-staging
 jobs:
   push_to_registry:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: staging
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Issue:
Fixes # 
Part 1 of the remake of https://github.com/processing/p5.js-web-editor/pull/4252
- Currently `deploy-staging` always gets triggered upon unit test completion, even if a test run has failed
- This PR updates to only trigger `deploy-staging` if the unit tests pass

### Demo:
<!-- Please add a screenshot for UI related changes -->

### Changes:
<!-- Summarise your changes -->

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
