### PR TITLE
Fix stale asset usage meter

### DIFF
--- a/client/modules/IDE/components/AssetSize.jsx
+++ b/client/modules/IDE/components/AssetSize.jsx
@@ -21,9 +21,7 @@ const formatPercent = (percent) => {
 const AssetSize = () => {
   const { t } = useTranslation();
 
-  const totalSize = useSelector(
-    (state) => state.user.totalSize || state.assets.totalSize
-  );
+  const totalSize = useSelector((state) => state.assets.totalSize);
 
   if (totalSize === undefined) {
     return null;

--- a/client/modules/IDE/reducers/assets.js
+++ b/client/modules/IDE/reducers/assets.js
@@ -2,7 +2,7 @@ import { createSlice } from '@reduxjs/toolkit';
 
 const initialState = {
   list: [],
-  totalSize: 0
+  totalSize: undefined
 };
 
 const assetsSlice = createSlice({

--- a/client/modules/IDE/selectors/users.js
+++ b/client/modules/IDE/selectors/users.js
@@ -26,7 +26,7 @@ export const getreachedTotalSizeLimit = createSelector(
   getTotalSize,
   getAssetsTotalSize,
   (totalSize, assetsTotalSize) => {
-    const currentSize = totalSize || assetsTotalSize || 0;
+    const currentSize = assetsTotalSize ?? totalSize ?? 0;
     if (currentSize >= limit) return true;
     // if (totalSize > 1000) return true;
     return false;


### PR DESCRIPTION
### Issue:
Related to #4085.

The asset usage meter currently prefers `user.totalSize`, which is loaded with the authenticated session and can become stale after assets are uploaded or deleted. Although the asset-list request returns the current storage total and the assets reducer updates that total after deletion, the meter can continue displaying the older session value. The same precedence can also keep the upload-limit message stale after the asset list has loaded.

### Demo:
No screenshot included. This is a state-source correction and requires conflicting session and asset-list totals to reproduce.

### Changes:
- use `assets.totalSize` as the asset meter's current source of truth
- initialize the assets total as `undefined` so the meter remains hidden until the asset request completes
- prefer the loaded assets total in the upload-limit selector
- use nullish fallback so an exact `0 B` total does not restore a stale positive session value

This pull request contains one commit and changes only three existing client files. It does not include shared-asset-library changes.

### I have verified that this pull request:

* [ ] has no linting errors (`npm run lint`)
* [ ] has no test errors (`npm run test`)
* [ ] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the  `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #123`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)

`git diff --check` passed. I did not mark the dependency-based checks as complete because this fresh checkout does not contain `node_modules`.