### PR TITLE
♦fix: handle network errors in validateAndSignUpUser (#4285)

### DIFF
--- a/client/modules/User/actions.ts
+++ b/client/modules/User/actions.ts
@@ -25,7 +25,7 @@ import type {
 } from '../../../common/types';
 import type { GetRootState, RootState } from '../../reducers';
 
-export function authError(error: Error) {
+export function authError(error: Error | string) {
   return {
     type: ActionTypes.AUTH_ERROR,
     payload: error
@@ -97,7 +97,10 @@ export function validateAndLoginUser(formProps: {
           })
           .catch((error) =>
             resolve({
-              [FORM_ERROR]: error.response.data.message
+              [FORM_ERROR]:
+                error.response?.data?.message ||
+                error.message ||
+                'Unknown error.'
             })
           );
       }
@@ -127,8 +130,12 @@ export function validateAndSignUpUser(formValues: CreateUserRequestBody) {
           resolve();
         })
         .catch((error) => {
-          const { response } = error;
-          dispatch(authError(response.data.error));
+          const message =
+            error.response?.data?.error ||
+            error.response?.data?.message ||
+            error.message ||
+            'Unknown error.';
+          dispatch(authError(message));
           resolve({ error });
         });
     });
@@ -188,7 +195,7 @@ export function resetProject(dispatch: Dispatch) {
 }
 
 export function logoutUser() {
-  return (dispatch: Dispatch) => {
+  return (dispatch: Dispatch) =>
     apiClient
       .get('/logout')
       .then(() => {
@@ -198,10 +205,13 @@ export function logoutUser() {
         resetProject(dispatch);
       })
       .catch((error) => {
-        const { response } = error;
-        dispatch(authError(response.data.error));
+        const message =
+          error.response?.data?.error ||
+          error.response?.data?.message ||
+          error.message ||
+          'Unknown error.';
+        dispatch(authError(message));
       });
-  };
 }
 
 /**
@@ -479,8 +489,11 @@ export function unlinkService(service: string) {
         dispatch(authenticateUser(response.data));
       })
       .catch((error) => {
-        const { response } = error;
-        const message = response.message || response.data.error;
+        const message =
+          error.response?.message ||
+          error.response?.data?.error ||
+          error.message ||
+          'Unknown error.';
         dispatch(authError(message));
       });
   };
@@ -500,8 +513,11 @@ export function setUserCookieConsent(
         });
       })
       .catch((error) => {
-        const { response } = error;
-        const message = response.message || response.data.error;
+        const message =
+          error.response?.message ||
+          error.response?.data?.error ||
+          error.message ||
+          'Unknown error.';
         dispatch(authError(message));
       });
   };

--- a/client/modules/User/actions.unit.test.ts
+++ b/client/modules/User/actions.unit.test.ts
@@ -1,0 +1,129 @@
+// @ts-ignore
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { FORM_ERROR } from 'final-form';
+import * as UserActions from './actions';
+import * as ActionTypes from '../../constants';
+import { apiClient } from '../../utils/apiClient';
+import browserHistory from '../../browserHistory';
+import { initialTestState } from '../../testData/testReduxStore';
+
+const mockStore = configureStore([thunk]);
+
+describe('User actions unit tests', () => {
+  let store: any;
+
+  beforeEach(() => {
+    store = mockStore(initialTestState);
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    store.clearActions();
+  });
+
+  describe('validateAndSignUpUser', () => {
+    const formValues = {
+      username: 'newuser',
+      email: 'newuser@example.com',
+      password: 'password123'
+    };
+
+    it('handles successful signup', async () => {
+      const mockUserData = {
+        id: 'u123',
+        username: 'newuser',
+        email: 'newuser@example.com'
+      };
+      jest
+        .spyOn(apiClient, 'post')
+        .mockResolvedValueOnce({ data: mockUserData });
+      const pushSpy = jest
+        .spyOn(browserHistory, 'push')
+        .mockImplementation(() => {});
+
+      const result = await store.dispatch(
+        UserActions.validateAndSignUpUser(formValues)
+      );
+
+      expect(result).toBeUndefined();
+      expect(pushSpy).toHaveBeenCalledWith('/');
+      const actions = store.getActions();
+      expect(actions).toContainEqual(
+        UserActions.authenticateUser(mockUserData as any)
+      );
+      expect(actions).toContainEqual(
+        expect.objectContaining({ type: ActionTypes.JUST_OPENED_PROJECT })
+      );
+    });
+
+    it('handles server validation/API error gracefully (with error.response)', async () => {
+      const apiError = {
+        response: {
+          data: { error: 'Username is in use' },
+          status: 422
+        }
+      };
+      jest.spyOn(apiClient, 'post').mockRejectedValueOnce(apiError);
+
+      const result = await store.dispatch(
+        UserActions.validateAndSignUpUser(formValues)
+      );
+
+      expect(result).toEqual({ error: apiError });
+      expect(store.getActions()).toContainEqual({
+        type: ActionTypes.AUTH_ERROR,
+        payload: 'Username is in use'
+      });
+    });
+
+    it('handles network error where error.response is undefined without throwing or hanging', async () => {
+      const networkError = new Error('Network Error');
+      jest.spyOn(apiClient, 'post').mockRejectedValueOnce(networkError);
+
+      const result = await store.dispatch(
+        UserActions.validateAndSignUpUser(formValues)
+      );
+
+      expect(result).toEqual({ error: networkError });
+      expect(store.getActions()).toContainEqual({
+        type: ActionTypes.AUTH_ERROR,
+        payload: 'Network Error'
+      });
+    });
+  });
+
+  describe('validateAndLoginUser', () => {
+    const loginValues = {
+      email: 'user@example.com',
+      password: 'password123'
+    };
+
+    it('handles network error where error.response is undefined', async () => {
+      const networkError = new Error('Network Error');
+      jest.spyOn(apiClient, 'post').mockRejectedValueOnce(networkError);
+
+      const result = await store.dispatch(
+        UserActions.validateAndLoginUser(loginValues)
+      );
+
+      expect(result).toEqual({
+        [FORM_ERROR]: 'Network Error'
+      });
+    });
+  });
+
+  describe('logoutUser', () => {
+    it('handles network error where error.response is undefined', async () => {
+      const networkError = new Error('Network Error');
+      jest.spyOn(apiClient, 'get').mockRejectedValueOnce(networkError);
+
+      await store.dispatch(UserActions.logoutUser());
+
+      expect(store.getActions()).toContainEqual({
+        type: ActionTypes.AUTH_ERROR,
+        payload: 'Network Error'
+      });
+    });
+  });
+});


### PR DESCRIPTION
### Issue:
Fixes #4285

When submitting the signup form during a network error, request timeout, or server disconnection, Axios produces an error object where `error.response` is `undefined`.

Previously, `validateAndSignUpUser()` attempted to access `response.data.error` directly inside its `.catch()` handler. This caused a synchronous `TypeError: Cannot read properties of undefined (reading 'data')`, preventing `resolve({ error })` from executing. Consequently, the promise returned to React Final Form remained pending indefinitely, freezing the signup form in a permanent `submitting` state with disabled submit controls and no user feedback.

### Changes:
- **`client/modules/User/actions.ts`**:
  - Safely extract error messages in `validateAndSignUpUser` using optional chaining (`error.response?.data?.error || error.response?.data?.message || error.message || 'Unknown error.'`) so `authError` is dispatched and `resolve({ error })` is always reached.
  - Updated `authError(error: Error | string)` type definition to permit string error payloads.
  - Guarded against similar missing `error.response` crashes in `validateAndLoginUser`, `logoutUser`, `unlinkService`, and `setUserCookieConsent`.
  - Returned the promise from `logoutUser` thunk.
- **`client/modules/User/actions.unit.test.ts`**:
  - Added unit test suite covering successful signup, API 422 error handling, network error fallbacks (ensuring the promise resolves and does not hang), and login/logout error handling.

### I have verified that this pull request:

* [x] has no linting errors (`npm run lint`)
* [x] has no test errors (`npm run test`)
* [x] has no typecheck errors (`npm run typecheck`)
* [x] is from a uniquely-named feature branch and is up to date with the `develop` branch.
* [x] is descriptively named and links to an issue number, i.e. `Fixes #4285`
* [x] meets the standards outlined in the [accessibility guidelines](https://github.com/processing/p5.js-web-editor/blob/develop/contributor_docs/accessibility.md)
