### PR TITLE
Update `deploy.yaml` trigger to be upon release publishing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,8 @@
 name: Deploy to production
 on:
-  workflow_run:
-    workflows: ["Test"]
-    branches:
-      - release
+  release:
     types:
-      - completed
+      - published
 env:
   PROJECT_ID: ${{ secrets.GKE_PROJECT }}
   GKE_CLUSTER: p5-gke-cluster
@@ -21,7 +18,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
         with:
-          ref: release
+          ref: ${{ github.event.release.tag_name }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
         with:


### PR DESCRIPTION
### Issue:
Fixes # 
Remake of https://github.com/processing/p5.js-web-editor/pull/4252
- [x] update `deploy` workflow trigger to be upon publishing a release on Github UI (instead of merges into the `release` branch)

### Demo:
<!-- Please add a screenshot for UI related changes -->

### Changes:
<!-- Summarise your changes -->

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
