### PR TITLE
stop triggering duplicate unit tests on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,11 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - develop
+      - release
 
 jobs:
   test:


### PR DESCRIPTION
### Issue:
Fixes # 
- current setup makes it so that every time we open a PR, it triggers 2 runs of the unit test workflow
- this updates so that:
  - opening a PR to any branch triggers a single unit test run
  - updating a PR to any branch triggers a single unit test run
  - pushing to `develop` triggers a single unit test run 
  - pushing to `release` triggers a single unit test run 

### Demo:
Before - 2 unit tests:
<img width="981" height="666" alt="Screenshot 2026-09-01 at 17 09 32" src="https://github.com/user-attachments/assets/facc4965-fba8-4ae0-a5f3-dd83f43cfc5f" />

After - 1 unit test:
<img width="919" height="632" alt="Screenshot 2026-09-01 at 17 09 48" src="https://github.com/user-attachments/assets/18949d0b-e677-40f4-b043-843595c9f0b3" />


### Changes:
<!-- Summarise your changes -->

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
