### PR TITLE
Add `create-release.yaml`

### DIFF
--- a/.github/workflows/release-reminder.yml
+++ b/.github/workflows/release-reminder.yml
@@ -1,0 +1,32 @@
+name: Weekly release reminder
+
+on:
+  # Tuesdays 15:30 UTC
+  schedule:
+    - cron: "30 15 * * 2"
+  workflow_dispatch: {}
+
+permissions:
+  issues: write
+
+jobs:
+  remind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open release reminder issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title: `Weekly release - ${new Date().toISOString().slice(0, 10)}`,
+              body: [
+                "1. Decide on any remaining PRs to merge into `develop`",
+                "2. Review what's merged into `develop` since the last release.",
+                "3. Decide the version bump (patch/minor/major).",
+                "4. Run the [Create a release](../actions/workflows/release.yml) workflow with that version.",
+                "",
+                "No release needed this week? Just close this issue."
+              ].join("\n")
+            });


### PR DESCRIPTION
### Issue:
Fixes # 
Recreation of https://github.com/processing/p5.js-web-editor/pull/4252
- Adds `create-release.yaml` which creates an issue every Tuesday ahead of the release party that reminds maintainers to create the release of the week

### Demo:
<!-- Please add a screenshot for UI related changes -->

### Changes:
<!-- Summarise your changes -->

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
