### PR TITLE
Fix Tab-to-accept crashing for user-defined function completions

### DIFF
--- a/client/utils/contextAwareHinter.js
+++ b/client/utils/contextAwareHinter.js
@@ -262,15 +262,17 @@ export default function contextAwareHinter(context, { hints = [] } = {}) {
         (!scopeToDeclaredVarsMap[currentContext]?.[varName] &&
           scopeToDeclaredVarsMap.global?.[varName] === 'fun');
 
-      return buildVarOrFunctionOption({
-        name: varName,
-        isFunc,
-        userDefinedFunctionMetadata,
-        blacklist,
-        range: wordInfo,
+      return buildVarOrFunctionOption(
+        {
+          name: varName,
+          isFunc,
+          userDefinedFunctionMetadata,
+          blacklist,
+          range: wordInfo
+        },
         state,
         pos
-      });
+      );
     });
 
   const globalOptions = hints


### PR DESCRIPTION
Fixes #4272

### Issue:

`buildVarOrFunctionOption()` in `contextAwareHinter.js` expects `state` and `pos` as separate positional arguments (matching its sibling builders, `buildMethodOption` and `buildGlobalHintOption`), but its call site was bundling
them as properties inside the options object instead. Since the function's destructuring pattern doesn't include `state`/`pos`, both silently ended up `undefined` inside the function.

That `undefined` `state` got captured in the completion's `apply` closure. When accepting a user-defined function completion via Tab, `state.doc.lineAt(pos)` threw `TypeError: Cannot read properties of undefined (reading 'doc')`. The Tab
keymap handler treats a failed accept as "unhandled" and falls through to the next binding, so nothing got inserted — matching the reported bug.

This only affected completions for **user-defined** functions/variables from the app's custom hinter; built-in p5 keywords and CodeMirror's own local-scope suggestions were unaffected (which is why the popup could show two entries for
the same identifier — one broken, one fine).

### Changes:
- Fixed the `buildVarOrFunctionOption()` call site in `client/utils/contextAwareHinter.js` to pass `state` and `pos` as separate trailing arguments instead of bundling them inside the options object.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
