### PR TITLE
GSOC-E2E: Fix rename flake

### DIFF
--- a/e2e/specs/sketches_management.spec.ts
+++ b/e2e/specs/sketches_management.spec.ts
@@ -96,6 +96,10 @@ test.describe.serial('sketch lifecycle', () => {
     await editor().click();
     await page.keyboard.press('ControlOrMeta+A');
     await page.keyboard.type(updatedCode, { delay: 5 });
+    // Wait for the unsaved changes indicator to appear, then save the sketch.
+    await expect(
+      page.getByRole('img', { name: 'Sketch has unsaved changes' })
+    ).toBeVisible();
     await page.keyboard.press('Control+S');
     await expect(page.getByText('Sketch saved.')).toBeVisible({
       timeout: 10_000


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->
Fixes a rename flake in sketches_management.spec.ts

### Demo:
<!-- Please add a screenshot for UI related changes -->

### Changes:
<!-- Summarise your changes -->
Check 'Sketch has unsaved changes' indicator appears before saving

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
