### PR TITLE
Add `release.yaml` for automating release processes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Create a release
+
+on:
+  workflow_dispatch:
+    inputs:
+      newversion:
+        description: >
+          Version to release. Accepts an explicit semver (e.g. 2.22.0) or an
+          npm version keyword (patch, minor, major, prepatch, preminor,
+          premajor, prerelease). See https://docs.npmjs.com/cli/version
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:ci
+
+      # future: deploy to staging (+stop deploying to staging upon merges to develop) + e2e test pointed at staging
+
+  release:
+    needs: verify
+    runs-on: ubuntu-latest
+    # Requires a maintainer to approve in the Actions UI before this job runs.
+    # Configure required reviewers under Settings > Environments > release-approval.
+    environment: release-approval
+    steps:
+      - name: Check out develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+
+      - name: Fetch release branch
+        run: git fetch origin release:release
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Create cut release branch
+        run: git checkout -b "release-${{ inputs.newversion }}"
+
+      - name: Bump version
+        id: bump
+        run: |
+          NEW_VERSION=$(npm version "${{ inputs.newversion }}" -m "v%s")
+          echo "version=$NEW_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Merge into release
+        run: |
+          git checkout release
+          git pull origin release
+          git merge --no-ff "release-${{ inputs.newversion }}" -m "Merge release-${{ inputs.newversion }} into release"
+          git push origin release
+          git push origin --tags
+
+      - name: Merge back into develop
+        run: |
+          git checkout develop
+          git pull origin develop
+          git merge --no-ff "release-${{ inputs.newversion }}" -m "Merge release-${{ inputs.newversion }} into develop"
+          git push origin develop
+
+      - name: Push cut release branch
+        run: git push origin "release-${{ inputs.newversion }}"
+
+      - name: Draft GitHub release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.bump.outputs.version }}" \
+            --target release \
+            --title "${{ steps.bump.outputs.version }}" \
+            --generate-notes \
+            --draft

--- a/contributor_docs/release.md
+++ b/contributor_docs/release.md
@@ -3,13 +3,39 @@
 A guide for deploying a release to the p5.js Editor production environment.
 
 ## Background
-This project's release guide is based on:
-* [git-flow](https://nvie.com/posts/a-successful-git-branching-model/)
-* [Semantic Versioning (semver)](https://semver.org/)
-* [npm-version](https://docs.npmjs.com/cli/version)
-* [Let's stop saying Master/Slave](https://medium.com/@mikebroberts/let-s-stop-saying-master-slave-10f1d1bf34df)
 
-## Steps
+This project's release guide is based on:
+
+- [git-flow](https://nvie.com/posts/a-successful-git-branching-model/)
+- [Semantic Versioning (semver)](https://semver.org/)
+- [npm-version](https://docs.npmjs.com/cli/version)
+- [Let's stop saying Master/Slave](https://medium.com/@mikebroberts/let-s-stop-saying-master-slave-10f1d1bf34df)
+
+## Steps for a standard release:
+
+### via GHA:
+
+1. An issue titled "Weekly release - DATE" will be created every Tuesday at 15:30 UTC. Go to the [Issues tab](https://github.com/processing/p5.js-web-editor/issues) and click the link in the description to the [Create a release](../.github/workflows/release.yml) GitHub Actions workflow.
+2. Run the **Create a release** workflow via "Run workflow".
+3. Enter the `version` to release
+4. `version` can be `major`, `minor`, `patch`, etc. (see [npm-version](https://docs.npmjs.com/cli/version) for valid values.
+5. Wait for the workflow to run the `verify` job.
+6. This tests the checkout code from `develop`.
+7. If tests fail, the workflow will stop & record its result as a failure. Devs should fix any test failures, then attempt the [Create a release](../.github/workflows/release.yml) workflow again.
+8. If the tests succeed, the workflow will wait on maintainer approval for the `draft-release` job.
+9. Go to [Staging](https://stagingeditor.p5js.org) and perform any remaining manual checks.
+10. If all looks good, approve the `release` job.
+11. This does the manual steps 5-12 below:
+12. Merges the cut release into `release`
+13. Merges `release` into `develop`
+14. Creates a new draft GitHub release with auto-generated notes & version & tags.
+15. [Review the drafted release](https://github.com/processing/p5.js-web-editor/releases) and click **Publish release** when ready. This will then trigger the deployment to [Production](editor.p5js.org).
+16. **Manually** verify the release has completed successfully:
+17. `$ kubectl get pods --namespace production` to check the pods are running (this might take a few minutes and you can rerun the command to check again).
+18. Validate that [production](https://stagingeditor.p5js.org/) is working and you are finished!
+
+### Manually:
+
 1. `$ git checkout develop`
 2. `$ git pull origin develop`
 3. `$ git checkout -b release-<newversion>`
@@ -29,9 +55,11 @@ This project's release guide is based on:
 14. `$ kubectl get pods --namespace production` to check the pods are running (this might take a few minutes and you can rerun the command to check again).
 15. Validate that [production](https://stagingeditor.p5js.org/) is working and you are finished!
 
-
 ## Steps for a Patch Release
+
 Sometimes you might need to push a release for an isolated and small bug fix without what's currently been merged into the `develop` branch. The steps for pushing a Patch Release are similar to a standard Release, except you work with the `release` branch as opposed to `develop`.
+
+This process is not yet automated by the Actions workflow above, so it's still done by hand.
 
 1. `$ git checkout release`
 2. `$ git pull origin release`


### PR DESCRIPTION
### Issue:
Fixes # 
Remake of https://github.com/processing/p5.js-web-editor/pull/4252
- [x] adds `release.yaml` which automates some of the manual instructions for creating a release
- [x] updates the contributor docs with the `release.yaml` instructions 

### Note:
This PR requires us to configure a github actions environment `release-approval`, which will have an approvers list, so that the release workflow is not triggered by non-maintainers

### Demo:
<!-- Please add a screenshot for UI related changes -->

### Changes:
<!-- Summarise your changes -->

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
