### PR TITLE
GSOC-E2E: Add confirmation of sketch loading before playing it

### DIFF
--- a/e2e/specs/sketches_management.spec.ts
+++ b/e2e/specs/sketches_management.spec.ts
@@ -126,6 +126,11 @@ test.describe.serial('sketch lifecycle', () => {
       .getByText('renamed-sketch')
       .click();
 
+    // Confirm the reopened sketch has actually loaded before playing it
+    await expect(
+      page.locator('button.editable-input__label')
+    ).toContainText('renamed-sketch', { timeout: 10_000 });
+
     // Run the renamed sketch and verify the edited code persisted
     await page.locator('#play-sketch').click({ force: true });
     await expect(


### PR DESCRIPTION
### Issue:
Fixes # 
<!-- Please add the issue this relates to, and a provide a brief description of the current state of the codebase and what this PR attempts to fix. -->

### Demo:
<!-- Please add a screenshot for UI related changes -->

### Changes:
<!-- Summarise your changes -->

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [ ] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [ ] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [ ] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
